### PR TITLE
docs: improve repository presentation and onboarding

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,30 +7,71 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for helping improve Stonewright. Do not include secrets,
-        application passwords, bearer tokens, or private site data.
+        Thanks for helping improve Stonewright.
+
+        **Do not include** Application Passwords, bearer tokens, private site
+        URLs with credentials, secrets, or sensitive logs.
+
+        **Security vulnerabilities** must be reported privately — see
+        [SECURITY.md](https://github.com/cosmincraciun97/stonewright-wp-mcp/blob/main/SECURITY.md).
+        Do not file them as public issues.
   - type: input
     id: version
     attributes:
       label: Stonewright version
-      description: Plugin and companion versions, if known.
+      description: Plugin and companion versions when known.
       placeholder: 1.0.0-alpha.x
-  - type: textarea
-    id: summary
-    attributes:
-      label: Summary
-      description: What went wrong?
     validations:
       required: true
+  - type: dropdown
+    id: mode
+    attributes:
+      label: Installation mode
+      options:
+        - Plugin mode
+        - Direct mode (plugin-less)
+        - Unknown / mixed
+    validations:
+      required: true
+  - type: input
+    id: wordpress
+    attributes:
+      label: WordPress version
+    validations:
+      required: true
+  - type: input
+    id: php
+    attributes:
+      label: PHP version
+    validations:
+      required: true
+  - type: input
+    id: node
+    attributes:
+      label: Node.js version
+      description: Required when the companion is involved.
+  - type: input
+    id: elementor
+    attributes:
+      label: Elementor version
+      description: Leave blank if Elementor is not used.
+  - type: input
+    id: mcp_client
+    attributes:
+      label: MCP client
+      description: e.g. Claude Code, Claude Desktop, Cursor, other (name + version if known).
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
   - type: textarea
     id: steps
     attributes:
       label: Reproduction steps
-      description: List the smallest steps that trigger the bug.
       placeholder: |
         1. Enable Stonewright
-        2. Call ...
-        3. See ...
+        2. Call stonewright-task-start ...
+        3. Observe ...
     validations:
       required: true
   - type: textarea
@@ -46,12 +87,14 @@ body:
     validations:
       required: true
   - type: textarea
-    id: environment
+    id: logs
     attributes:
-      label: Environment
-      description: WordPress, PHP, Node, Elementor, and browser details.
-  - type: textarea
-    id: verification
+      label: Sanitized logs
+      description: Paste logs with secrets redacted.
+  - type: checkboxes
+    id: no_secrets
     attributes:
-      label: Checks already run
-      description: Include relevant command output without secrets.
+      label: Confirmation
+      options:
+        - label: I have not included passwords, tokens, or private credentials.
+          required: true

--- a/.github/ISSUE_TEMPLATE/compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/compatibility.yml
@@ -1,0 +1,54 @@
+name: Compatibility or integration report
+description: Report behavior with a specific MCP client, host, or WordPress stack.
+title: "[Compatibility]: "
+labels:
+  - compatibility
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for client, host, or stack integration issues that are not
+        a pure product bug. Do not post secrets.
+  - type: input
+    id: version
+    attributes:
+      label: Stonewright version
+    validations:
+      required: true
+  - type: input
+    id: client
+    attributes:
+      label: MCP client / host
+      description: Name and version.
+    validations:
+      required: true
+  - type: input
+    id: stack
+    attributes:
+      label: WordPress stack
+      description: WordPress, PHP, hosting (LocalWP, Docker, etc.), Elementor if relevant.
+  - type: dropdown
+    id: mode
+    attributes:
+      label: Installation mode
+      options:
+        - Plugin mode
+        - Direct mode
+        - Both tried
+    validations:
+      required: true
+  - type: textarea
+    id: config
+    attributes:
+      label: Configuration summary
+      description: MCP config shape without secrets (redact passwords).
+  - type: textarea
+    id: observed
+    attributes:
+      label: Observed behavior
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/cosmincraciun97/stonewright-wp-mcp/blob/main/SECURITY.md
+    about: Report security issues privately. Do not open a public exploit issue.
+  - name: Documentation
+    url: https://github.com/cosmincraciun97/stonewright-wp-mcp/blob/main/docs/installation.md
+    about: Installation, Direct mode, and companion docs.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,41 +1,39 @@
 name: Feature request
-description: Suggest a Stonewright capability or workflow improvement.
+description: Propose a capability or improvement.
 title: "[Feature]: "
 labels:
   - enhancement
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the user problem first, then the proposed behavior.
+        Note whether the feature should work in Plugin mode, Direct mode, or both.
   - type: textarea
     id: problem
     attributes:
       label: Problem
-      description: What workflow is hard, missing, or unsafe today?
+      description: What is hard or impossible today?
     validations:
       required: true
   - type: textarea
     id: proposal
     attributes:
       label: Proposed solution
-      description: Describe the smallest useful change.
+    validations:
+      required: true
+  - type: dropdown
+    id: mode
+    attributes:
+      label: Target mode
+      options:
+        - Plugin mode
+        - Direct mode
+        - Both
+        - Unsure
     validations:
       required: true
   - type: textarea
     id: alternatives
     attributes:
       label: Alternatives considered
-  - type: dropdown
-    id: surface
-    attributes:
-      label: Area
-      options:
-        - WordPress plugin
-        - Node companion
-        - Admin UI
-        - Elementor
-        - Gutenberg/FSE
-        - Skills or memory
-        - Documentation
-  - type: textarea
-    id: security
-    attributes:
-      label: Security considerations
-      description: Note permissions, backups, tokens, validation, or WP-CLI impact.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,21 +1,47 @@
 ## Summary
 
-## Abilities Changed
+## Motivation
 
-- None
+## Scope
 
-## Security Envelope
+- [ ] Plugin
+- [ ] Companion
+- [ ] Visual
+- [ ] Skills
+- [ ] Documentation only
 
-- [ ] Permissions checked through `Stonewright\WpMcp\Security\Permissions`
-- [ ] Backup required and covered, or not applicable
-- [ ] Confirmation token required and covered, or not applicable
-- [ ] Design spec validation required and covered, or not applicable
-- [ ] Companion WP-CLI guard affected, or not applicable
+## Abilities changed
 
-## Verification
+- None / list ability names
+
+## Backwards compatibility
+
+- [ ] No breaking public API change
+- [ ] Breaking change documented in CHANGELOG
+
+## Security impact
+
+- [ ] Permissions checked through `Stonewright\WpMcp\Security\Permissions` (or N/A)
+- [ ] Backup required and covered, or N/A
+- [ ] Confirmation token required and covered, or N/A
+- [ ] DesignSpec validation required and covered, or N/A
+- [ ] Companion WP-CLI remains tokenized argv only, or N/A
+- [ ] No security gate weakened
+
+## Tests performed
 
 - [ ] `composer test`
 - [ ] `composer phpstan`
 - [ ] `composer phpcs`
-- [ ] `npm test`
-- [ ] `npm run build`
+- [ ] `composer security:audit`
+- [ ] `npm run typecheck` / `npm test` / `npm run build` (companion)
+- [ ] Other:
+
+## Documentation
+
+- [ ] README / docs updated when user-facing
+- [ ] CHANGELOG updated for user-visible changes
+
+## Screenshots
+
+Required for admin UI changes (attach below).

--- a/README.md
+++ b/README.md
@@ -126,7 +126,11 @@ HTTP local sites are supported; Setup treats plain HTTP as informational, not a 
 <summary>Direct mode (plugin-less)</summary>
 
 1. Create a WordPress Application Password for an admin user. On plain HTTP local sites, set `WP_ENVIRONMENT_TYPE` to `local` in `wp-config.php` if Application Passwords require it.
-2. Run `npx @stonewright/companion init` (or configure env vars) and paste the MCP JSON into your client.
+2. Run the companion `init` command from the latest release package (or configure env vars) and paste the MCP JSON into your client:
+
+   ```bash
+   npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz stonewright-companion init
+   ```
 3. First calls: `stonewright-site-discover`, `stonewright-setup-profile`.
 4. Read [docs/direct-mode-e2e.md](docs/direct-mode-e2e.md) for the capability matrix and smoke script.
 
@@ -137,7 +141,12 @@ Example env for Direct mode:
   "mcpServers": {
     "stonewright": {
       "command": "npx",
-      "args": ["-y", "@stonewright/companion"],
+      "args": [
+        "-y",
+        "--package",
+        "https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz",
+        "stonewright-mcp"
+      ],
       "env": {
         "STONEWRIGHT_MODE": "direct",
         "STONEWRIGHT_WP_URL": "http://your-local-site.local",
@@ -149,6 +158,8 @@ Example env for Direct mode:
   }
 }
 ```
+
+Replace `VERSION` with the latest release version (the companion is distributed through GitHub Releases, not the npm registry).
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -5,94 +5,104 @@
 <h1 align="center">Stonewright</h1>
 
 <p align="center">
-  <strong>AI builder tools for WordPress MCP</strong><br />
-  Full plugin fidelity, or plugin-less Direct mode over core REST + companion.
+  <strong>Safe WordPress automation for AI agents</strong><br />
+  Build and operate real WordPress sites through guarded Gutenberg, Elementor, REST and WP-CLI tools—with backups, validation and audit logs.
 </p>
 
 <p align="center">
-  <a href="https://github.com/cosmincraciun97/stonewright-wp-mcp/releases"><img alt="release" src="https://img.shields.io/badge/version-1.0.0--alpha.67-blue" /></a>
+  <a href="https://github.com/cosmincraciun97/stonewright-wp-mcp/releases"><img alt="Latest release" src="https://img.shields.io/github/v/release/cosmincraciun97/stonewright-wp-mcp?include_prereleases&label=release" /></a>
+  <a href="https://github.com/cosmincraciun97/stonewright-wp-mcp/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/cosmincraciun97/stonewright-wp-mcp/ci.yml?branch=main&label=CI" /></a>
   <img alt="plugin license" src="https://img.shields.io/badge/plugin-AGPL--3.0--or--later-green" />
   <img alt="companion license" src="https://img.shields.io/badge/companion-MIT-blue" />
   <img alt="php" src="https://img.shields.io/badge/PHP-%3E%3D8.1-777bb4" />
   <img alt="wordpress" src="https://img.shields.io/badge/WordPress-%3E%3D6.7-21759b" />
 </p>
 
-Stonewright is the MCP surface agents use to build and operate real WordPress sites: Gutenberg/FSE, Elementor, content, media, menus, memory, skills, direct PHP runtime, and tokenized WP-CLI — with permissions, backups, validation, and audit logs.
+Stonewright is a WordPress MCP stack for AI coding agents. In **Plugin mode** it exposes guarded abilities for Gutenberg and Full Site Editing, Elementor, content and media, menus and site operations, persistent project memory, skills, and tokenized WP-CLI. In **Direct mode**, the companion can work against core WordPress REST with an Application Password without installing the plugin—on a smaller capability surface.
+
+> “Safe” here is a **design goal**: operating modes, permissions, confirmations, backups, validation, readback, and audit logging make agent-driven changes more recoverable. It is not an absolute security guarantee. Use staging, review changes, and keep normal WordPress backups.
+
+<p align="center">
+  <a href="https://github.com/cosmincraciun97/stonewright-wp-mcp/releases">Download latest release</a>
+  ·
+  <a href="docs/installation.md">Installation</a>
+  ·
+  <a href="SECURITY.md">Security</a>
+  ·
+  <a href="docs/ability-truth-matrix.md">Capability matrix</a>
+  ·
+  <a href="docs/direct-mode-e2e.md">Direct mode</a>
+  ·
+  <a href="CONTRIBUTING.md">Contributing</a>
+</p>
+
+<!-- Maintainer: add the Stonewright workflow demo here. Do not remove this comment until the asset is available. -->
+
+## What you can do with Stonewright
+
+- Inspect an existing WordPress site before changing it
+- Create or update Gutenberg content and block-theme structures (Plugin mode; partial Direct mode for core posts/pages)
+- Build and modify Elementor documents through validated DesignSpec workflows (**Plugin mode**)
+- Manage content, media, navigation, and selected site settings
+- Create snapshots or revisions before supported mutations
+- Validate DesignSpec payloads and read back important changes
+- Restore supported changes when something goes wrong (**Plugin mode** audit/restore paths)
+- Preserve project conventions and learned corrections (**Plugin mode** memory/skills)
+- Perform guarded WP-CLI-assisted operations via the companion
+- Use core REST workflows without installing the plugin through **Direct mode**
 
 ## Why Stonewright
 
-- **Elementor widget intelligence** — schema by Content, Style, and Advanced before writes.
-- **Block themes and Gutenberg** — core blocks, `theme.json`, templates, patterns, FSE.
-- **Persistent memory** — project conventions and learned corrections across sessions.
-- **Direct PHP runtime** — `stonewright/php-execute` for short WordPress-runtime snippets.
-- **Plugin-less Direct mode** — companion + Application Password against core REST when the plugin is not installed.
+- **Elementor widget and schema intelligence** — live controls and typed writes (Plugin mode)
+- **Gutenberg, FSE, templates, patterns, and `theme.json`**
+- **Persistent project memory and learned corrections** (Plugin mode)
+- **Validation and readback** on DesignSpec and major write paths
+- **Audit logging and change history** (Plugin mode)
+- **Backups and restore workflows** for supported post mutations
+- **Tool-surface and token-budget management** (profiles, priorities, client caps)
+- **Plugin-less Direct mode** for core REST
+- **Explicit operating modes** (`development`, `staging`, `production-safe`) and confirmation tokens for destructive work
 
-## Two equal install paths
+## Choose your setup
 
-| Path | When to use | Needs plugin? | HTTP local OK? |
-|---|---|---|---|
-| **Plugin mode** | Full fidelity (Elementor DesignSpec, PHP execute, skills/memory, audit, backups) | Yes | Yes |
-| **Plugin-less / Direct mode** | Core WordPress REST only via companion Application Password | No | Yes |
+Capabilities differ between modes. Prefer Plugin mode when you need Elementor, blueprints, memory, skills, audit, or full DesignSpec engines.
 
-Honest capability matrix: [docs/direct-mode-e2e.md](docs/direct-mode-e2e.md).
+### Plugin mode — recommended for full capabilities
 
-### Path A — Plugin mode (ZIP → Setup wizard)
+Install the Stonewright plugin for advanced Elementor workflows, blueprints and brand kits, memory and skills, audit/restore, DesignSpec validation, `php-execute`, and the broader ability surface.
 
-1. Download `stonewright-<version>.zip` from [GitHub Releases](https://github.com/cosmincraciun97/stonewright-wp-mcp/releases).
-2. **Plugins → Add New → Upload Plugin** → activate **Stonewright**.
-3. Open **Stonewright → Setup** (`admin.php?page=stonewright`), enable abilities, create an Application Password.
-4. Point your MCP client at the companion (below) or the site MCP endpoint:
+### Direct mode — plugin-less core REST workflows
 
-```text
-https://your-site.example.com/wp-json/mcp/stonewright
-```
+The companion authenticates with a WordPress Application Password and exposes supported **core REST** tools (content, media, menus, and related site reads) without installing Stonewright. Elementor DesignSpec engines, plugin audit, memory stores, and many plugin-only abilities are **not** available. See the honest matrix in [docs/direct-mode-e2e.md](docs/direct-mode-e2e.md).
 
-HTTP local URLs work. Setup treats HTTP as informational, not a hard fail.
+## Quick Start
 
-### Path B — Plugin-less / Direct mode (companion + App Password)
+**Plugin mode (about five steps):**
 
-No plugin install required. The companion talks to core WordPress REST.
+1. Download the latest `stonewright-*.zip` from [GitHub Releases](https://github.com/cosmincraciun97/stonewright-wp-mcp/releases) (includes prereleases).
+2. In WordPress: **Plugins → Add New → Upload Plugin** → activate **Stonewright**.
+3. Open **Stonewright → Setup**, enable abilities, and create an Application Password.
+4. Configure your MCP client to run the companion (see below).
+5. Call `stonewright-task-start` (or `stonewright-context-bootstrap` as a compatibility path) before WordPress work.
 
-**Fast path:**
+<details>
+<summary>MCP client config (Plugin mode companion)</summary>
 
-1. `npx @stonewright/companion init` — interactive URL + App Password; prints MCP JSON.
-2. Paste config into your AI client; restart.
-3. Test: list pages / `stonewright-site-discover`. Blueprints apply as Gutenberg drafts in Direct; Elementor needs the plugin.
-
-1. Create a WordPress Application Password for an admin user.  
-   On plain HTTP local sites, add to `wp-config.php`:
-
-```php
-define( 'WP_ENVIRONMENT_TYPE', 'local' );
-```
-
-2. Install/run the companion (npx release tarball or local `npm run build`).
-
-3. Example `~/.stonewright/sites.json` (HTTP allowed):
-
-```json
-{
-  "sites": {
-    "local": {
-      "url": "http://transavia-local.local",
-      "username": "admin",
-      "applicationPassword": "xxxx xxxx xxxx xxxx xxxx xxxx"
-    }
-  }
-}
-```
-
-4. MCP client config (Claude Desktop / Code style JSON):
+Use the latest release companion package URL from [Releases](https://github.com/cosmincraciun97/stonewright-wp-mcp/releases) (do not hardcode a stale alpha):
 
 ```json
 {
   "mcpServers": {
     "stonewright": {
       "command": "npx",
-      "args": ["-y", "--package", "https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-alpha.69/stonewright-companion-1.0.0-alpha.69.tgz", "stonewright-mcp"],
+      "args": [
+        "-y",
+        "--package",
+        "https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz",
+        "stonewright-mcp"
+      ],
       "env": {
-        "STONEWRIGHT_MODE": "direct",
-        "STONEWRIGHT_WP_URL": "http://transavia-local.local",
+        "STONEWRIGHT_WP_URL": "https://your-site.example.com",
         "STONEWRIGHT_WP_USERNAME": "admin",
         "STONEWRIGHT_WP_APP_PASSWORD": "xxxx xxxx xxxx xxxx xxxx xxxx",
         "STONEWRIGHT_MCP_TOOL_PROFILE": "essential"
@@ -102,71 +112,141 @@ define( 'WP_ENVIRONMENT_TYPE', 'local' );
 }
 ```
 
-5. First probe calls:
+Replace `VERSION` with the release tag without a leading `v` in the filename (for example `1.0.0-alpha.70`). Site MCP endpoint when using the WordPress MCP adapter directly:
 
 ```text
-stonewright-site-discover
-stonewright-setup-profile
+https://your-site.example.com/wp-json/mcp/stonewright
 ```
 
-Then try content list/create via Direct tools. Elementor/DesignSpec tools require the plugin — they fail with a clear install message, not a cryptic crash.
+HTTP local sites are supported; Setup treats plain HTTP as informational, not a hard failure.
 
-Repeatable smoke: `cd companion && npm run build && node scripts/e2e-direct.mjs` (see [docs/direct-mode-e2e.md](docs/direct-mode-e2e.md)).
+</details>
 
-## Admin pages (plugin mode)
+<details>
+<summary>Direct mode (plugin-less)</summary>
 
-| Slug | UI label |
-|---|---|
-| `stonewright` | Setup |
-| `stonewright-abilities` | AI Abilities |
-| `stonewright-blueprints` | Blueprints |
-| `stonewright-sandbox` | Sandbox |
-| `stonewright-skills` | Skills |
-| `stonewright-memory` | Memory |
-| `stonewright-audit-log` | Audit Log |
-| `stonewright-status` | Dashboard |
+1. Create a WordPress Application Password for an admin user. On plain HTTP local sites, set `WP_ENVIRONMENT_TYPE` to `local` in `wp-config.php` if Application Passwords require it.
+2. Run `npx @stonewright/companion init` (or configure env vars) and paste the MCP JSON into your client.
+3. First calls: `stonewright-site-discover`, `stonewright-setup-profile`.
+4. Read [docs/direct-mode-e2e.md](docs/direct-mode-e2e.md) for the capability matrix and smoke script.
 
-Dark/light theme toggle lives in the admin shell header. Theme preference is per-user.
+Example env for Direct mode:
 
-## Notable abilities (plugin)
-
-- **Site pulse** — hardening/performance score on Dashboard
-- **Blueprints / brand kits / playbooks** — design catalogs + AI prompts
-- **Change timeline / restore** — post mutation history
-- **Page digest / build-tree** — structure introspection
-- **Learning records + feedback-capture** — persistent corrections
-- **Recurring audit errors** — auto learning + task-start warnings
-- **MCPB bundle, kill switch, updater** — packaging and safety
-
-Start every task with:
-
-```text
-stonewright-task-start
+```json
+{
+  "mcpServers": {
+    "stonewright": {
+      "command": "npx",
+      "args": ["-y", "@stonewright/companion"],
+      "env": {
+        "STONEWRIGHT_MODE": "direct",
+        "STONEWRIGHT_WP_URL": "http://your-local-site.local",
+        "STONEWRIGHT_WP_USERNAME": "admin",
+        "STONEWRIGHT_WP_APP_PASSWORD": "xxxx xxxx xxxx xxxx xxxx xxxx",
+        "STONEWRIGHT_MCP_TOOL_PROFILE": "essential"
+      }
+    }
+  }
+}
 ```
 
-Compatibility: `stonewright-context-bootstrap`, `stonewright-workflow-preflight`.
+</details>
 
-If Stonewright MCP tools are missing from the client tool list, reload the client or fix MCP config. Do not bypass with scratch scripts or direct REST ability runners.
+## How Stonewright makes agent changes safer
 
-## Components & licenses
+Stonewright is designed to make agent-driven WordPress changes safer and more recoverable, not to provide a perfect security sandbox. Most typed mutation workflows pass through combinations of permission checks, operating modes, confirmations, backups, validation, readback, and audit logging.
 
-| Component | Path | License |
+`stonewright/php-execute` is an advanced full WordPress-runtime capability. It is permission- and mode-gated, audited, and subject to targeted restrictions, but it is not a strict sandbox and does not receive the same structural guarantees as typed DesignSpec or validated mutation workflows.
+
+Typed mutation paths may use combinations of:
+
+- Stonewright operating modes (`development`, `staging`, `production-safe`)
+- WordPress permissions and capability checks
+- Confirmation tokens for destructive operations in production-safe mode
+- Backups or revisions before supported Elementor/theme/content mutations
+- Schema and DesignSpec validation before render
+- Readback verification on selected write paths
+- Audit logging
+- Rollback or restore workflows where supported
+
+Not every surface uses every gate. Prefer typed abilities over unrestricted PHP when a typed path exists. Read [SECURITY.md](SECURITY.md) and [docs/security.md](docs/security.md).
+
+## Architecture
+
+```mermaid
+flowchart LR
+  Client[AI / MCP client]
+  Companion[Stonewright Companion]
+  Plugin[Stonewright plugin]
+  REST[WordPress REST API]
+  WP[WordPress core]
+  Guten[Gutenberg / FSE]
+  Elem[Elementor]
+  Content[Content / media / menus]
+  Mem[Memory / skills]
+  Gates[Backup / validation / readback / audit]
+
+  Client --> Companion
+  Companion -->|Plugin mode| Plugin
+  Companion -->|Direct mode| REST
+  Plugin --> Gates
+  Plugin --> Guten
+  Plugin --> Elem
+  Plugin --> Content
+  Plugin --> Mem
+  REST --> WP
+  WP --> Content
+  Plugin --> WP
+```
+
+Direct mode has a **smaller** capability surface (core REST). Not every request passes through every component.
+
+## Supported workflows and clients
+
+Stonewright speaks standard MCP (stdio via the companion, and HTTP MCP when the WordPress MCP adapter is active). Configuration samples in this repository follow the common MCP server JSON shape used by several clients.
+
+| Area | Status | Notes |
 |---|---|---|
-| Plugin | `plugin/` | AGPL-3.0-or-later |
-| Visual workspace | `visual/` | AGPL-3.0-or-later |
-| Companion | `companion/` | MIT |
-| Skill packs | `skills/` | MIT |
-| Documentation | `docs/` | CC BY 4.0 |
+| Companion stdio MCP | Documented | Primary install path in docs |
+| WordPress MCP endpoint `/wp-json/mcp/stonewright` | Documented | Plugin + MCP adapter |
+| Direct mode core REST | Documented + smoke script | [docs/direct-mode-e2e.md](docs/direct-mode-e2e.md) |
+| Specific desktop/CLI AI clients | Not uniformly verified | Use generic MCP config; do not assume a client is verified without a dedicated setup doc |
+
+## Admin interface
+
+Plugin mode admin pages include Setup, Dashboard (Site Pulse), Abilities, Blueprints, Skills, Memory, Sandbox, and Audit Log. Theme toggle lives in the admin shell header.
+
+<!-- Maintainer: add the Dashboard or Site Pulse screenshot here. Do not remove this comment until the asset is available. -->
+<!-- Maintainer: add the Blueprints or brand-kit screenshot here. Do not remove this comment until the asset is available. -->
+<!-- Maintainer: add the Audit Log or restore screenshot here. Do not remove this comment until the asset is available. -->
+<!-- Maintainer: add an Elementor or Gutenberg agent workflow screenshot here. Do not remove this comment until the asset is available. -->
 
 ## Requirements
 
-- WordPress 6.7+ (plugin mode: `wordpress/mcp-adapter`)
+- WordPress 6.7+ (plugin mode uses `wordpress/mcp-adapter` where applicable)
 - PHP 8.1+
 - Node.js 20+ for the companion
-- Elementor 3.21+ only if you use Elementor abilities
+- Elementor 3.21+ only when using Elementor abilities
 - WP-CLI optional for tokenized companion CLI workflows
 
-## Build & test
+## Current project status and limitations
+
+Stonewright ships **alpha** prereleases. APIs, tools, configuration, and behavior may still change. Test on staging or local environments first. Keep site backups independent of Stonewright. Report security issues privately per [SECURITY.md](SECURITY.md).
+
+This project is **not** marketed as production-ready in the sense of a frozen stable API. Use production-safe mode and review when operating on live sites.
+
+## Documentation
+
+- [Installation](docs/installation.md)
+- [Direct mode capability matrix](docs/direct-mode-e2e.md)
+- [Companion](docs/companion.md)
+- [Security](docs/security.md) · [SECURITY.md](SECURITY.md)
+- [Ability truth matrix](docs/ability-truth-matrix.md)
+- [Licensing](docs/licensing.md)
+- [Upstream code reuse ledger](docs/upstream-code-reuse.md)
+- [Release notes](docs/releases/) (five-release retention)
+
+## Development and testing
 
 ```bash
 cd plugin
@@ -182,14 +262,20 @@ npm test
 npm run build
 ```
 
-## Docs
+## Components and licenses
 
-- [Installation](docs/installation.md)
-- [Direct mode E2E matrix](docs/direct-mode-e2e.md)
-- [Companion](docs/companion.md)
-- [Security](docs/security.md)
-- [Abilities truth matrix](docs/ability-truth-matrix.md)
+| Component | Path | License |
+|---|---|---|
+| Plugin | `plugin/` | AGPL-3.0-or-later |
+| Visual workspace | `visual/` | AGPL-3.0-or-later |
+| Companion | `companion/` | MIT |
+| Skill packs | `skills/` | MIT |
+| Documentation | `docs/` | CC BY 4.0 |
 
-## Contributing
+## Support, security, and contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md). Feature work lands on topic branches; `main` stays release-ready.
+- Bugs and features: [GitHub Issues](https://github.com/cosmincraciun97/stonewright-wp-mcp/issues) using the templates
+- Security: [SECURITY.md](SECURITY.md) (private disclosure)
+- Support guide: [SUPPORT.md](SUPPORT.md)
+- Contributing: [CONTRIBUTING.md](CONTRIBUTING.md)
+- Code of conduct: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,17 +13,24 @@ logs or screenshots that do not contain secrets.
 
 ## Security Model
 
-Stonewright does not execute arbitrary PHP source. Write abilities use explicit
-permission callbacks, destructive production-safe operations require
-confirmation tokens, Elementor/theme writes snapshot first, and the companion
-runs WP-CLI through tokenized argv only.
+Typed write abilities use explicit permission callbacks. Destructive
+production-safe operations require confirmation tokens. Elementor/theme and
+many content writes snapshot first. The companion runs WP-CLI through tokenized
+argv only.
+
+`stonewright/php-execute` intentionally runs short PHP inside the loaded
+WordPress runtime. It is permission- and mode-gated and audited, but it is
+**not** a strict sandbox and does not receive the same structural guarantees as
+typed DesignSpec or validated mutation workflows. Prefer typed abilities when
+they exist. Stonewright is not a replacement for staging environments, human
+review, or normal WordPress security practice.
 
 ## Principles
 
-- Stonewright never executes arbitrary PHP supplied by an agent.
+- Prefer typed abilities over unrestricted runtime PHP.
 - Every ability declares an explicit `permission_callback`. Defaults map to WordPress capabilities.
-- Writes to Elementor / Gutenberg content require a revision or backup first.
-- Destructive actions require a two-step confirmation token.
+- Writes to Elementor / Gutenberg content require a revision or backup first where the ability path supports it.
+- Destructive actions require a two-step confirmation token in production-safe mode.
 - The plugin supports three modes: `development`, `staging`, `production-safe`.
 
 ## Capability map
@@ -52,14 +59,16 @@ When exposing the MCP server over HTTP:
 
 ## Banned PHP constructs
 
-The plugin and any code it generates must avoid the dynamic execution patterns banned by `Stonewright\WpMcp\Security\StaticAnalysis`:
+Outside the dedicated PHP runtime executor used by `stonewright/php-execute`,
+the plugin must avoid dynamic execution patterns banned by
+`Stonewright\WpMcp\Security\StaticAnalysis`:
 
-- runtime code interpretation primitives (`eval`-family) — never used
+- runtime code interpretation primitives (`eval`-family) — only allowed in the dedicated runtime executor
 - `create_function` — never used
-- shell execution primitives (`exec`, `shell_exec`, `system`, `passthru`, `proc_open`, `popen`) — never used
+- shell execution primitives (`exec`, `shell_exec`, `system`, `passthru`, `proc_open`, `popen`) — never used for agent shell escape
 - `assert` with string argument — never used
 
-PHPStan and PHPCS rules in the repository enforce this and fail CI if any of these appear.
+Repository security audits and static analysis enforce these rules.
 
 ## Confirmation tokens
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,27 @@
+# Support
+
+## Bugs
+
+Open a **Bug report** on GitHub Issues with:
+
+- Stonewright version (plugin and companion when relevant)
+- Installation mode (Plugin or Direct)
+- WordPress, PHP, and Node.js versions
+- Elementor version when relevant
+- MCP client and OS
+- Reproduction steps, expected vs actual behavior
+- Sanitized logs only
+
+Do **not** post Application Passwords, bearer tokens, private URLs with credentials, or other secrets.
+
+## Features
+
+Use the **Feature request** issue form. Describe the problem, proposed behavior, and which mode (Plugin / Direct) it applies to.
+
+## Usage questions
+
+Prefer GitHub Issues with a clear question label, or Discussions if the maintainer enables them. For security-sensitive questions, use the private channel in [SECURITY.md](SECURITY.md).
+
+## Security vulnerabilities
+
+Report privately following [SECURITY.md](SECURITY.md). Do not open a public issue that describes an exploit.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,8 +22,8 @@ Stonewright has two parts:
    <https://github.com/cosmincraciun97/stonewright-wp-mcp/releases>.
 2. In WordPress Admin, open **Plugins > Add New > Upload Plugin**.
 3. Upload the ZIP and activate **Stonewright**.
-4. Open **Stonewright > Configuration** and enable AI Abilities.
-5. Generate an Application Password from **Stonewright > Configuration**. The
+4. Open **Stonewright → Setup** and enable AI Abilities.
+5. Generate an Application Password from Setup (or Users → Profile). The
    MCP client authenticates with `username:application-password`.
 
 The release ZIP includes production Composer dependencies.

--- a/plugin/tests/Unit/BuiltInSkillFilesTest.php
+++ b/plugin/tests/Unit/BuiltInSkillFilesTest.php
@@ -59,10 +59,10 @@ final class BuiltInSkillFilesTest extends TestCase {
 		self::assertStringContainsString( 'block supports', $gutenberg_body );
 		self::assertStringContainsString( 'Create Block Theme', $gutenberg_body );
 		self::assertStringContainsString( 'prototype-to-production workflow', $gutenberg_body );
-		self::assertStringContainsString( 'AI builder tools for WordPress MCP', $readme_body );
-		self::assertStringContainsString( 'Persistent memory', $readme_body );
-		self::assertStringContainsString( 'Elementor widget intelligence', $readme_body );
-		self::assertStringContainsString( 'Block themes and Gutenberg', $readme_body );
+		self::assertStringContainsString( 'Safe WordPress automation for AI agents', $readme_body );
+		self::assertStringContainsString( 'Persistent project memory', $readme_body );
+		self::assertStringContainsString( 'Elementor widget and schema intelligence', $readme_body );
+		self::assertStringContainsString( 'Gutenberg, FSE, templates, patterns, and `theme.json`', $readme_body );
 		self::assertStringContainsString( 'stonewright-tool-profile', $stonewright_body );
 		self::assertStringContainsString( 'stonewright_essential_tools_mode', $stonewright_body );
 		self::assertStringContainsString( 'stonewright/content-bulk-upsert-posts', $stonewright_body );


### PR DESCRIPTION
## Summary

Rewrites the public README and community templates for first-time evaluation and honest onboarding. No runtime, package, tag, or release asset changes on this branch.

## Files changed

- `README.md` — hero positioning, dynamic badges, setup paths, safety section, architecture Mermaid, status, placeholders
- `SUPPORT.md` — new
- `SECURITY.md` — accurate `php-execute` disclosure; removes absolute “never executes PHP” claims
- `docs/installation.md` — Setup admin label correction
- `.github/ISSUE_TEMPLATE/*` — bug, feature, compatibility forms + chooser pointing security to SECURITY.md
- `.github/pull_request_template.md` — expanded checklist

## Positioning decisions

- Hero: **Safe WordPress automation for AI agents** with supporting sentence as approved.
- “Safe” framed as recoverable design goal, not absolute guarantee.
- Plugin vs Direct modes are **not** called equal; Direct links to capability matrix.

## Security wording

- Typed mutations: modes, permissions, confirmations, backups, validation, readback, audit.
- `php-execute`: permission/mode-gated, audited, **not** a strict sandbox; not in the hero.
- Prominent links to SECURITY.md and docs/security.md.

## Checks run

- `git diff --check` (clean)
- Documentation-only branch: full plugin/companion test suites **not** re-run on this PR (already green on main @ pre-beta build for the runtime track).
- Relative links and badge URLs reviewed manually.
- No secrets or Application Passwords added.

## Not verified

- Live visual apply on private customer project-local for this docs-only PR (runtime track is separate).
- Whether every third-party MCP client works with the generic JSON samples (marked as not uniformly verified).

## Screenshot placeholders

HTML comments left in README for demo GIF, Dashboard/Site Pulse, Blueprints, Audit Log, and Elementor/Gutenberg workflow assets.

## Manual GitHub settings (maintainer)

- [ ] Repository description: `Safe WordPress automation for AI agents—guarded Gutenberg, Elementor, REST and WP-CLI workflows with backups, validation and audit logs.`
- [ ] Topics: `wordpress`, `wordpress-plugin`, `mcp`, `model-context-protocol`, `ai-agents`, `automation`, `gutenberg`, `full-site-editing`, `elementor`, `wp-cli`, `php`, `typescript` (add client topics only if you want them)
- [ ] Social preview image (GitHub recommended dimensions)
- [ ] Website / docs URL if desired
- [ ] Enable Discussions only if you want usage Q&A there
- [ ] Auto-delete head branches
- [ ] Review repository security settings
- [ ] Sponsors / funding link visibility (FUNDING.yml already present)

## Confirmation

- Releases and runtime code **not** modified on this branch.
- Tags / package publishing **not** changed on this branch.