### PR TITLE
Design Studio admin page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Unreleased); older history lives in git tags and GitHub releases.
 
 ## [Unreleased]
 
+### Added
+
+- A Design Studio page in wp-admin. It shows which direction is active, whether
+  it is ready and whether it matches the Elementor kit, and where each token
+  came from. Directions are edited in a structured form with a live specimen
+  beside it, and unsaved work survives a reload. Saving, activating, restoring a
+  revision, and pushing to Elementor each open a review drawer that lists what is
+  about to change before anything runs. Quality reports are read on the same
+  page, filtered by severity, viewport, or rule, and evidence that was never
+  captured stays visible as unverified instead of being rounded up to a pass.
+
 ## [1.0.0-alpha.87] - 2026-07-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ Unreleased); older history lives in git tags and GitHub releases.
   page, filtered by severity, viewport, or rule, and evidence that was never
   captured stays visible as unverified instead of being rounded up to a pass.
 
+### Fixed
+
+- Design Studio history now explicitly requests revision versions, so saved
+  revisions appear and can be reviewed or restored.
+
 ## [1.0.0-alpha.87] - 2026-07-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ Stonewright speaks standard MCP (stdio via the companion, and HTTP MCP when the 
 
 ## Admin interface
 
-Plugin mode admin pages include Setup, Dashboard (Site Pulse), Abilities, Blueprints, Skills, Memory, Sandbox, and Audit Log. Theme toggle lives in the admin shell header.
+Plugin mode admin pages include Setup, Dashboard (Site Pulse), Abilities, Blueprints, Design Studio, Skills, Memory, Sandbox, and Audit Log. Theme toggle lives in the admin shell header.
 
 <!-- Maintainer: add the Dashboard or Site Pulse screenshot here. Do not remove this comment until the asset is available. -->
 <!-- Maintainer: add the Blueprints or brand-kit screenshot here. Do not remove this comment until the asset is available. -->

--- a/e2e/tests/admin-ui.spec.ts
+++ b/e2e/tests/admin-ui.spec.ts
@@ -9,6 +9,7 @@ const STONEWRIGHT_PAGES = [
 	{ slug: 'stonewright', label: 'Setup' },
 	{ slug: 'stonewright-abilities', label: 'AI Abilities' },
 	{ slug: 'stonewright-blueprints', label: 'Blueprints' },
+	{ slug: 'stonewright-design-studio', label: 'Design Studio' },
 	{ slug: 'stonewright-prompts', label: 'Prompts' },
 	{ slug: 'stonewright-sandbox', label: 'Sandbox' },
 	{ slug: 'stonewright-skills', label: 'Skills' },

--- a/e2e/tests/design-studio-a11y.spec.ts
+++ b/e2e/tests/design-studio-a11y.spec.ts
@@ -1,0 +1,186 @@
+import { expect, test, type Page } from '@playwright/test';
+import { ACTIVE_SYNCED, STUDIO_URL, login, stubStudio } from './helpers/design-studio';
+
+/**
+ * Design Studio — keyboard operation, focus management, and motion.
+ *
+ * Everything here is a promise the page makes to somebody who is not using a
+ * mouse: the tabs are a real tablist, the review drawer is a real dialog that
+ * gives focus back, state changes are announced, and nothing important is
+ * delegated to a native browser dialog.
+ */
+
+async function activeElement(page: Page): Promise<{ tag: string; text: string; inDrawer: boolean }> {
+	return page.evaluate(() => {
+		const el = document.activeElement as HTMLElement | null;
+		return {
+			tag: el?.tagName.toLowerCase() ?? '',
+			text: (el?.textContent ?? '').trim(),
+			inDrawer: !!el?.closest('[data-sw-ds-drawer]'),
+		};
+	});
+}
+
+test.describe('Design Studio accessibility', () => {
+	test.beforeEach(async ({ page }, testInfo) => {
+		test.skip(testInfo.project.name !== 'desktop-1440-light', 'Keyboard proof runs once.');
+		await login(page);
+		await stubStudio(page, ACTIVE_SYNCED);
+	});
+
+	test('the tabs are a tablist with roving focus and URL state', async ({ page }) => {
+		await page.goto(STUDIO_URL, { waitUntil: 'domcontentloaded' });
+
+		const tabs = page.locator('[role="tab"]');
+		await expect(tabs).toHaveCount(4);
+		await expect(page.locator('[role="tablist"]')).toBeVisible();
+		await expect(tabs.nth(0)).toHaveAttribute('aria-selected', 'true');
+		await expect(tabs.nth(0)).toHaveAttribute('tabindex', '0');
+		await expect(tabs.nth(1)).toHaveAttribute('tabindex', '-1');
+		await expect(tabs.nth(0)).toHaveAttribute('aria-controls', 'sw-ds-panel-overview');
+
+		await tabs.nth(0).focus();
+		await page.keyboard.press('ArrowRight');
+		await expect(tabs.nth(1)).toBeFocused();
+		await expect(tabs.nth(1)).toHaveAttribute('aria-selected', 'true');
+		await expect(page).toHaveURL(/view=editor/);
+		await expect(page.locator('[data-sw-panel="editor"]')).toBeVisible();
+		await expect(page.locator('[data-sw-panel="overview"]')).toBeHidden();
+
+		await page.keyboard.press('End');
+		await expect(tabs.nth(3)).toBeFocused();
+		await expect(page).toHaveURL(/view=history/);
+
+		await page.keyboard.press('Home');
+		await expect(tabs.nth(0)).toBeFocused();
+		await expect(page).toHaveURL(/view=overview/);
+
+		await page.keyboard.press('ArrowLeft');
+		await expect(tabs.nth(3)).toBeFocused();
+
+		// The back button walks the same history the tabs pushed.
+		await page.goBack();
+		await expect(page).toHaveURL(/view=overview/);
+		await expect(page.locator('[data-sw-panel="overview"]')).toBeVisible();
+	});
+
+	test('the focused tab shows a visible focus ring', async ({ page }) => {
+		await page.goto(STUDIO_URL, { waitUntil: 'domcontentloaded' });
+
+		// Reach the tab by keyboard so :focus-visible applies the way a keyboard
+		// user would see it.
+		await page.locator('[role="tab"]').nth(0).focus();
+		await page.keyboard.press('ArrowRight');
+		const outline = await page.locator('[role="tab"]').nth(1).evaluate((node) => {
+			const style = window.getComputedStyle(node);
+			return {
+				width: style.outlineWidth,
+				style: style.outlineStyle,
+				color: style.outlineColor,
+			};
+		});
+
+		expect(outline.style).not.toBe('none');
+		expect(parseFloat(outline.width)).toBeGreaterThanOrEqual(2);
+		expect(outline.color).not.toBe('rgba(0, 0, 0, 0)');
+	});
+
+	test('the review drawer is a modal dialog that traps and returns focus', async ({ page }) => {
+		const dialogs: string[] = [];
+		page.on('dialog', (dialog) => {
+			dialogs.push(dialog.message());
+			void dialog.dismiss();
+		});
+
+		await page.goto(STUDIO_URL, { waitUntil: 'domcontentloaded' });
+
+		const planButton = page.getByRole('button', { name: 'Plan Elementor sync' });
+		await planButton.click();
+
+		const drawer = page.locator('[data-sw-ds-drawer]');
+		await expect(drawer).toBeVisible();
+		await expect(drawer).toHaveAttribute('role', 'dialog');
+		await expect(drawer).toHaveAttribute('aria-modal', 'true');
+		await expect(drawer).toHaveAttribute('aria-labelledby', 'sw-ds-drawer-title');
+		await expect(page.locator('#sw-ds-drawer-title')).toBeVisible();
+
+		// Focus lands inside the drawer and cannot Tab out of it.
+		await expect.poll(async () => (await activeElement(page)).inDrawer).toBe(true);
+		for (let i = 0; i < 6; i += 1) {
+			await page.keyboard.press('Tab');
+			expect((await activeElement(page)).inDrawer, `Tab ${i + 1} escaped the drawer`).toBe(true);
+		}
+		await page.keyboard.press('Shift+Tab');
+		expect((await activeElement(page)).inDrawer).toBe(true);
+
+		await page.keyboard.press('Escape');
+		await expect(drawer).toHaveCount(0);
+		await expect(planButton).toBeFocused();
+
+		expect(dialogs, 'the page must not use native browser dialogs').toEqual([]);
+	});
+
+	test('state changes are announced through a polite live region', async ({ page }) => {
+		await page.goto(STUDIO_URL, { waitUntil: 'domcontentloaded' });
+
+		const status = page.locator('[data-sw-ds-status]');
+		await expect(status).toHaveAttribute('role', 'status');
+		await expect(status).toHaveAttribute('aria-live', 'polite');
+		await expect(status).toContainText('Loaded 1 design directions.');
+
+		await page.getByRole('button', { name: 'Plan Elementor sync' }).click();
+		await page.locator('[data-sw-ds-drawer]').getByRole('button', { name: 'Apply is blocked' }).click();
+		await expect(status).toContainText('blocked');
+		await expect(status).toHaveAttribute('data-tone', 'danger');
+	});
+
+	test('leaving the editor with unsaved work is reviewed, not silently dropped', async ({
+		page,
+	}) => {
+		await page.goto(`${STUDIO_URL}&view=editor`, { waitUntil: 'domcontentloaded' });
+
+		await page.locator('#sw-ds-field-summary').fill('An edit that has not been saved.');
+		await page.getByRole('tab', { name: 'Overview' }).click();
+
+		const drawer = page.locator('[data-sw-ds-drawer]');
+		await expect(drawer.getByRole('heading')).toHaveText(
+			'Leave the editor with unsaved changes?',
+		);
+		await drawer.getByRole('button', { name: 'Cancel' }).click();
+		await expect(page.locator('[data-sw-panel="editor"]')).toBeVisible();
+
+		await page.getByRole('tab', { name: 'Overview' }).click();
+		await drawer.getByRole('button', { name: 'Leave the editor' }).click();
+		await expect(page.locator('[data-sw-panel="overview"]')).toBeVisible();
+
+		// The draft survives in the session, so the edit is recoverable.
+		const stored = await page.evaluate(() =>
+			Object.keys(window.sessionStorage).filter((key) =>
+				key.startsWith('stonewright.design-studio.draft.'),
+			),
+		);
+		expect(stored.length).toBeGreaterThan(0);
+	});
+});
+
+test.describe('Design Studio reduced motion', () => {
+	test('the drawer does not animate when motion is reduced', async ({ page }, testInfo) => {
+		test.skip(testInfo.project.name !== 'desktop-1440-light', 'Motion proof runs once.');
+		await page.emulateMedia({ reducedMotion: 'reduce' });
+		await login(page);
+		await stubStudio(page, ACTIVE_SYNCED);
+		await page.goto(STUDIO_URL, { waitUntil: 'domcontentloaded' });
+
+		await page.getByRole('button', { name: 'Plan Elementor sync' }).click();
+		const drawer = page.locator('[data-sw-ds-drawer]');
+		await expect(drawer).toBeVisible();
+
+		const motion = await drawer.evaluate((node) => {
+			const style = window.getComputedStyle(node);
+			return { duration: style.transitionDuration, transform: style.transform };
+		});
+
+		expect(parseFloat(motion.duration)).toBeLessThanOrEqual(0.01);
+		expect(['none', 'matrix(1, 0, 0, 1, 0, 0)']).toContain(motion.transform);
+	});
+});

--- a/e2e/tests/design-studio.spec.ts
+++ b/e2e/tests/design-studio.spec.ts
@@ -1,0 +1,328 @@
+import { expect, test } from '@playwright/test';
+import path from 'node:path';
+import fs from 'node:fs';
+import { restPost, wpRestNonce } from './helpers/wp-rest';
+import {
+	ACTIVE_SYNCED,
+	DRAFT_WITH_ISSUES,
+	EMPTY,
+	INCOMPLETE_EVIDENCE,
+	READY_INACTIVE,
+	REVISION_HISTORY,
+	STUDIO_URL,
+	contract,
+	login,
+	stubStudio,
+} from './helpers/design-studio';
+
+/**
+ * Design Studio — state fixtures, real write round-trips, screenshot matrix.
+ *
+ * The presentation blocks render stubbed REST payloads so all eight states are
+ * reachable on a stock wp-env. The write-path block is not stubbed: it drives
+ * save, activate, and restore against the live routes, so the fixtures never
+ * become the only evidence that the page works.
+ */
+
+const artifactDir = path.join(process.cwd(), 'artifacts', 'design-studio');
+
+/* -------------------------------------------------------------------------- */
+/* Presentation states                                                         */
+/* -------------------------------------------------------------------------- */
+
+test.describe('Design Studio states', () => {
+	test.beforeEach(async ({ page }, testInfo) => {
+		// State proof is viewport-independent; the matrix test covers geometry.
+		test.skip(testInfo.project.name !== 'desktop-1440-light', 'State proof runs once.');
+		await login(page);
+	});
+
+	test('empty state explains what a direction is and offers the first step', async ({ page }) => {
+		await stubStudio(page, EMPTY);
+		await page.goto(STUDIO_URL, { waitUntil: 'domcontentloaded' });
+
+		const empty = page.locator('[data-sw-panel="overview"] .sw-ds-empty');
+		await expect(empty).toBeVisible();
+		await expect(empty.getByRole('heading')).toHaveText('No design direction yet');
+		await expect(empty.getByRole('button', { name: 'Create the first direction' })).toBeVisible();
+		await expect(page.locator('[data-sw-ds-status]')).toHaveText(
+			'No design direction is stored yet.',
+		);
+	});
+
+	test('active direction leads with readiness, hashes, and its specimen', async ({ page }) => {
+		await stubStudio(page, ACTIVE_SYNCED);
+		await page.goto(STUDIO_URL, { waitUntil: 'domcontentloaded' });
+
+		const hero = page.locator('[data-sw-panel="overview"] .sw-ds-hero');
+		await expect(hero.getByRole('heading', { name: 'Quarry' })).toBeVisible();
+		await expect(hero.locator('.sw-ds-badge', { hasText: 'active' })).toBeVisible();
+		await expect(hero.locator('.sw-ds-badge', { hasText: 'ready' }).first()).toBeVisible();
+		await expect(hero.locator('.sw-ds-swatch')).toHaveCount(4);
+		await expect(hero.locator('.sw-ds-dial')).toHaveCount(3);
+		// Activate is refused for the direction that is already active.
+		await expect(hero.getByRole('button', { name: 'Activate' })).toBeDisabled();
+	});
+
+	test('a direction that is ready but not active can be activated', async ({ page }) => {
+		await stubStudio(page, READY_INACTIVE);
+		await page.goto(STUDIO_URL, { waitUntil: 'domcontentloaded' });
+
+		await page.locator('#sw-ds-direction-picker').selectOption('12');
+		const hero = page.locator('[data-sw-panel="overview"] .sw-ds-hero');
+		await expect(hero.getByRole('heading', { name: 'Foundry' })).toBeVisible();
+		await expect(hero.getByRole('button', { name: 'Activate' })).toBeEnabled();
+	});
+
+	test('a draft with readiness issues says so instead of looking finished', async ({ page }) => {
+		await stubStudio(page, DRAFT_WITH_ISSUES);
+		await page.goto(STUDIO_URL, { waitUntil: 'domcontentloaded' });
+
+		const hero = page.locator('[data-sw-panel="overview"] .sw-ds-hero');
+		await expect(hero.locator('.sw-ds-badge', { hasText: 'not ready' })).toBeVisible();
+		await expect(hero.locator('.sw-ds-badge', { hasText: 'sync blocked' })).toBeVisible();
+		await expect(hero.locator('.sw-ds-badge', { hasText: '3 issues' })).toBeVisible();
+		await expect(hero.locator('.sw-ds-swatch')).toHaveCount(0);
+	});
+
+	test('editor reports invalid fields inline and in a summary, and blocks the save', async ({
+		page,
+	}) => {
+		await stubStudio(page, ACTIVE_SYNCED);
+		await page.goto(`${STUDIO_URL}&view=editor`, { waitUntil: 'domcontentloaded' });
+
+		const save = page.locator('[data-sw-ds-save]');
+		await expect(save).toBeEnabled();
+
+		await page.locator('#sw-ds-field-name').fill('');
+		await page.locator('#sw-ds-field-tokens').fill('{ not json');
+		await page.locator('#sw-ds-field-variance').fill('180');
+
+		const summary = page.locator('[data-sw-ds-error-summary]');
+		await expect(summary).toBeVisible();
+		await expect(summary.getByRole('heading')).toContainText('need attention');
+		await expect(page.locator('[data-sw-field="name"]')).toHaveClass(/is-invalid/);
+		await expect(page.locator('#sw-ds-field-tokens')).toHaveAttribute('aria-invalid', 'true');
+		await expect(page.locator('[data-sw-field="variance"] .sw-ds-field__error')).toContainText(
+			'0 to 100',
+		);
+		await expect(save).toBeDisabled();
+	});
+
+	test('a sync plan that the kit moved under is shown as blocked, not applied', async ({
+		page,
+	}) => {
+		await stubStudio(page, ACTIVE_SYNCED);
+		await page.goto(STUDIO_URL, { waitUntil: 'domcontentloaded' });
+
+		await page.getByRole('button', { name: 'Plan Elementor sync' }).click();
+
+		const drawer = page.locator('[data-sw-ds-drawer]');
+		await expect(drawer).toBeVisible();
+		await expect(drawer.getByRole('heading')).toHaveText('Apply this sync to the Elementor kit');
+		await expect(drawer.locator('.sw-ds-review__value--danger')).toHaveCount(2);
+		await expect(drawer.locator('.sw-ds-finding')).toHaveCount(1);
+
+		await drawer.getByRole('button', { name: 'Apply is blocked' }).click();
+		await expect(page.locator('[data-sw-ds-status]')).toContainText('blocked');
+		await expect(page.locator('[data-sw-ds-status]')).toHaveAttribute('data-tone', 'danger');
+	});
+
+	test('a failing quality report shows measured evidence and a repair hint', async ({ page }) => {
+		await stubStudio(page, ACTIVE_SYNCED);
+		await page.goto(`${STUDIO_URL}&view=quality`, { waitUntil: 'domcontentloaded' });
+
+		await page.locator('#sw-ds-post-id').fill('7');
+		await page.getByRole('button', { name: 'Load reports' }).click();
+
+		await expect(page.locator('.sw-ds-badge', { hasText: 'fail' })).toBeVisible();
+		await expect(page.locator('.sw-ds-finding')).toHaveCount(3);
+		await expect(page.locator('.sw-ds-finding__evidence').first()).toContainText('"ratio": 3.02');
+		await expect(page.locator('.sw-ds-finding__repair').first()).toContainText('4.5:1');
+
+		await page.locator('#sw-ds-filter-severity').selectOption('error');
+		await expect(page.locator('.sw-ds-finding')).toHaveCount(2);
+		await page.locator('#sw-ds-filter-viewport').selectOption('mobile');
+		await expect(page.locator('.sw-ds-finding')).toHaveCount(2);
+		await page.locator('#sw-ds-filter-rule').fill('target');
+		await expect(page.locator('.sw-ds-finding')).toHaveCount(1);
+	});
+
+	test('incomplete evidence never reads as a pass', async ({ page }) => {
+		await stubStudio(page, INCOMPLETE_EVIDENCE);
+		await page.goto(`${STUDIO_URL}&view=quality`, { waitUntil: 'domcontentloaded' });
+
+		await page.locator('#sw-ds-post-id').fill('7');
+		await page.getByRole('button', { name: 'Load reports' }).click();
+
+		await expect(page.locator('.sw-ds-badge', { hasText: 'not_checked' })).toBeVisible();
+		await expect(page.locator('.sw-ds-badge', { hasText: 'pass' })).toHaveCount(0);
+		await expect(page.locator('.sw-ds-badge', { hasText: '0 rules checked' })).toBeVisible();
+		await expect(page.locator('.sw-ds-card__meta')).toBeVisible();
+		await expect(page.getByText('Treat these rules as unverified')).toBeVisible();
+	});
+
+	test('history lists revisions and reviews a restore before running it', async ({ page }) => {
+		await stubStudio(page, REVISION_HISTORY);
+		await page.goto(`${STUDIO_URL}&view=history`, { waitUntil: 'domcontentloaded' });
+
+		await expect(page.locator('.sw-ds-table tbody tr')).toHaveCount(3);
+		await expect(page.locator('.sw-ds-table__hash').first()).toHaveText('a1b2c3d4e5f6');
+
+		await page.locator('.sw-ds-table tbody tr').nth(2).getByRole('button', { name: 'Restore' }).click();
+
+		const drawer = page.locator('[data-sw-ds-drawer]');
+		await expect(drawer.getByRole('heading')).toHaveText('Restore revision 2');
+		await expect(drawer.locator('.sw-ds-review li')).toHaveCount(5);
+
+		await drawer.getByRole('button', { name: 'Restore revision' }).click();
+		await expect(page.locator('[data-sw-ds-status]')).toContainText('Restored revision 2');
+	});
+});
+
+/* -------------------------------------------------------------------------- */
+/* Live write path                                                             */
+/* -------------------------------------------------------------------------- */
+
+test.describe('Design Studio write path', () => {
+	test('save, activate, and restore run against the real routes', async ({ page }, testInfo) => {
+		test.skip(testInfo.project.name !== 'desktop-1440-light', 'Write proof runs once.');
+		await login(page);
+
+		const nonce = await wpRestNonce(page);
+		const slug = `e2e-direction-${Date.now()}`;
+		const created = await restPost(
+			page,
+			'/stonewright/v1/design-studio/directions',
+			{ slug, contract: contract({ identity: { name: 'E2E direction', summary: 'Seeded by Playwright.' } }) },
+			nonce,
+		);
+		expect(created.ok, `seed failed: ${JSON.stringify(created.body)}`).toBe(true);
+		const seeded = created.body as { id: number };
+		expect(seeded.id).toBeGreaterThan(0);
+
+		await page.goto(STUDIO_URL, { waitUntil: 'domcontentloaded' });
+		await page.locator('#sw-ds-direction-picker').selectOption(String(seeded.id));
+		await expect(page.getByRole('heading', { name: 'E2E direction' })).toBeVisible();
+
+		// Save a second revision through the editor and its review drawer.
+		const saved = page.evaluate(
+			() =>
+				new Promise<number>((resolve) => {
+					document.addEventListener(
+						'stonewright:direction-saved',
+						(event) => resolve(Number((event as CustomEvent).detail.revision)),
+						{ once: true },
+					);
+				}),
+		);
+		await page.getByRole('button', { name: 'Open in editor' }).click();
+		await page.locator('#sw-ds-field-summary').fill('Edited by the Playwright write-path test.');
+		await page.locator('[data-sw-ds-save]').click();
+		await page.locator('[data-sw-ds-drawer]').getByRole('button', { name: 'Save direction' }).click();
+		expect(await saved).toBeGreaterThanOrEqual(2);
+
+		// Activate it, then read the history the save produced.
+		const activated = page.evaluate(
+			() =>
+				new Promise<number>((resolve) => {
+					document.addEventListener(
+						'stonewright:direction-activated',
+						(event) => resolve(Number((event as CustomEvent).detail.active_id)),
+						{ once: true },
+					);
+				}),
+		);
+		await page.getByRole('link', { name: 'Overview' }).click();
+		await page.locator('#sw-ds-direction-picker').selectOption(String(seeded.id));
+		await page.getByRole('button', { name: 'Activate' }).click();
+		await page.locator('[data-sw-ds-drawer]').getByRole('button', { name: 'Activate' }).click();
+		expect(await activated).toBe(seeded.id);
+
+		await page.getByRole('link', { name: 'History' }).click();
+		const rows = page.locator('.sw-ds-table tbody tr');
+		await expect(rows.first()).toBeVisible();
+		expect(await rows.count()).toBeGreaterThanOrEqual(2);
+
+		await rows.last().getByRole('button', { name: 'Restore' }).click();
+		await page.locator('[data-sw-ds-drawer]').getByRole('button', { name: 'Restore revision' }).click();
+		await expect(page.locator('[data-sw-ds-status]')).toContainText('Restored revision');
+	});
+});
+
+/* -------------------------------------------------------------------------- */
+/* Screenshot matrix                                                           */
+/* -------------------------------------------------------------------------- */
+
+const MATRIX_VIEWPORTS = [
+	{ name: '375x812', width: 375, height: 812 },
+	{ name: '768x1024', width: 768, height: 1024 },
+	{ name: '1024x768', width: 1024, height: 768 },
+	{ name: '1280x800', width: 1280, height: 800 },
+	{ name: '1440x900', width: 1440, height: 900 },
+] as const;
+
+test.describe('Design Studio screenshot matrix', () => {
+	test('ten screenshots across five widths in light and dark', async ({ page }, testInfo) => {
+		test.skip(testInfo.project.name !== 'desktop-1440-light', 'The matrix drives its own sizes.');
+		test.setTimeout(180_000);
+		fs.mkdirSync(artifactDir, { recursive: true });
+
+		await login(page);
+		await stubStudio(page, ACTIVE_SYNCED);
+
+		const volatile = [
+			page.locator('.sw-ds-card__meta'),
+			page.locator('.sw-ds-fact__value'),
+			page.locator('.sw-shell__version'),
+		];
+
+		let dark = false;
+		for (const theme of ['light', 'dark'] as const) {
+			await page.goto(STUDIO_URL, { waitUntil: 'domcontentloaded' });
+			await page.locator('.sw-ds-hero').waitFor({ state: 'visible' });
+
+			if ((theme === 'dark') !== dark) {
+				await page.locator('[data-sw-theme-toggle]').click();
+				await expect(page.locator('.sw-shell')).toHaveClass(
+					theme === 'dark' ? /sw-theme-dark/ : /sw-theme-light/,
+				);
+				dark = theme === 'dark';
+			}
+
+			for (const viewport of MATRIX_VIEWPORTS) {
+				await page.setViewportSize({ width: viewport.width, height: viewport.height });
+				await page.locator('.sw-ds-hero').waitFor({ state: 'visible' });
+				await page.waitForTimeout(120);
+
+				const overflow = await page.evaluate(() => {
+					const shell = document.querySelector('.sw-shell') as HTMLElement | null;
+					if (!shell) {
+						return -1;
+					}
+					const delta = shell.scrollWidth - shell.clientWidth;
+					return delta > 2 ? delta : 0;
+				});
+				expect(overflow, `${viewport.name} ${theme}: horizontal overflow`).toBe(0);
+
+				await page.screenshot({
+					path: path.join(artifactDir, `design-studio-${viewport.name}-${theme}.png`),
+					fullPage: true,
+					mask: volatile,
+				});
+			}
+		}
+
+		// Leave the shared admin user on the default theme for later specs.
+		if (dark) {
+			await page.setViewportSize({ width: 1440, height: 900 });
+			await page.locator('[data-sw-theme-toggle]').click();
+			await expect(page.locator('.sw-shell')).toHaveClass(/sw-theme-light/);
+		}
+
+		const written = fs
+			.readdirSync(artifactDir)
+			.filter((name) => name.startsWith('design-studio-') && name.endsWith('.png'));
+		expect(written, `screenshot matrix wrote ${written.length} files`).toHaveLength(10);
+	});
+});

--- a/e2e/tests/design-studio.spec.ts
+++ b/e2e/tests/design-studio.spec.ts
@@ -233,13 +233,15 @@ test.describe('Design Studio write path', () => {
 					);
 				}),
 		);
-		await page.getByRole('link', { name: 'Overview' }).click();
+		// The view switcher is a tablist, and the admin shell has its own
+		// "Overview" navigation group — asking for a link would leave the page.
+		await page.getByRole('tab', { name: 'Overview' }).click();
 		await page.locator('#sw-ds-direction-picker').selectOption(String(seeded.id));
 		await page.getByRole('button', { name: 'Activate' }).click();
 		await page.locator('[data-sw-ds-drawer]').getByRole('button', { name: 'Activate' }).click();
 		expect(await activated).toBe(seeded.id);
 
-		await page.getByRole('link', { name: 'History' }).click();
+		await page.getByRole('tab', { name: 'History' }).click();
 		const rows = page.locator('.sw-ds-table tbody tr');
 		await expect(rows.first()).toBeVisible();
 		expect(await rows.count()).toBeGreaterThanOrEqual(2);

--- a/e2e/tests/helpers/design-studio.ts
+++ b/e2e/tests/helpers/design-studio.ts
@@ -1,0 +1,374 @@
+import { type Page, type Route } from '@playwright/test';
+
+/**
+ * Design Studio e2e fixtures and REST stubbing.
+ *
+ * Presentation states are driven by stubbing the Design Studio REST routes.
+ * A page that only renders what the server sent should be provable without
+ * having to manufacture eight different databases, and states like "the kit
+ * moved under the plan" cannot be created on a stock wp-env at all. The write
+ * path is exercised separately against the live routes in design-studio.spec.ts.
+ */
+
+const WP_USER = process.env.WP_USERNAME ?? 'admin';
+const WP_PASS = process.env.WP_PASSWORD ?? 'password';
+export const STUDIO_URL = '/wp-admin/admin.php?page=stonewright-design-studio';
+
+export async function login(page: Page): Promise<void> {
+	await page.goto('/wp-admin/', { waitUntil: 'domcontentloaded' });
+	if (!page.url().includes('wp-login.php')) {
+		return;
+	}
+	await page.locator('#user_login').waitFor({ state: 'visible', timeout: 15_000 });
+	await page.locator('#user_login').fill(WP_USER);
+	await page.locator('#user_pass').fill(WP_PASS);
+	await page.locator('#wp-submit').click();
+	try {
+		await page.waitForURL(/\/wp-admin\//, { timeout: 45_000, waitUntil: 'domcontentloaded' });
+	} catch {
+		if (page.url().includes('wp-login.php')) {
+			await page.locator('#user_login').fill(WP_USER);
+			await page.locator('#user_pass').fill(WP_PASS);
+			await page.locator('#wp-submit').click();
+			await page.waitForURL(/\/wp-admin\//, { timeout: 45_000, waitUntil: 'domcontentloaded' });
+		}
+	}
+}
+
+/* -------------------------------------------------------------------------- */
+/* Fixtures                                                                    */
+/* -------------------------------------------------------------------------- */
+
+type DirectionRow = {
+	id: number;
+	slug: string;
+	name: string;
+	status: string;
+	revision: number;
+	contract_hash: string;
+	source_type: string;
+	ready: boolean;
+	sync_ready: boolean;
+	issue_count: number;
+	updated_at: string;
+	active: boolean;
+};
+
+export type StudioFixture = {
+	directions: DirectionRow[];
+	activeId: number;
+	detail?: Record<string, { direction: unknown; versions: unknown[] }>;
+	quality?: unknown;
+	syncPlan?: unknown;
+};
+
+function row(overrides: Partial<DirectionRow> = {}): DirectionRow {
+	return {
+		id: 11,
+		slug: 'quarry',
+		name: 'Quarry',
+		status: 'published',
+		revision: 4,
+		contract_hash: 'a1b2c3d4e5f60718293a4b5c6d7e8f90',
+		source_type: 'manual',
+		ready: true,
+		sync_ready: true,
+		issue_count: 0,
+		updated_at: '2026-07-24 10:15:00',
+		active: true,
+		...overrides,
+	};
+}
+
+export function contract(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		schema_version: '1.0',
+		identity: { name: 'Quarry', summary: 'Quiet stone surfaces, one accent, generous rhythm.' },
+		tokens: {
+			colors: {
+				surface: '#f7f6f3',
+				ink: '#1d1c1a',
+				accent: '#8a5a2b',
+				muted: '#6b6862',
+			},
+			typography: { body: '16px', lead: '20px', display: '32px' },
+			spacing: { xs: '4px', sm: '8px', md: '16px', lg: '32px' },
+			radii: { sm: '4px', md: '10px' },
+			elevation: {},
+			motion: {},
+		},
+		components: {},
+		dials: { variance: 25, density: 40, motion: 15 },
+		guidance: {
+			do: ['Lead with one accent colour.', 'Keep body copy at 16px or larger.'],
+			avoid: ['Gradient text.', 'More than two type families.'],
+		},
+		provenance: { captured_from: 'kit 42', method: 'manual' },
+		waivers: [],
+		readiness: { ready: true, sync_ready: true, issues: [] },
+		...overrides,
+	};
+}
+
+const FAILING_REPORT = {
+	report_id: 'qr-2026-07-24-01',
+	schema_version: '1.0',
+	status: 'fail',
+	coverage: {
+		checked: ['contrast.text', 'target.size', 'overflow.horizontal', 'token.spacing'],
+		not_checked: ['state.focus', 'state.hover'],
+		not_checked_rules: ['state.focus', 'state.hover'],
+	},
+	findings: [
+		{
+			rule_id: 'contrast.text',
+			severity: 'error',
+			viewport: 'mobile',
+			element_ref: 'hero > h1',
+			evidence: { ratio: 3.02, required: 4.5, text_color: '#8a8a8a', background_color: '#ffffff' },
+			repair_hint: 'Raise the heading colour to at least 4.5:1 against the hero surface.',
+			waived: false,
+			waiver_reason: '',
+		},
+		{
+			rule_id: 'target.size',
+			severity: 'error',
+			viewport: 'mobile',
+			element_ref: 'hero > a.cta',
+			evidence: { width: 20, height: 20, minimum: 24 },
+			repair_hint: 'Give the call to action at least a 24 by 24 pixel hit area.',
+			waived: false,
+			waiver_reason: '',
+		},
+		{
+			rule_id: 'token.spacing',
+			severity: 'warning',
+			viewport: 'desktop',
+			element_ref: 'section.features',
+			evidence: { observed: 27, nearest: 32, scale: [4, 8, 16, 32] },
+			repair_hint: 'Snap the section padding to the 32px step.',
+			waived: false,
+			waiver_reason: '',
+		},
+	],
+	truncated_findings: 0,
+	direction_revision: 4,
+	direction_hash: 'a1b2c3d4e5f60718293a4b5c6d7e8f90',
+	render_hash: '99887766554433221100ffeeddccbbaa',
+};
+
+const INCOMPLETE_REPORT = {
+	report_id: 'qr-2026-07-24-02',
+	schema_version: '1.0',
+	status: 'not_checked',
+	coverage: {
+		checked: [],
+		not_checked: ['contrast.text', 'contrast.focus', 'target.size', 'token.typography'],
+		not_checked_rules: ['contrast.text', 'contrast.focus', 'target.size', 'token.typography'],
+	},
+	findings: [],
+	truncated_findings: 0,
+	direction_revision: 4,
+	direction_hash: 'a1b2c3d4e5f60718293a4b5c6d7e8f90',
+	render_hash: '0011223344556677889900aabbccddee',
+};
+
+const CONFLICTED_PLAN = {
+	ok: true,
+	id: 11,
+	slug: 'quarry',
+	kit_id: 42,
+	contract_hash: 'a1b2c3d4e5f60718293a4b5c6d7e8f90',
+	base_hash: 'feedfacecafebeef00112233445566778899aabbccddeeff',
+	operations: [{ path: 'system_colors.primary', from: '#111111', to: '#8a5a2b' }],
+	warnings: ['The kit defines two custom colours the direction does not name.'],
+	blocked: [
+		{
+			path: 'custom_typography.0',
+			reason: 'The kit typography entry changed after this plan was built. Re-plan before applying.',
+		},
+	],
+	ready_to_apply: false,
+};
+
+/**
+ * Serves the Design Studio routes from a fixture. Matching works for pretty
+ * permalinks and for the plain-permalink `?rest_route=` form wp-env uses.
+ */
+export async function stubStudio(page: Page, fixture: StudioFixture): Promise<void> {
+	await page.route(
+		// REST traffic only — the admin page URL also carries the slug.
+		(url) =>
+			url.href.includes('design-studio') &&
+			(url.pathname.includes('/wp-json/') || url.searchParams.has('rest_route')),
+		async (route: Route) => {
+			const url = new URL(route.request().url());
+			const target = url.searchParams.get('rest_route') ?? url.pathname;
+			const method = route.request().method();
+			const json = (body: unknown) =>
+				route.fulfill({
+					status: 200,
+					contentType: 'application/json',
+					body: JSON.stringify(body),
+				});
+
+			if (target.includes('/quality')) {
+				return json(
+					fixture.quality ?? {
+						ok: true,
+						post_id: Number(url.searchParams.get('post_id') ?? 0),
+						count: 0,
+						reports: [],
+					},
+				);
+			}
+
+			const detailMatch = target.match(/\/directions\/(\d+)(\/([a-z-]+))?$/);
+			if (detailMatch) {
+				const id = detailMatch[1];
+				const action = detailMatch[3] ?? '';
+
+				if (action === 'sync-plan') {
+					return json(fixture.syncPlan ?? CONFLICTED_PLAN);
+				}
+				if (action === 'activate') {
+					return json({
+						ok: true,
+						id: Number(id),
+						active_id: Number(id),
+						previous_active_id: fixture.activeId,
+						revision: 4,
+						effect_verified: true,
+					});
+				}
+				if (action === 'restore') {
+					return json({ ok: true, id: Number(id), revision: 5, restored_revision: 2 });
+				}
+
+				const detail = fixture.detail?.[id];
+				return json(
+					detail ?? {
+						ok: true,
+						direction: { ...row({ id: Number(id) }), contract: contract() },
+						versions: [],
+					},
+				);
+			}
+
+			if (method === 'POST') {
+				return json({
+					ok: true,
+					id: 11,
+					slug: 'quarry',
+					status: 'draft',
+					revision: 5,
+					contract_hash: 'bb00bb00bb00bb00bb00bb00bb00bb00',
+					effect_verified: true,
+				});
+			}
+
+			return json({
+				ok: true,
+				count: fixture.directions.length,
+				active_id: fixture.activeId,
+				directions: fixture.directions,
+			});
+		},
+	);
+}
+
+export const EMPTY: StudioFixture = { directions: [], activeId: 0 };
+
+export const ACTIVE_SYNCED: StudioFixture = {
+	directions: [row()],
+	activeId: 11,
+	detail: {
+		'11': { direction: { ...row(), contract: contract() }, versions: [] },
+	},
+	quality: { ok: true, post_id: 7, count: 1, reports: [FAILING_REPORT] },
+};
+
+export const READY_INACTIVE: StudioFixture = {
+	directions: [
+		row({ id: 12, slug: 'foundry', name: 'Foundry', active: false, revision: 1 }),
+		row(),
+	],
+	activeId: 11,
+	detail: {
+		'12': {
+			direction: { ...row({ id: 12, slug: 'foundry', name: 'Foundry', active: false }), contract: contract() },
+			versions: [],
+		},
+	},
+};
+
+export const DRAFT_WITH_ISSUES: StudioFixture = {
+	directions: [
+		row({
+			id: 13,
+			slug: 'draft-quarry',
+			name: 'Quarry draft',
+			status: 'draft',
+			ready: false,
+			sync_ready: false,
+			issue_count: 3,
+			active: false,
+			revision: 1,
+		}),
+	],
+	activeId: 0,
+	detail: {
+		'13': {
+			direction: {
+				...row({ id: 13, slug: 'draft-quarry', name: 'Quarry draft', ready: false, active: false }),
+				contract: contract({
+					tokens: { colors: {}, typography: {}, spacing: {}, radii: {}, elevation: {}, motion: {} },
+					readiness: {
+						ready: false,
+						sync_ready: false,
+						issues: ['tokens.colors is empty', 'tokens.typography is empty', 'guidance.do is empty'],
+					},
+				}),
+			},
+			versions: [],
+		},
+	},
+};
+
+export const REVISION_HISTORY: StudioFixture = {
+	directions: [row()],
+	activeId: 11,
+	detail: {
+		'11': {
+			direction: { ...row(), contract: contract() },
+			versions: [
+				{
+					revision: 4,
+					status: 'published',
+					contract_hash: 'a1b2c3d4e5f60718293a4b5c6d7e8f90',
+					source_type: 'manual',
+					created_at: '2026-07-24 10:15:00',
+				},
+				{
+					revision: 3,
+					status: 'published',
+					contract_hash: 'c0ffee00c0ffee00c0ffee00c0ffee00',
+					source_type: 'elementor',
+					created_at: '2026-07-22 09:02:00',
+				},
+				{
+					revision: 2,
+					status: 'draft',
+					contract_hash: 'deadbeefdeadbeefdeadbeefdeadbeef',
+					source_type: 'import',
+					created_at: '2026-07-20 16:41:00',
+				},
+			],
+		},
+	},
+};
+
+export const INCOMPLETE_EVIDENCE: StudioFixture = {
+	...ACTIVE_SYNCED,
+	quality: { ok: true, post_id: 7, count: 1, reports: [INCOMPLETE_REPORT] },
+};

--- a/e2e/tests/helpers/design-studio.ts
+++ b/e2e/tests/helpers/design-studio.ts
@@ -91,7 +91,13 @@ export function contract(overrides: Record<string, unknown> = {}): Record<string
 				accent: '#8a5a2b',
 				muted: '#6b6862',
 			},
-			typography: { body: '16px', lead: '20px', display: '32px' },
+			// Typography entries are maps of CSS properties, not bare sizes —
+			// the write-path test posts this contract to the real validator.
+			typography: {
+				body: { family: 'Inter', size: '16px', line_height: 1.5 },
+				lead: { family: 'Inter', size: '20px', line_height: 1.4 },
+				display: { family: 'Inter', size: '32px', line_height: 1.15, weight: 600 },
+			},
 			spacing: { xs: '4px', sm: '8px', md: '16px', lg: '32px' },
 			radii: { sm: '4px', md: '10px' },
 			elevation: {},
@@ -103,7 +109,9 @@ export function contract(overrides: Record<string, unknown> = {}): Record<string
 			do: ['Lead with one accent colour.', 'Keep body copy at 16px or larger.'],
 			avoid: ['Gradient text.', 'More than two type families.'],
 		},
-		provenance: { captured_from: 'kit 42', method: 'manual' },
+		// Provenance is keyed by contract path, and each entry names a source
+		// and a reference.
+		provenance: { 'tokens.colors': { source: 'elementor-kit', reference: 'kit:42' } },
 		waivers: [],
 		readiness: { ready: true, sync_ready: true, issues: [] },
 		...overrides,

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+### Added
+
+- Admin page `stonewright-design-studio` with four views (overview, editor,
+  quality, history) and REST routes under `stonewright/v1/design-studio`. Every
+  route delegates to the typed design-direction and quality abilities, so
+  permission checks, task context tokens, confirmation tokens, backups,
+  validation, audit records, and effect readback are inherited rather than
+  reimplemented. Reads require `can_read_design()`; writes require
+  `can_manage_design()` and a `wp_rest` nonce.
+- Design Studio front end (`assets/admin/design-studio.js`,
+  `assets/admin/design-studio.css`): no framework, no jQuery, no native browser
+  dialogs, and no markup built from stored content — every value reaches the DOM
+  through `textContent`. Keyboard-operable tablist with URL-restored views,
+  session-scoped draft recovery, a focus-trapping review drawer that returns
+  focus on close, a polite live region, token-only theming for light and dark,
+  and a reduced-motion path.
+
 ## [1.0.0-alpha.87] - 2026-07-25
 
 ### Added

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -79,6 +79,17 @@
   instruction, so the gate is announced before the first write rather than
   discovered by a rejected one.
 
+### Fixed
+
+- Saving a design direction from the Design Studio editor no longer drops the
+  contract sections the editor does not expose. `components`, `provenance`,
+  `waivers`, and `readiness` are carried over from the stored contract, so
+  editing a summary no longer erases the provenance record or resets readiness
+  to false and leaves an activated direction refusing to activate.
+- The Design Studio live region keeps the result of a write on screen. A
+  restore or an activation re-renders its view, and the render's "loaded"
+  message used to replace the outcome before a screen reader could reach it.
+
 ## [1.0.0-alpha.86] - 2026-07-24
 
 ### Fixed

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -89,6 +89,8 @@
 - The Design Studio live region keeps the result of a write on screen. A
   restore or an activation re-renders its view, and the render's "loaded"
   message used to replace the outcome before a screen reader could reach it.
+- Design Studio history explicitly opts into revision versions when reading a
+  direction, so real saved revisions are listed and remain restorable.
 
 ## [1.0.0-alpha.86] - 2026-07-24
 

--- a/plugin/assets/admin/design-studio.css
+++ b/plugin/assets/admin/design-studio.css
@@ -674,10 +674,19 @@
 	background: var(--sw-bg);
 }
 
-.sw-ds-finding__repair {
+.sw-ds-finding__repair,
+.sw-ds-finding__element,
+.sw-ds-finding__waiver {
 	margin: 0;
 	font-size: var(--sw-text-sm);
 	color: var(--sw-text-secondary);
+}
+
+.sw-ds-finding__element {
+	font-family: var(--sw-font-mono);
+	font-size: var(--sw-text-xs);
+	color: var(--sw-text-muted);
+	overflow-wrap: anywhere;
 }
 
 .sw-ds-coverage {

--- a/plugin/assets/admin/design-studio.css
+++ b/plugin/assets/admin/design-studio.css
@@ -1,0 +1,898 @@
+/**
+ * Design Studio — stone & precision.
+ *
+ * Colour, elevation, spacing, and radius come from the shared shell tokens, so
+ * the page follows the light/dark toggle without owning a palette of its own.
+ * The layout is written mobile-first: one column is the default and the
+ * two-column editor is an enhancement above 960px.
+ */
+
+.sw-design-studio {
+	--sw-ds-radius: 12px;
+	--sw-ds-radius-sm: 10px;
+	--sw-ds-radius-lg: 14px;
+	--sw-ds-rule: 1px solid var(--sw-border);
+	--sw-ds-serif: 'Iowan Old Style', 'Palatino Linotype', Palatino, 'Book Antiqua', Georgia, serif;
+	--sw-ds-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+
+	max-width: var(--sw-shell-content-max, 1200px);
+	color: var(--sw-text);
+	font-family: var(--sw-ds-sans);
+	font-size: var(--sw-text-md);
+	line-height: 1.5;
+}
+
+.sw-design-studio .stonewright-page-header {
+	margin: 0 0 var(--sw-space-5);
+}
+
+.sw-design-studio .stonewright-page-header h1 {
+	margin: 0 0 var(--sw-space-2);
+	font-family: var(--sw-ds-serif);
+	font-size: var(--sw-text-2xl);
+	font-weight: 600;
+	letter-spacing: -0.015em;
+	line-height: 1.2;
+	color: var(--sw-text);
+}
+
+.sw-design-studio .stonewright-page-header p {
+	margin: 0;
+	max-width: 46rem;
+	font-size: var(--sw-text-sm);
+	color: var(--sw-text-secondary);
+}
+
+/* ============ Tabs ============ */
+
+.sw-ds-tabs {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--sw-space-1);
+	margin: 0 0 var(--sw-space-4);
+	padding: 0 0 var(--sw-space-2);
+	border-bottom: var(--sw-ds-rule);
+}
+
+.sw-ds-tab {
+	display: inline-block;
+	padding: var(--sw-space-2) var(--sw-space-3);
+	border: 1px solid transparent;
+	border-radius: var(--sw-ds-radius-sm);
+	font-size: var(--sw-text-sm);
+	font-weight: 500;
+	line-height: 1.2;
+	text-decoration: none;
+	color: var(--sw-text-secondary);
+	background: transparent;
+	transition: background-color var(--sw-dur) var(--sw-ease), color var(--sw-dur) var(--sw-ease);
+}
+
+.sw-ds-tab:hover {
+	color: var(--sw-text);
+	background: var(--sw-bg);
+}
+
+.sw-ds-tab.is-current {
+	color: var(--sw-text);
+	border-color: var(--sw-border);
+	background: var(--sw-surface);
+	box-shadow: var(--sw-shadow-1);
+}
+
+.sw-design-studio a:focus-visible,
+.sw-design-studio button:focus-visible,
+.sw-design-studio input:focus-visible,
+.sw-design-studio select:focus-visible,
+.sw-design-studio textarea:focus-visible,
+.sw-design-studio [tabindex]:focus-visible {
+	outline: 2px solid var(--sw-focus-ring);
+	outline-offset: 2px;
+	border-radius: var(--sw-ds-radius-sm);
+}
+
+/* ============ Live region ============ */
+
+.sw-ds-status {
+	margin: 0 0 var(--sw-space-4);
+	min-height: 1.25rem;
+	font-size: var(--sw-text-sm);
+	color: var(--sw-text-secondary);
+}
+
+.sw-ds-status:empty {
+	margin: 0;
+	min-height: 0;
+}
+
+.sw-ds-status[data-tone='ok'] {
+	color: var(--sw-ok-text);
+}
+
+.sw-ds-status[data-tone='warn'] {
+	color: var(--sw-warn-text);
+}
+
+.sw-ds-status[data-tone='danger'] {
+	color: var(--sw-danger-text);
+}
+
+/* ============ Panels and cards ============ */
+
+.sw-ds-panel[hidden] {
+	display: none;
+}
+
+.sw-ds-panel__loading {
+	padding: var(--sw-space-6);
+	border: 1px dashed var(--sw-border);
+	border-radius: var(--sw-ds-radius);
+	font-size: var(--sw-text-sm);
+	color: var(--sw-text-muted);
+	text-align: center;
+}
+
+.sw-ds-card {
+	padding: var(--sw-space-5);
+	border: var(--sw-ds-rule);
+	border-radius: var(--sw-ds-radius-lg);
+	background: var(--sw-surface);
+	box-shadow: var(--sw-shadow-1);
+}
+
+.sw-ds-card + .sw-ds-card {
+	margin-top: var(--sw-space-4);
+}
+
+.sw-ds-card__title {
+	margin: 0 0 var(--sw-space-1);
+	font-family: var(--sw-ds-serif);
+	font-size: var(--sw-text-xl);
+	font-weight: 600;
+	letter-spacing: -0.01em;
+	color: var(--sw-text);
+}
+
+.sw-ds-card__meta {
+	margin: 0 0 var(--sw-space-4);
+	font-size: var(--sw-text-xs);
+	color: var(--sw-text-muted);
+	font-family: var(--sw-font-mono);
+}
+
+.sw-ds-card__body p {
+	margin: 0 0 var(--sw-space-3);
+	font-size: var(--sw-text-sm);
+	color: var(--sw-text-secondary);
+}
+
+/* ============ Badges ============ */
+
+.sw-ds-badge {
+	display: inline-block;
+	padding: 2px var(--sw-space-2);
+	border-radius: var(--sw-radius-pill);
+	font-size: var(--sw-text-xs);
+	font-weight: 600;
+	letter-spacing: 0.02em;
+	line-height: 1.6;
+	white-space: nowrap;
+	color: var(--sw-text-secondary);
+	background: var(--sw-bg);
+}
+
+.sw-ds-badge--active,
+.sw-ds-badge--ok,
+.sw-ds-badge--pass {
+	color: var(--sw-ok-text);
+	background: var(--sw-ok-soft);
+}
+
+.sw-ds-badge--draft,
+.sw-ds-badge--warn,
+.sw-ds-badge--warning {
+	color: var(--sw-warn-text);
+	background: var(--sw-warn-soft);
+}
+
+.sw-ds-badge--error,
+.sw-ds-badge--fail,
+.sw-ds-badge--blocked {
+	color: var(--sw-danger-text);
+	background: var(--sw-danger-soft);
+}
+
+.sw-ds-badge--info {
+	color: var(--sw-info-text);
+	background: var(--sw-info-soft);
+}
+
+.sw-ds-badges {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--sw-space-2);
+	margin: 0 0 var(--sw-space-4);
+}
+
+/* ============ Buttons ============ */
+
+.sw-ds-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--sw-space-2);
+	margin: var(--sw-space-4) 0 0;
+}
+
+.sw-ds-button {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--sw-space-2);
+	padding: var(--sw-space-2) var(--sw-space-4);
+	border: 1px solid var(--sw-border-strong);
+	border-radius: var(--sw-ds-radius-sm);
+	font-family: inherit;
+	font-size: var(--sw-text-sm);
+	font-weight: 500;
+	line-height: 1.4;
+	cursor: pointer;
+	color: var(--sw-text);
+	background: var(--sw-surface);
+	transition: background-color var(--sw-dur) var(--sw-ease), border-color var(--sw-dur) var(--sw-ease);
+}
+
+.sw-ds-button:hover:not(:disabled) {
+	border-color: var(--sw-text-muted);
+	background: var(--sw-bg);
+}
+
+.sw-ds-button:disabled {
+	cursor: not-allowed;
+	color: var(--sw-disabled-fg);
+	background: var(--sw-disabled-bg);
+}
+
+.sw-ds-button--primary {
+	border-color: transparent;
+	color: var(--sw-on-brand);
+	background: var(--sw-brand-fill);
+}
+
+.sw-ds-button--primary:hover:not(:disabled) {
+	border-color: transparent;
+	background: var(--sw-brand-fill-hover);
+}
+
+.sw-ds-button--danger {
+	color: var(--sw-danger-text);
+	border-color: var(--sw-danger-text);
+	background: var(--sw-danger-soft);
+}
+
+.sw-ds-button__icon {
+	width: 14px;
+	height: 14px;
+	flex: 0 0 auto;
+	stroke: currentColor;
+	fill: none;
+	stroke-width: 1.5;
+}
+
+/* ============ Overview ============ */
+
+.sw-ds-hero {
+	display: grid;
+	gap: var(--sw-space-5);
+	grid-template-columns: 1fr;
+	align-items: start;
+}
+
+.sw-ds-hero__facts {
+	display: grid;
+	gap: var(--sw-space-3);
+	grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+	margin: 0 0 var(--sw-space-4);
+	padding: 0;
+	list-style: none;
+}
+
+.sw-ds-fact {
+	padding: var(--sw-space-3);
+	border: var(--sw-ds-rule);
+	border-radius: var(--sw-ds-radius-sm);
+	background: var(--sw-bg);
+}
+
+.sw-ds-fact__label {
+	display: block;
+	font-size: var(--sw-text-xs);
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	color: var(--sw-text-muted);
+}
+
+.sw-ds-fact__value {
+	display: block;
+	margin-top: var(--sw-space-1);
+	font-size: var(--sw-text-lg);
+	font-weight: 600;
+	color: var(--sw-text);
+	overflow-wrap: anywhere;
+}
+
+/* Compact specimen: the direction rendered with its own tokens. */
+
+.sw-ds-specimen {
+	padding: var(--sw-space-4);
+	border: var(--sw-ds-rule);
+	border-radius: var(--sw-ds-radius);
+	background: var(--sw-surface-raised);
+}
+
+.sw-ds-specimen__title {
+	margin: 0 0 var(--sw-space-3);
+	font-size: var(--sw-text-xs);
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	color: var(--sw-text-muted);
+}
+
+.sw-ds-swatches {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--sw-space-2);
+	margin: 0 0 var(--sw-space-4);
+	padding: 0;
+	list-style: none;
+}
+
+.sw-ds-swatch {
+	display: flex;
+	flex-direction: column;
+	gap: var(--sw-space-1);
+	min-width: 0;
+}
+
+.sw-ds-swatch__chip {
+	width: 40px;
+	height: 40px;
+	border: var(--sw-ds-rule);
+	border-radius: var(--sw-ds-radius-sm);
+}
+
+.sw-ds-swatch__name {
+	font-size: var(--sw-text-xs);
+	font-family: var(--sw-font-mono);
+	color: var(--sw-text-muted);
+	overflow-wrap: anywhere;
+}
+
+.sw-ds-dials {
+	display: grid;
+	gap: var(--sw-space-2);
+	margin: 0;
+}
+
+.sw-ds-dial {
+	display: grid;
+	grid-template-columns: 5rem 1fr 3rem;
+	align-items: center;
+	gap: var(--sw-space-2);
+	font-size: var(--sw-text-xs);
+	color: var(--sw-text-secondary);
+}
+
+.sw-ds-dial__track {
+	height: 6px;
+	border-radius: var(--sw-radius-pill);
+	background: var(--sw-border);
+	overflow: hidden;
+}
+
+.sw-ds-dial__fill {
+	display: block;
+	height: 100%;
+	border-radius: var(--sw-radius-pill);
+	background: var(--sw-brand-fill);
+}
+
+.sw-ds-dial__value {
+	text-align: right;
+	font-family: var(--sw-font-mono);
+	color: var(--sw-text);
+}
+
+/* Recent quality strip. */
+
+.sw-ds-strip {
+	display: flex;
+	gap: var(--sw-space-2);
+	margin: var(--sw-space-4) 0 0;
+	padding: 0 0 var(--sw-space-2);
+	list-style: none;
+	overflow-x: auto;
+}
+
+.sw-ds-strip__item {
+	flex: 0 0 auto;
+	padding: var(--sw-space-2) var(--sw-space-3);
+	border: var(--sw-ds-rule);
+	border-radius: var(--sw-ds-radius-sm);
+	font-size: var(--sw-text-xs);
+	background: var(--sw-bg);
+}
+
+.sw-ds-empty {
+	padding: var(--sw-space-7) var(--sw-space-5);
+	border: 1px dashed var(--sw-border-strong);
+	border-radius: var(--sw-ds-radius-lg);
+	text-align: center;
+	background: var(--sw-surface);
+}
+
+.sw-ds-empty h2 {
+	margin: 0 0 var(--sw-space-2);
+	font-family: var(--sw-ds-serif);
+	font-size: var(--sw-text-xl);
+	font-weight: 600;
+	color: var(--sw-text);
+}
+
+.sw-ds-empty p {
+	margin: 0 auto var(--sw-space-4);
+	max-width: 34rem;
+	font-size: var(--sw-text-sm);
+	color: var(--sw-text-secondary);
+}
+
+/* ============ Editor ============ */
+
+.sw-ds-editor {
+	display: grid;
+	gap: var(--sw-space-5);
+	grid-template-columns: 1fr;
+	align-items: start;
+}
+
+.sw-ds-editor__main,
+.sw-ds-editor__aside {
+	min-width: 0;
+}
+
+.sw-ds-fieldset {
+	margin: 0 0 var(--sw-space-5);
+	padding: 0;
+	border: 0;
+}
+
+.sw-ds-fieldset > legend {
+	padding: 0;
+	margin: 0 0 var(--sw-space-3);
+	font-family: var(--sw-ds-serif);
+	font-size: var(--sw-text-lg);
+	font-weight: 600;
+	color: var(--sw-text);
+}
+
+.sw-ds-field {
+	display: grid;
+	gap: var(--sw-space-1);
+	margin: 0 0 var(--sw-space-4);
+}
+
+.sw-ds-field__label {
+	font-size: var(--sw-text-sm);
+	font-weight: 500;
+	color: var(--sw-text);
+}
+
+.sw-ds-field__hint {
+	font-size: var(--sw-text-xs);
+	color: var(--sw-text-muted);
+}
+
+.sw-ds-field input[type='text'],
+.sw-ds-field input[type='number'],
+.sw-ds-field textarea,
+.sw-ds-field select {
+	width: 100%;
+	box-sizing: border-box;
+	padding: var(--sw-space-2) var(--sw-space-3);
+	border: var(--sw-ds-rule);
+	border-radius: var(--sw-ds-radius-sm);
+	font-family: inherit;
+	font-size: var(--sw-text-sm);
+	color: var(--sw-text);
+	background: var(--sw-surface);
+}
+
+.sw-ds-field textarea {
+	min-height: 6rem;
+	resize: vertical;
+	font-family: var(--sw-font-mono);
+	font-size: var(--sw-text-xs);
+	line-height: 1.6;
+}
+
+.sw-ds-field.is-invalid input,
+.sw-ds-field.is-invalid textarea,
+.sw-ds-field.is-invalid select {
+	border-color: var(--sw-danger-text);
+}
+
+.sw-ds-field__error {
+	font-size: var(--sw-text-xs);
+	color: var(--sw-danger-text);
+}
+
+.sw-ds-error-summary {
+	margin: 0 0 var(--sw-space-4);
+	padding: var(--sw-space-4);
+	border: 1px solid var(--sw-danger-text);
+	border-radius: var(--sw-ds-radius);
+	background: var(--sw-danger-soft);
+}
+
+.sw-ds-error-summary h2 {
+	margin: 0 0 var(--sw-space-2);
+	font-size: var(--sw-text-md);
+	font-weight: 600;
+	color: var(--sw-danger-text);
+}
+
+.sw-ds-error-summary ul {
+	margin: 0;
+	padding-left: var(--sw-space-5);
+	font-size: var(--sw-text-sm);
+	color: var(--sw-danger-text);
+}
+
+.sw-ds-error-summary a {
+	color: inherit;
+}
+
+.sw-ds-recovery {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: var(--sw-space-3);
+	margin: 0 0 var(--sw-space-4);
+	padding: var(--sw-space-3) var(--sw-space-4);
+	border: 1px solid var(--sw-warn-text);
+	border-radius: var(--sw-ds-radius);
+	font-size: var(--sw-text-sm);
+	color: var(--sw-warn-text);
+	background: var(--sw-warn-soft);
+}
+
+.sw-ds-provenance {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	font-size: var(--sw-text-xs);
+}
+
+.sw-ds-provenance li {
+	display: grid;
+	grid-template-columns: 7rem 1fr;
+	gap: var(--sw-space-2);
+	padding: var(--sw-space-2) 0;
+	border-bottom: var(--sw-ds-rule);
+}
+
+.sw-ds-provenance li:last-child {
+	border-bottom: 0;
+}
+
+.sw-ds-provenance dt,
+.sw-ds-provenance .sw-ds-provenance__key {
+	color: var(--sw-text-muted);
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+}
+
+.sw-ds-provenance .sw-ds-provenance__value {
+	font-family: var(--sw-font-mono);
+	color: var(--sw-text);
+	overflow-wrap: anywhere;
+}
+
+/* ============ Quality ============ */
+
+.sw-ds-filters {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--sw-space-3);
+	margin: 0 0 var(--sw-space-4);
+	padding: var(--sw-space-3) var(--sw-space-4);
+	border: var(--sw-ds-rule);
+	border-radius: var(--sw-ds-radius);
+	background: var(--sw-bg);
+}
+
+.sw-ds-filter {
+	display: grid;
+	gap: var(--sw-space-1);
+	font-size: var(--sw-text-xs);
+	color: var(--sw-text-muted);
+}
+
+.sw-ds-filter select,
+.sw-ds-filter input {
+	padding: var(--sw-space-1) var(--sw-space-2);
+	border: var(--sw-ds-rule);
+	border-radius: var(--sw-ds-radius-sm);
+	font-family: inherit;
+	font-size: var(--sw-text-sm);
+	color: var(--sw-text);
+	background: var(--sw-surface);
+}
+
+.sw-ds-findings {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+.sw-ds-finding {
+	display: grid;
+	gap: var(--sw-space-2);
+	padding: var(--sw-space-4);
+	border: var(--sw-ds-rule);
+	border-radius: var(--sw-ds-radius);
+	background: var(--sw-surface);
+}
+
+.sw-ds-finding + .sw-ds-finding {
+	margin-top: var(--sw-space-3);
+}
+
+.sw-ds-finding__head {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: var(--sw-space-2);
+}
+
+.sw-ds-finding__rule {
+	font-family: var(--sw-font-mono);
+	font-size: var(--sw-text-sm);
+	font-weight: 600;
+	color: var(--sw-text);
+	overflow-wrap: anywhere;
+}
+
+.sw-ds-finding__evidence {
+	margin: 0;
+	padding: var(--sw-space-3);
+	border-radius: var(--sw-ds-radius-sm);
+	font-family: var(--sw-font-mono);
+	font-size: var(--sw-text-xs);
+	line-height: 1.6;
+	white-space: pre-wrap;
+	overflow-wrap: anywhere;
+	color: var(--sw-text-secondary);
+	background: var(--sw-bg);
+}
+
+.sw-ds-finding__repair {
+	margin: 0;
+	font-size: var(--sw-text-sm);
+	color: var(--sw-text-secondary);
+}
+
+.sw-ds-coverage {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--sw-space-4);
+	margin: 0 0 var(--sw-space-4);
+	font-size: var(--sw-text-xs);
+	color: var(--sw-text-muted);
+}
+
+/* ============ History ============ */
+
+.sw-ds-table-wrap {
+	overflow-x: auto;
+	border: var(--sw-ds-rule);
+	border-radius: var(--sw-ds-radius);
+	background: var(--sw-surface);
+}
+
+.sw-ds-table {
+	width: 100%;
+	border-collapse: collapse;
+	font-size: var(--sw-text-sm);
+}
+
+.sw-ds-table th,
+.sw-ds-table td {
+	padding: var(--sw-space-3);
+	text-align: left;
+	border-bottom: var(--sw-ds-rule);
+	white-space: nowrap;
+}
+
+.sw-ds-table th {
+	font-size: var(--sw-text-xs);
+	font-weight: 600;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	color: var(--sw-text-muted);
+	background: var(--sw-bg);
+}
+
+.sw-ds-table tr:last-child td {
+	border-bottom: 0;
+}
+
+.sw-ds-table td.sw-ds-table__hash {
+	font-family: var(--sw-font-mono);
+	font-size: var(--sw-text-xs);
+	color: var(--sw-text-secondary);
+}
+
+/* ============ Review drawer ============ */
+
+.sw-ds-scrim {
+	position: fixed;
+	inset: 0;
+	z-index: 100000;
+	display: flex;
+	justify-content: flex-end;
+	background: transparent;
+}
+
+/* The dim layer is a child so the drawer itself stays fully opaque. */
+.sw-ds-scrim::before {
+	content: '';
+	position: absolute;
+	inset: 0;
+	background: var(--sw-shell-header-bg);
+	opacity: 0;
+	transition: opacity var(--sw-dur) var(--sw-ease);
+}
+
+.sw-ds-scrim.is-open::before {
+	opacity: 0.55;
+}
+
+.sw-ds-drawer {
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	width: min(34rem, 100%);
+	max-width: 100%;
+	height: 100%;
+	padding: var(--sw-space-5);
+	box-sizing: border-box;
+	overflow-y: auto;
+	border-left: var(--sw-ds-rule);
+	background: var(--sw-surface);
+	box-shadow: var(--sw-shadow-3);
+	transform: translateX(2rem);
+	transition: transform var(--sw-dur) var(--sw-ease);
+}
+
+.sw-ds-scrim.is-open .sw-ds-drawer {
+	transform: translateX(0);
+}
+
+.sw-ds-drawer__title {
+	margin: 0 0 var(--sw-space-2);
+	font-family: var(--sw-ds-serif);
+	font-size: var(--sw-text-xl);
+	font-weight: 600;
+	color: var(--sw-text);
+}
+
+.sw-ds-drawer__lede {
+	margin: 0 0 var(--sw-space-4);
+	font-size: var(--sw-text-sm);
+	color: var(--sw-text-secondary);
+}
+
+.sw-ds-drawer__body {
+	flex: 1 1 auto;
+	margin: 0 0 var(--sw-space-5);
+}
+
+.sw-ds-drawer__footer {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--sw-space-2);
+	justify-content: flex-end;
+	padding-top: var(--sw-space-4);
+	border-top: var(--sw-ds-rule);
+}
+
+.sw-ds-review {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	font-size: var(--sw-text-sm);
+}
+
+.sw-ds-review li {
+	display: grid;
+	grid-template-columns: 8rem 1fr;
+	gap: var(--sw-space-2);
+	padding: var(--sw-space-2) 0;
+	border-bottom: var(--sw-ds-rule);
+}
+
+.sw-ds-review li:last-child {
+	border-bottom: 0;
+}
+
+.sw-ds-review__key {
+	color: var(--sw-text-muted);
+}
+
+.sw-ds-review__value {
+	font-family: var(--sw-font-mono);
+	font-size: var(--sw-text-xs);
+	color: var(--sw-text);
+	overflow-wrap: anywhere;
+}
+
+.sw-ds-review__value--warn {
+	color: var(--sw-warn-text);
+}
+
+.sw-ds-review__value--danger {
+	color: var(--sw-danger-text);
+}
+
+.sw-ds-visually-hidden {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	margin: -1px;
+	padding: 0;
+	overflow: hidden;
+	clip: rect(0 0 0 0);
+	white-space: nowrap;
+	border: 0;
+}
+
+/* ============ Desktop enhancement ============ */
+
+@media (min-width: 960px) {
+
+	.sw-ds-hero {
+		grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+	}
+
+	.sw-ds-editor {
+		grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+	}
+
+	.sw-ds-editor__aside {
+		position: sticky;
+		top: calc(var(--sw-shell-offset, 76px) + var(--sw-space-4));
+	}
+}
+
+@media (min-width: 1280px) {
+
+	.sw-ds-hero__facts {
+		grid-template-columns: repeat(4, minmax(0, 1fr));
+	}
+}
+
+/* ============ Reduced motion ============ */
+
+@media (prefers-reduced-motion: reduce) {
+
+	.sw-design-studio *,
+	.sw-ds-scrim,
+	.sw-ds-drawer {
+		transition-duration: 1ms;
+		animation-duration: 1ms;
+		animation-iteration-count: 1;
+	}
+
+	.sw-ds-drawer {
+		transform: none;
+	}
+}

--- a/plugin/assets/admin/design-studio.js
+++ b/plugin/assets/admin/design-studio.js
@@ -1670,6 +1670,22 @@
 	/* View plumbing                                                       */
 	/* ------------------------------------------------------------------ */
 
+	/**
+	 * Loads the direction list once, for views that assume a selection.
+	 *
+	 * Only the overview fetches the list on its own. A deep link straight to
+	 * the editor, quality, or history view therefore used to render against
+	 * `selectedId` zero: no revisions, nothing to edit, and no way back except
+	 * visiting the overview first.
+	 */
+	function ensureDirections() {
+		if ( state.listLoaded ) {
+			return Promise.resolve( state.directions );
+		}
+
+		return loadDirections();
+	}
+
 	function render( view ) {
 		var panel = panelFor( view );
 
@@ -1679,13 +1695,30 @@
 
 		if ( 'overview' === view ) {
 			renderOverview( panel );
-		} else if ( 'editor' === view ) {
-			renderEditor( panel );
-		} else if ( 'quality' === view ) {
-			renderQuality( panel );
-		} else if ( 'history' === view ) {
-			renderHistory( panel );
+
+			return;
 		}
+
+		pending( panel, 'Loading design directions.' );
+
+		ensureDirections()
+			.then( function () {
+				// The reader may have moved on while the list was in flight.
+				if ( state.view !== view ) {
+					return;
+				}
+
+				if ( 'editor' === view ) {
+					renderEditor( panel );
+				} else if ( 'quality' === view ) {
+					renderQuality( panel );
+				} else if ( 'history' === view ) {
+					renderHistory( panel );
+				}
+			} )
+			.catch( function ( error ) {
+				renderError( panel, error );
+			} );
 	}
 
 	function showView( view ) {

--- a/plugin/assets/admin/design-studio.js
+++ b/plugin/assets/admin/design-studio.js
@@ -673,7 +673,10 @@
 			return Promise.resolve( null );
 		}
 
-		return get( DIRECTIONS_ROUTE + '/' + encodeURIComponent( String( id ) ) ).then( function ( payload ) {
+		return get(
+			DIRECTIONS_ROUTE + '/' + encodeURIComponent( String( id ) ),
+			{ include_versions: true }
+		).then( function ( payload ) {
 			state.direction = payload.direction || null;
 			state.versions = Array.isArray( payload.versions ) ? payload.versions : [];
 

--- a/plugin/assets/admin/design-studio.js
+++ b/plugin/assets/admin/design-studio.js
@@ -229,8 +229,27 @@
 		return error;
 	}
 
-	function get( path ) {
-		return window.fetch( boot.restRoot + path, {
+	/**
+	 * Appends query arguments. `restRoot` already carries a query string when
+	 * the site runs plain permalinks, so the separator cannot be assumed.
+	 */
+	function query( path, params ) {
+		var url = boot.restRoot + path;
+		var pairs = [];
+
+		Object.keys( params || {} ).forEach( function ( key ) {
+			pairs.push( encodeURIComponent( key ) + '=' + encodeURIComponent( String( params[ key ] ) ) );
+		} );
+
+		if ( ! pairs.length ) {
+			return url;
+		}
+
+		return url + ( url.indexOf( '?' ) === -1 ? '?' : '&' ) + pairs.join( '&' );
+	}
+
+	function get( path, params ) {
+		return window.fetch( query( path, params ), {
 			credentials: 'same-origin',
 			headers: { Accept: 'application/json', 'X-WP-Nonce': boot.nonce || '' }
 		} ).then( function ( response ) {
@@ -604,7 +623,7 @@
 	}
 
 	function loadReports( postId ) {
-		return get( QUALITY_ROUTE + '?post_id=' + encodeURIComponent( String( postId ) ) ).then( function ( payload ) {
+		return get( QUALITY_ROUTE, { post_id: postId } ).then( function ( payload ) {
 			state.reports = Array.isArray( payload.reports ) ? payload.reports : [];
 			state.reportIndex = 0;
 
@@ -1507,7 +1526,7 @@
 							finding.waived ? badge( 'waived', 'warn' ) : null
 						] ),
 						finding.element_ref
-							? el( 'p', { className: 'sw-ds-finding__repair', text: 'Element: ' + finding.element_ref } )
+							? el( 'p', { className: 'sw-ds-finding__element', text: finding.element_ref } )
 							: null,
 						el( 'pre', {
 							className: 'sw-ds-finding__evidence',
@@ -1517,7 +1536,7 @@
 							? el( 'p', { className: 'sw-ds-finding__repair', text: finding.repair_hint } )
 							: null,
 						finding.waiver_reason
-							? el( 'p', { className: 'sw-ds-finding__repair', text: 'Waiver: ' + finding.waiver_reason } )
+							? el( 'p', { className: 'sw-ds-finding__waiver', text: 'Waiver: ' + finding.waiver_reason } )
 							: null
 					] );
 

--- a/plugin/assets/admin/design-studio.js
+++ b/plugin/assets/admin/design-studio.js
@@ -186,7 +186,19 @@
 	/* Live region                                                         */
 	/* ------------------------------------------------------------------ */
 
+	/**
+	 * True while the live region is holding the result of a write.
+	 *
+	 * A write re-renders its view, and the render then wants to say what it
+	 * loaded. Without this the outcome the reader is waiting for — "Restored
+	 * revision 2 as revision 5." — is replaced by "Loaded 3 revisions." before
+	 * anyone, screen reader included, has read it.
+	 */
+	var outcomeShown = false;
+
 	function announce( message, tone ) {
+		outcomeShown = !! tone;
+
 		if ( ! statusNode ) {
 			return;
 		}
@@ -196,6 +208,17 @@
 		} else {
 			statusNode.removeAttribute( 'data-tone' );
 		}
+	}
+
+	/**
+	 * Says what a view loaded, unless an outcome is still on screen.
+	 */
+	function announceLoad( message ) {
+		if ( outcomeShown ) {
+			return;
+		}
+
+		announce( message );
 	}
 
 	function emit( name, detail ) {
@@ -746,7 +769,7 @@
 								: el( 'p', { className: 'sw-ds-field__hint', text: 'Your account cannot create design directions.' } )
 						] )
 					);
-					announce( 'No design direction is stored yet.' );
+					announceLoad( 'No design direction is stored yet.' );
 
 					return;
 				}
@@ -781,7 +804,7 @@
 				);
 
 				panel.appendChild( directionPicker() );
-				announce( 'Loaded ' + state.directions.length + ' design directions.' );
+				announceLoad( 'Loaded ' + state.directions.length + ' design directions.' );
 			} )
 			.catch( function ( error ) {
 				renderError( panel, error );
@@ -1619,7 +1642,7 @@
 						el( 'table', { className: 'sw-ds-table' }, [ el( 'thead', null, [ head ] ), body ] )
 					] )
 				);
-				announce( 'Loaded ' + state.versions.length + ' revisions.' );
+				announceLoad( 'Loaded ' + state.versions.length + ' revisions.' );
 			} )
 			.catch( function ( error ) {
 				renderError( panel, error );
@@ -1724,6 +1747,10 @@
 	function showView( view ) {
 		state.view = view;
 		root.setAttribute( 'data-sw-current-view', view );
+
+		// Leaving the view retires the outcome it was holding, so the view
+		// being opened is free to say what it loaded.
+		outcomeShown = false;
 
 		tabNodes.forEach( function ( tab ) {
 			var isCurrent = tab.getAttribute( 'data-sw-view' ) === view;

--- a/plugin/assets/admin/design-studio.js
+++ b/plugin/assets/admin/design-studio.js
@@ -1,0 +1,1780 @@
+/**
+ * Stonewright Design Studio.
+ *
+ * The page owns no design rules. Every read and every write goes through the
+ * Design Studio REST routes, which delegate to the typed design abilities, so
+ * the admin UI inherits their validation, backup, confirmation-token, audit,
+ * and readback guarantees.
+ *
+ * Direction names, evidence strings, and repair hints are stored content, so
+ * this file builds DOM nodes and assigns textContent rather than composing
+ * markup. Confirmation happens in a review drawer, never in a native dialog.
+ *
+ * No third-party dependencies.
+ */
+( function () {
+	'use strict';
+
+	var boot = window.stonewrightDesignStudio || {};
+	var root = document.querySelector( '[data-sw-design-studio]' );
+
+	if ( ! root || ! boot.restRoot || ! window.fetch ) {
+		return;
+	}
+
+	var SVG_NS = 'http://www.w3.org/2000/svg';
+	var DIRECTIONS_ROUTE = '/directions';
+	var QUALITY_ROUTE = '/quality';
+	var DRAFT_PREFIX = 'stonewright.design-studio.draft.';
+	var DIALS = [ 'variance', 'density', 'motion' ];
+	var VIEWS = Array.isArray( boot.views ) && boot.views.length
+		? boot.views.slice()
+		: [ 'overview', 'editor', 'quality', 'history' ];
+
+	var statusNode = root.querySelector( '[data-sw-ds-status]' );
+	var tabNodes = [].slice.call( root.querySelectorAll( '[data-sw-view]' ) );
+	var panelNodes = [].slice.call( root.querySelectorAll( '[data-sw-panel]' ) );
+
+	var state = {
+		view: root.getAttribute( 'data-sw-current-view' ) || VIEWS[ 0 ],
+		directions: [],
+		activeId: 0,
+		selectedId: boot.activeDirection ? Number( boot.activeDirection.id ) || 0 : 0,
+		direction: null,
+		versions: [],
+		draft: null,
+		errors: [],
+		isDirty: false,
+		recovered: false,
+		postId: 0,
+		reports: [],
+		reportIndex: 0,
+		filters: { severity: '', viewport: '', rule: '' },
+		listLoaded: false,
+		busy: false
+	};
+
+	var canWrite = !! ( boot.can && boot.can.manageDesign );
+
+	/* ------------------------------------------------------------------ */
+	/* DOM helpers                                                         */
+	/* ------------------------------------------------------------------ */
+
+	function el( tag, options, children ) {
+		var node = document.createElement( tag );
+		var config = options || {};
+		var key;
+
+		if ( config.className ) {
+			node.className = config.className;
+		}
+		if ( typeof config.text !== 'undefined' && null !== config.text ) {
+			node.textContent = String( config.text );
+		}
+		if ( config.attrs ) {
+			for ( key in config.attrs ) {
+				if ( Object.prototype.hasOwnProperty.call( config.attrs, key ) && null !== config.attrs[ key ] ) {
+					node.setAttribute( key, String( config.attrs[ key ] ) );
+				}
+			}
+		}
+		if ( config.on ) {
+			for ( key in config.on ) {
+				if ( Object.prototype.hasOwnProperty.call( config.on, key ) ) {
+					node.addEventListener( key, config.on[ key ] );
+				}
+			}
+		}
+		appendAll( node, children );
+
+		return node;
+	}
+
+	function appendAll( parent, children ) {
+		if ( ! children ) {
+			return parent;
+		}
+		var list = Array.isArray( children ) ? children : [ children ];
+		list.forEach( function ( child ) {
+			if ( null === child || false === child || typeof child === 'undefined' ) {
+				return;
+			}
+			parent.appendChild( typeof child === 'string' ? document.createTextNode( child ) : child );
+		} );
+
+		return parent;
+	}
+
+	function clear( node ) {
+		while ( node && node.firstChild ) {
+			node.removeChild( node.firstChild );
+		}
+
+		return node;
+	}
+
+	var ICON_PATHS = {
+		check: 'M3 8.4l3.3 3.3L13 4.6',
+		plus: 'M8 3v10M3 8h10',
+		sync: 'M13.4 7.2A5.4 5.4 0 003 6.2M2.6 8.8A5.4 5.4 0 0013 9.8M2.6 4.4v2.8h2.8M13.4 11.6V8.8h-2.8',
+		clock: 'M8 4.2V8l2.4 1.6M14 8A6 6 0 112 8a6 6 0 0112 0z',
+		alert: 'M8 5.6v3.2M8 11.2h.01M8 2.4l6 11.2H2z'
+	};
+
+	function icon( name ) {
+		var svg = document.createElementNS( SVG_NS, 'svg' );
+		var path = document.createElementNS( SVG_NS, 'path' );
+
+		svg.setAttribute( 'class', 'sw-ds-button__icon' );
+		svg.setAttribute( 'viewBox', '0 0 16 16' );
+		svg.setAttribute( 'aria-hidden', 'true' );
+		svg.setAttribute( 'focusable', 'false' );
+		path.setAttribute( 'd', ICON_PATHS[ name ] || ICON_PATHS.check );
+		path.setAttribute( 'stroke-linecap', 'round' );
+		path.setAttribute( 'stroke-linejoin', 'round' );
+		svg.appendChild( path );
+
+		return svg;
+	}
+
+	function button( label, options ) {
+		var config = options || {};
+		var node = el(
+			'button',
+			{
+				className: 'sw-ds-button' + ( config.variant ? ' sw-ds-button--' + config.variant : '' ),
+				attrs: { type: 'button' },
+				on: config.onClick ? { click: config.onClick } : null
+			},
+			[ config.icon ? icon( config.icon ) : null, el( 'span', { text: label } ) ]
+		);
+
+		if ( config.disabled ) {
+			node.disabled = true;
+		}
+		if ( config.hint ) {
+			node.setAttribute( 'title', config.hint );
+		}
+
+		return node;
+	}
+
+	function badge( label, tone ) {
+		return el( 'span', { className: 'sw-ds-badge' + ( tone ? ' sw-ds-badge--' + tone : '' ), text: label } );
+	}
+
+	function fact( label, value ) {
+		return el( 'li', { className: 'sw-ds-fact' }, [
+			el( 'span', { className: 'sw-ds-fact__label', text: label } ),
+			el( 'span', { className: 'sw-ds-fact__value', text: value } )
+		] );
+	}
+
+	function shortHash( value ) {
+		var hash = String( value || '' );
+
+		return hash.length > 12 ? hash.slice( 0, 12 ) : hash;
+	}
+
+	function label( value, fallback ) {
+		var text = String( typeof value === 'undefined' || null === value ? '' : value ).trim();
+
+		return '' === text ? fallback : text;
+	}
+
+	/* ------------------------------------------------------------------ */
+	/* Live region                                                         */
+	/* ------------------------------------------------------------------ */
+
+	function announce( message, tone ) {
+		if ( ! statusNode ) {
+			return;
+		}
+		statusNode.textContent = message ? String( message ) : '';
+		if ( tone ) {
+			statusNode.setAttribute( 'data-tone', tone );
+		} else {
+			statusNode.removeAttribute( 'data-tone' );
+		}
+	}
+
+	function emit( name, detail ) {
+		root.dispatchEvent( new CustomEvent( name, { bubbles: true, detail: detail || {} } ) );
+	}
+
+	/* ------------------------------------------------------------------ */
+	/* Transport                                                           */
+	/* ------------------------------------------------------------------ */
+
+	function readBody( response ) {
+		return response.text().then( function ( body ) {
+			if ( ! body ) {
+				return {};
+			}
+			try {
+				return JSON.parse( body );
+			} catch ( error ) {
+				return {};
+			}
+		} );
+	}
+
+	function failure( payload, status ) {
+		var message = payload && payload.message ? String( payload.message ) : 'Request failed (' + status + ').';
+		var error = new Error( message );
+
+		error.code = payload && payload.code ? String( payload.code ) : '';
+		error.payload = payload || {};
+
+		return error;
+	}
+
+	function get( path ) {
+		return window.fetch( boot.restRoot + path, {
+			credentials: 'same-origin',
+			headers: { Accept: 'application/json', 'X-WP-Nonce': boot.nonce || '' }
+		} ).then( function ( response ) {
+			return readBody( response ).then( function ( payload ) {
+				if ( ! response.ok ) {
+					throw failure( payload, response.status );
+				}
+
+				return payload;
+			} );
+		} );
+	}
+
+	function post( path, body ) {
+		return window.fetch( boot.restRoot + path, {
+			method: 'POST',
+			credentials: 'same-origin',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+				'X-WP-Nonce': boot.nonce || ''
+			},
+			body: JSON.stringify( body || {} )
+		} ).then( function ( response ) {
+			return readBody( response ).then( function ( payload ) {
+				if ( ! response.ok ) {
+					throw failure( payload, response.status );
+				}
+
+				return payload;
+			} );
+		} );
+	}
+
+	function busy( isBusy ) {
+		state.busy = !! isBusy;
+		root.setAttribute( 'aria-busy', state.busy ? 'true' : 'false' );
+	}
+
+	/* ------------------------------------------------------------------ */
+	/* Review drawer                                                       */
+	/* ------------------------------------------------------------------ */
+
+	var openScrim = null;
+	var lastFocused = null;
+
+	function focusableIn( node ) {
+		return [].slice.call(
+			node.querySelectorAll( 'a[href], button:not(:disabled), input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])' )
+		);
+	}
+
+	function trapFocus( drawer, event ) {
+		var items = focusableIn( drawer );
+
+		if ( ! items.length ) {
+			event.preventDefault();
+			drawer.focus();
+
+			return;
+		}
+
+		var first = items[ 0 ];
+		var last = items[ items.length - 1 ];
+
+		if ( event.shiftKey && document.activeElement === first ) {
+			event.preventDefault();
+			last.focus();
+		} else if ( ! event.shiftKey && document.activeElement === last ) {
+			event.preventDefault();
+			first.focus();
+		}
+	}
+
+	function restoreFocus() {
+		if ( lastFocused && document.contains( lastFocused ) ) {
+			lastFocused.focus();
+		}
+		lastFocused = null;
+	}
+
+	function closeDrawer() {
+		if ( ! openScrim ) {
+			return;
+		}
+		var scrim = openScrim;
+
+		openScrim = null;
+		document.removeEventListener( 'keydown', scrim.swKeydown, true );
+		if ( scrim.parentNode ) {
+			scrim.parentNode.removeChild( scrim );
+		}
+		restoreFocus();
+	}
+
+	/**
+	 * Opens the review drawer. `options.rows` is the review summary the user
+	 * confirms against: what changes, on which record, against which hash.
+	 */
+	function openDrawer( options ) {
+		var config = options || {};
+
+		closeDrawer();
+		lastFocused = document.activeElement;
+
+		var titleId = 'sw-ds-drawer-title';
+		var rows = ( config.rows || [] ).map( function ( row ) {
+			return el( 'li', null, [
+				el( 'span', { className: 'sw-ds-review__key', text: row.key } ),
+				el( 'span', {
+					className: 'sw-ds-review__value' + ( row.tone ? ' sw-ds-review__value--' + row.tone : '' ),
+					text: row.value
+				} )
+			] );
+		} );
+
+		var confirmButton = button( config.confirmLabel || 'Confirm', {
+			variant: config.confirmTone || 'primary',
+			icon: config.confirmIcon || 'check',
+			onClick: function () {
+				var result = config.onConfirm ? config.onConfirm() : null;
+
+				closeDrawer();
+				return result;
+			}
+		} );
+
+		var drawer = el(
+			'div',
+			{
+				className: 'sw-ds-drawer',
+				attrs: {
+					'data-sw-ds-drawer': '',
+					role: 'dialog',
+					'aria-modal': 'true',
+					'aria-labelledby': titleId,
+					tabindex: '-1'
+				}
+			},
+			[
+				el( 'h2', { className: 'sw-ds-drawer__title', text: config.title || 'Review', attrs: { id: titleId } } ),
+				config.lede ? el( 'p', { className: 'sw-ds-drawer__lede', text: config.lede } ) : null,
+				el( 'div', { className: 'sw-ds-drawer__body' }, [
+					rows.length ? el( 'ul', { className: 'sw-ds-review' }, rows ) : null,
+					config.extra || null
+				] ),
+				el( 'div', { className: 'sw-ds-drawer__footer' }, [
+					button( config.cancelLabel || 'Cancel', {
+						onClick: function () {
+							closeDrawer();
+							if ( config.onCancel ) {
+								config.onCancel();
+							}
+						}
+					} ),
+					confirmButton
+				] )
+			]
+		);
+
+		var scrim = el( 'div', { className: 'sw-ds-scrim' }, [ drawer ] );
+
+		scrim.addEventListener( 'click', function ( event ) {
+			if ( event.target === scrim ) {
+				closeDrawer();
+				if ( config.onCancel ) {
+					config.onCancel();
+				}
+			}
+		} );
+
+		scrim.swKeydown = function ( event ) {
+			if ( 'Escape' === event.key ) {
+				event.preventDefault();
+				closeDrawer();
+				if ( config.onCancel ) {
+					config.onCancel();
+				}
+			} else if ( 'Tab' === event.key ) {
+				trapFocus( drawer, event );
+			}
+		};
+
+		document.body.appendChild( scrim );
+		document.addEventListener( 'keydown', scrim.swKeydown, true );
+		openScrim = scrim;
+
+		window.requestAnimationFrame( function () {
+			scrim.classList.add( 'is-open' );
+			confirmButton.focus();
+		} );
+	}
+
+	/* ------------------------------------------------------------------ */
+	/* Contract helpers                                                    */
+	/* ------------------------------------------------------------------ */
+
+	function emptyContract() {
+		return {
+			schema_version: '1.0',
+			identity: { name: '', summary: '' },
+			tokens: { colors: {}, typography: {}, spacing: {}, radii: {}, elevation: {}, motion: {} },
+			components: {},
+			dials: { variance: 0, density: 0, motion: 0 },
+			guidance: { do: [], avoid: [] },
+			provenance: {},
+			waivers: [],
+			readiness: { ready: false, sync_ready: false, issues: [] }
+		};
+	}
+
+	function contractOf( direction ) {
+		if ( direction && direction.contract && typeof direction.contract === 'object' ) {
+			return direction.contract;
+		}
+
+		return emptyContract();
+	}
+
+	function draftKey( id ) {
+		return DRAFT_PREFIX + String( id || 0 );
+	}
+
+	function readStoredDraft( id ) {
+		try {
+			var raw = window.sessionStorage.getItem( draftKey( id ) );
+
+			return raw ? JSON.parse( raw ) : null;
+		} catch ( error ) {
+			return null;
+		}
+	}
+
+	function writeStoredDraft( id, draft ) {
+		try {
+			window.sessionStorage.setItem( draftKey( id ), JSON.stringify( draft ) );
+		} catch ( error ) {
+			// A full or blocked sessionStorage must not break editing.
+		}
+	}
+
+	function dropStoredDraft( id ) {
+		try {
+			window.sessionStorage.removeItem( draftKey( id ) );
+		} catch ( error ) {
+			// Nothing to recover from; ignore.
+		}
+	}
+
+	function draftFromDirection( direction ) {
+		var contract = contractOf( direction );
+		var identity = contract.identity || {};
+		var dials = contract.dials || {};
+		var guidance = contract.guidance || {};
+
+		return {
+			id: direction ? Number( direction.id ) || 0 : 0,
+			slug: direction ? String( direction.slug || '' ) : '',
+			status: direction ? String( direction.status || 'draft' ) : 'draft',
+			name: String( identity.name || '' ),
+			summary: String( identity.summary || '' ),
+			variance: Number( dials.variance || 0 ),
+			density: Number( dials.density || 0 ),
+			motion: Number( dials.motion || 0 ),
+			tokens: JSON.stringify( contract.tokens || {}, null, 2 ),
+			guidanceDo: ( guidance.do || [] ).join( '\n' ),
+			guidanceAvoid: ( guidance.avoid || [] ).join( '\n' )
+		};
+	}
+
+	function linesOf( value ) {
+		return String( value || '' )
+			.split( '\n' )
+			.map( function ( line ) {
+				return line.trim();
+			} )
+			.filter( function ( line ) {
+				return '' !== line;
+			} );
+	}
+
+	function validateDraft( draft ) {
+		var errors = [];
+
+		if ( '' === String( draft.name || '' ).trim() ) {
+			errors.push( { field: 'name', message: 'A direction needs a name.' } );
+		}
+		if ( draft.slug && ! /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test( draft.slug ) ) {
+			errors.push( { field: 'slug', message: 'A slug uses lowercase letters, digits, and single hyphens.' } );
+		}
+		DIALS.forEach( function ( dial ) {
+			var value = Number( draft[ dial ] );
+
+			if ( ! isFinite( value ) || value < 0 || value > 100 || Math.floor( value ) !== value ) {
+				errors.push( { field: dial, message: 'The ' + dial + ' dial is a whole number from 0 to 100.' } );
+			}
+		} );
+		try {
+			var tokens = JSON.parse( draft.tokens || '{}' );
+
+			if ( ! tokens || typeof tokens !== 'object' || Array.isArray( tokens ) ) {
+				errors.push( { field: 'tokens', message: 'Tokens must be a JSON object of token groups.' } );
+			}
+		} catch ( error ) {
+			errors.push( { field: 'tokens', message: 'Tokens are not valid JSON: ' + error.message } );
+		}
+
+		return errors;
+	}
+
+	function contractFromDraft( draft ) {
+		var contract = emptyContract();
+		var tokens = {};
+
+		try {
+			tokens = JSON.parse( draft.tokens || '{}' );
+		} catch ( error ) {
+			tokens = {};
+		}
+
+		contract.identity = { name: String( draft.name || '' ).trim(), summary: String( draft.summary || '' ).trim() };
+		contract.tokens = tokens && typeof tokens === 'object' ? tokens : {};
+		contract.dials = {
+			variance: Number( draft.variance ) || 0,
+			density: Number( draft.density ) || 0,
+			motion: Number( draft.motion ) || 0
+		};
+		contract.guidance = { do: linesOf( draft.guidanceDo ), avoid: linesOf( draft.guidanceAvoid ) };
+
+		return contract;
+	}
+
+	function markDirty( isDirty ) {
+		state.isDirty = !! isDirty;
+		if ( state.isDirty && state.draft ) {
+			writeStoredDraft( state.draft.id, state.draft );
+		}
+	}
+
+	/* ------------------------------------------------------------------ */
+	/* Data loading                                                        */
+	/* ------------------------------------------------------------------ */
+
+	function loadDirections() {
+		return get( DIRECTIONS_ROUTE ).then( function ( payload ) {
+			state.directions = Array.isArray( payload.directions ) ? payload.directions : [];
+			state.activeId = Number( payload.active_id ) || 0;
+			state.listLoaded = true;
+			if ( ! state.selectedId ) {
+				state.selectedId = state.activeId || ( state.directions[ 0 ] ? Number( state.directions[ 0 ].id ) || 0 : 0 );
+			}
+
+			return state.directions;
+		} );
+	}
+
+	function loadDirection( id ) {
+		if ( ! id ) {
+			state.direction = null;
+			state.versions = [];
+
+			return Promise.resolve( null );
+		}
+
+		return get( DIRECTIONS_ROUTE + '/' + encodeURIComponent( String( id ) ) ).then( function ( payload ) {
+			state.direction = payload.direction || null;
+			state.versions = Array.isArray( payload.versions ) ? payload.versions : [];
+
+			return state.direction;
+		} );
+	}
+
+	function loadReports( postId ) {
+		return get( QUALITY_ROUTE + '?post_id=' + encodeURIComponent( String( postId ) ) ).then( function ( payload ) {
+			state.reports = Array.isArray( payload.reports ) ? payload.reports : [];
+			state.reportIndex = 0;
+
+			return state.reports;
+		} );
+	}
+
+	/* ------------------------------------------------------------------ */
+	/* Views                                                               */
+	/* ------------------------------------------------------------------ */
+
+	function panelFor( view ) {
+		var match = null;
+
+		panelNodes.forEach( function ( node ) {
+			if ( node.getAttribute( 'data-sw-panel' ) === view ) {
+				match = node;
+			}
+		} );
+
+		return match;
+	}
+
+	function pending( panel, message ) {
+		clear( panel ).appendChild( el( 'div', { className: 'sw-ds-panel__loading', text: message } ) );
+	}
+
+	function renderError( panel, error ) {
+		clear( panel ).appendChild(
+			el( 'div', { className: 'sw-ds-error-summary' }, [
+				el( 'h2', { text: 'That request was refused' } ),
+				el( 'ul', null, [ el( 'li', { text: error && error.message ? error.message : 'Unknown error.' } ) ] )
+			] )
+		);
+		announce( error && error.message ? error.message : 'Request failed.', 'danger' );
+	}
+
+	function specimen( contract ) {
+		var colors = ( contract.tokens && contract.tokens.colors ) || {};
+		var dials = contract.dials || {};
+		var swatches = Object.keys( colors ).slice( 0, 8 ).map( function ( name ) {
+			var chip = el( 'span', { className: 'sw-ds-swatch__chip' } );
+			var value = colors[ name ];
+
+			if ( typeof value === 'string' ) {
+				chip.style.background = value;
+			}
+
+			return el( 'li', { className: 'sw-ds-swatch' }, [
+				chip,
+				el( 'span', { className: 'sw-ds-swatch__name', text: name } )
+			] );
+		} );
+
+		var dialRows = DIALS.map( function ( name ) {
+			var value = Math.max( 0, Math.min( 100, Number( dials[ name ] ) || 0 ) );
+			var fill = el( 'span', { className: 'sw-ds-dial__fill' } );
+
+			fill.style.width = value + '%';
+
+			return el( 'div', { className: 'sw-ds-dial' }, [
+				el( 'span', { text: name } ),
+				el( 'span', { className: 'sw-ds-dial__track' }, [ fill ] ),
+				el( 'span', { className: 'sw-ds-dial__value', text: String( value ) } )
+			] );
+		} );
+
+		return el( 'div', { className: 'sw-ds-specimen' }, [
+			el( 'p', { className: 'sw-ds-specimen__title', text: 'Specimen' } ),
+			swatches.length
+				? el( 'ul', { className: 'sw-ds-swatches' }, swatches )
+				: el( 'p', { className: 'sw-ds-field__hint', text: 'No colour tokens recorded yet.' } ),
+			el( 'div', { className: 'sw-ds-dials' }, dialRows )
+		] );
+	}
+
+	function directionBadges( row ) {
+		var badges = [ badge( label( row.status, 'draft' ), 'draft' === row.status ? 'draft' : 'info' ) ];
+
+		if ( row.active ) {
+			badges.push( badge( 'active', 'active' ) );
+		}
+		badges.push( badge( row.ready ? 'ready' : 'not ready', row.ready ? 'ok' : 'warn' ) );
+		badges.push( badge( row.sync_ready ? 'sync ready' : 'sync blocked', row.sync_ready ? 'ok' : 'warn' ) );
+		if ( row.issue_count ) {
+			badges.push( badge( row.issue_count + ' issues', 'error' ) );
+		}
+
+		return el( 'div', { className: 'sw-ds-badges' }, badges );
+	}
+
+	function renderOverview( panel ) {
+		pending( panel, 'Loading design directions.' );
+
+		loadDirections()
+			.then( function () {
+				return loadDirection( state.selectedId );
+			} )
+			.then( function () {
+				clear( panel );
+
+				if ( ! state.directions.length ) {
+					panel.appendChild(
+						el( 'div', { className: 'sw-ds-empty' }, [
+							el( 'h2', { text: 'No design direction yet' } ),
+							el( 'p', {
+								text: 'A direction records the tokens, dials, and guidance every rendered section is measured against. Create one and the quality checks gain something to compare with.'
+							} ),
+							canWrite
+								? button( 'Create the first direction', {
+									variant: 'primary',
+									icon: 'plus',
+									onClick: function () {
+										state.selectedId = 0;
+										state.direction = null;
+										state.draft = null;
+										requestView( 'editor' );
+									}
+								} )
+								: el( 'p', { className: 'sw-ds-field__hint', text: 'Your account cannot create design directions.' } )
+						] )
+					);
+					announce( 'No design direction is stored yet.' );
+
+					return;
+				}
+
+				var row = state.directions.filter( function ( item ) {
+					return Number( item.id ) === state.selectedId;
+				} )[ 0 ] || state.directions[ 0 ];
+
+				state.selectedId = Number( row.id ) || 0;
+
+				var contract = contractOf( state.direction );
+
+				panel.appendChild(
+					el( 'div', { className: 'sw-ds-hero' }, [
+						el( 'div', { className: 'sw-ds-card' }, [
+							el( 'h2', { className: 'sw-ds-card__title', text: label( row.name, label( row.slug, 'Untitled direction' ) ) } ),
+							el( 'p', {
+								className: 'sw-ds-card__meta',
+								text: 'revision ' + row.revision + ' · ' + shortHash( row.contract_hash ) + ' · updated ' + label( row.updated_at, 'unknown' )
+							} ),
+							directionBadges( row ),
+							el( 'ul', { className: 'sw-ds-hero__facts' }, [
+								fact( 'Slug', label( row.slug, 'none' ) ),
+								fact( 'Source', label( row.source_type, 'manual' ) ),
+								fact( 'Revision', String( row.revision ) ),
+								fact( 'Issues', String( row.issue_count ) )
+							] ),
+							overviewActions( row )
+						] ),
+						specimen( contract )
+					] )
+				);
+
+				panel.appendChild( directionPicker() );
+				announce( 'Loaded ' + state.directions.length + ' design directions.' );
+			} )
+			.catch( function ( error ) {
+				renderError( panel, error );
+			} );
+	}
+
+	function directionPicker() {
+		var select = el( 'select', { attrs: { id: 'sw-ds-direction-picker' } } );
+
+		state.directions.forEach( function ( row ) {
+			var option = el( 'option', { text: label( row.name, row.slug ) + ( row.active ? ' (active)' : '' ) } );
+
+			option.value = String( row.id );
+			if ( Number( row.id ) === state.selectedId ) {
+				option.selected = true;
+			}
+			select.appendChild( option );
+		} );
+
+		select.addEventListener( 'change', function () {
+			state.selectedId = Number( select.value ) || 0;
+			state.direction = null;
+			state.draft = null;
+			state.isDirty = false;
+			render( state.view );
+		} );
+
+		return el( 'div', { className: 'sw-ds-filters' }, [
+			el( 'div', { className: 'sw-ds-filter' }, [
+				el( 'label', { text: 'Direction', attrs: { for: 'sw-ds-direction-picker' } } ),
+				select
+			] )
+		] );
+	}
+
+	function overviewActions( row ) {
+		var actions = [
+			button( 'Open in editor', {
+				onClick: function () {
+					requestView( 'editor' );
+				}
+			} )
+		];
+
+		if ( canWrite ) {
+			actions.push(
+				button( 'Activate', {
+					variant: 'primary',
+					icon: 'check',
+					disabled: !! row.active,
+					hint: row.active ? 'This direction is already active.' : '',
+					onClick: function () {
+						reviewActivate( row );
+					}
+				} )
+			);
+			actions.push(
+				button( 'Plan Elementor sync', {
+					icon: 'sync',
+					onClick: function () {
+						runSyncPlan( row );
+					}
+				} )
+			);
+		}
+
+		return el( 'div', { className: 'sw-ds-actions' }, actions );
+	}
+
+	/* ---------------------------- Editor ------------------------------ */
+
+	function field( config ) {
+		var id = 'sw-ds-field-' + config.name;
+		var control;
+
+		if ( 'textarea' === config.type ) {
+			control = el( 'textarea', { attrs: { id: id, rows: String( config.rows || 6 ) } } );
+			control.value = config.value || '';
+		} else {
+			control = el( 'input', { attrs: { id: id, type: config.type || 'text' } } );
+			if ( 'number' === config.type ) {
+				control.setAttribute( 'min', '0' );
+				control.setAttribute( 'max', '100' );
+				control.setAttribute( 'step', '1' );
+			}
+			control.value = typeof config.value === 'undefined' ? '' : String( config.value );
+		}
+
+		var error = el( 'span', { className: 'sw-ds-field__error', attrs: { id: id + '-error' } } );
+		var wrapper = el( 'div', { className: 'sw-ds-field', attrs: { 'data-sw-field': config.name } }, [
+			el( 'label', { className: 'sw-ds-field__label', text: config.label, attrs: { for: id } } ),
+			config.hint ? el( 'span', { className: 'sw-ds-field__hint', text: config.hint } ) : null,
+			control,
+			error
+		] );
+
+		control.addEventListener( 'input', function () {
+			config.onInput( control.value );
+			markDirty( true );
+			refreshValidation();
+		} );
+
+		return wrapper;
+	}
+
+	function refreshValidation() {
+		var panel = panelFor( 'editor' );
+
+		if ( ! panel || ! state.draft ) {
+			return;
+		}
+
+		state.errors = validateDraft( state.draft );
+
+		var byField = {};
+
+		state.errors.forEach( function ( item ) {
+			byField[ item.field ] = item.message;
+		} );
+
+		[].slice.call( panel.querySelectorAll( '[data-sw-field]' ) ).forEach( function ( node ) {
+			var name = node.getAttribute( 'data-sw-field' );
+			var message = byField[ name ] || '';
+			var errorNode = node.querySelector( '.sw-ds-field__error' );
+			var control = node.querySelector( 'input, textarea, select' );
+
+			node.classList.toggle( 'is-invalid', '' !== message );
+			if ( errorNode ) {
+				errorNode.textContent = message;
+			}
+			if ( control ) {
+				control.setAttribute( 'aria-invalid', '' !== message ? 'true' : 'false' );
+			}
+		} );
+
+		var summary = panel.querySelector( '[data-sw-ds-error-summary]' );
+
+		if ( summary ) {
+			clear( summary );
+			if ( state.errors.length ) {
+				summary.hidden = false;
+				summary.appendChild( el( 'h2', { text: state.errors.length + ' fields need attention' } ) );
+				summary.appendChild(
+					el(
+						'ul',
+						null,
+						state.errors.map( function ( item ) {
+							return el( 'li', null, [
+								el( 'a', {
+									text: item.message,
+									attrs: { href: '#sw-ds-field-' + item.field }
+								} )
+							] );
+						} )
+					)
+				);
+			} else {
+				summary.hidden = true;
+			}
+		}
+
+		var save = panel.querySelector( '[data-sw-ds-save]' );
+
+		if ( save ) {
+			save.disabled = state.errors.length > 0 || ! canWrite;
+		}
+	}
+
+	function renderEditor( panel ) {
+		if ( state.selectedId && ! state.direction ) {
+			pending( panel, 'Loading the direction.' );
+			loadDirection( state.selectedId )
+				.then( function () {
+					renderEditor( panel );
+				} )
+				.catch( function ( error ) {
+					renderError( panel, error );
+				} );
+
+			return;
+		}
+
+		if ( ! state.draft ) {
+			var stored = readStoredDraft( state.selectedId );
+
+			state.draft = draftFromDirection( state.direction );
+			state.recovered = false;
+			if ( stored && JSON.stringify( stored ) !== JSON.stringify( state.draft ) ) {
+				state.recovered = true;
+			}
+			state.stored = stored;
+		}
+
+		var draft = state.draft;
+
+		clear( panel );
+
+		if ( state.recovered ) {
+			panel.appendChild(
+				el( 'div', { className: 'sw-ds-recovery' }, [
+					el( 'span', { text: 'An unsaved draft from this browser session is available for this direction.' } ),
+					button( 'Restore draft', {
+						onClick: function () {
+							state.draft = state.stored;
+							state.recovered = false;
+							markDirty( true );
+							render( 'editor' );
+						}
+					} ),
+					button( 'Discard draft', {
+						onClick: function () {
+							dropStoredDraft( state.selectedId );
+							state.recovered = false;
+							render( 'editor' );
+						}
+					} )
+				] )
+			);
+		}
+
+		var summary = el( 'div', { className: 'sw-ds-error-summary', attrs: { 'data-sw-ds-error-summary': '', role: 'alert' } } );
+
+		summary.hidden = true;
+		panel.appendChild( summary );
+
+		var identity = el( 'fieldset', { className: 'sw-ds-fieldset' }, [
+			el( 'legend', { text: 'Identity' } ),
+			field( {
+				name: 'name',
+				label: 'Name',
+				value: draft.name,
+				onInput: function ( value ) {
+					draft.name = value;
+				}
+			} ),
+			field( {
+				name: 'slug',
+				label: 'Slug',
+				hint: 'Optional. Defaults to the name.',
+				value: draft.slug,
+				onInput: function ( value ) {
+					draft.slug = value;
+				}
+			} ),
+			field( {
+				name: 'summary',
+				label: 'Summary',
+				type: 'textarea',
+				rows: 3,
+				value: draft.summary,
+				onInput: function ( value ) {
+					draft.summary = value;
+				}
+			} )
+		] );
+
+		var dials = el(
+			'fieldset',
+			{ className: 'sw-ds-fieldset' },
+			[ el( 'legend', { text: 'Dials' } ) ].concat(
+				DIALS.map( function ( name ) {
+					return field( {
+						name: name,
+						label: name.charAt( 0 ).toUpperCase() + name.slice( 1 ),
+						type: 'number',
+						hint: 'Whole number, 0 to 100.',
+						value: draft[ name ],
+						onInput: function ( value ) {
+							draft[ name ] = '' === value ? '' : Number( value );
+							updateSpecimen();
+						}
+					} );
+				} )
+			)
+		);
+
+		var tokens = el( 'fieldset', { className: 'sw-ds-fieldset' }, [
+			el( 'legend', { text: 'Tokens' } ),
+			field( {
+				name: 'tokens',
+				label: 'Token groups',
+				type: 'textarea',
+				rows: 14,
+				hint: 'JSON object. Only the allowlisted groups are stored: colors, typography, spacing, radii, elevation, motion.',
+				value: draft.tokens,
+				onInput: function ( value ) {
+					draft.tokens = value;
+					updateSpecimen();
+				}
+			} )
+		] );
+
+		var guidance = el( 'fieldset', { className: 'sw-ds-fieldset' }, [
+			el( 'legend', { text: 'Guidance' } ),
+			field( {
+				name: 'guidanceDo',
+				label: 'Do',
+				type: 'textarea',
+				rows: 4,
+				hint: 'One instruction per line.',
+				value: draft.guidanceDo,
+				onInput: function ( value ) {
+					draft.guidanceDo = value;
+				}
+			} ),
+			field( {
+				name: 'guidanceAvoid',
+				label: 'Avoid',
+				type: 'textarea',
+				rows: 4,
+				hint: 'One instruction per line.',
+				value: draft.guidanceAvoid,
+				onInput: function ( value ) {
+					draft.guidanceAvoid = value;
+				}
+			} )
+		] );
+
+		var save = button( 'Review and save', {
+			variant: 'primary',
+			icon: 'check',
+			onClick: function () {
+				reviewSave();
+			}
+		} );
+
+		save.setAttribute( 'data-sw-ds-save', '' );
+
+		var main = el( 'div', { className: 'sw-ds-editor__main' }, [
+			identity,
+			dials,
+			tokens,
+			guidance,
+			el( 'div', { className: 'sw-ds-actions' }, [
+				save,
+				button( 'Revert to stored', {
+					onClick: function () {
+						state.draft = draftFromDirection( state.direction );
+						dropStoredDraft( state.selectedId );
+						markDirty( false );
+						render( 'editor' );
+						announce( 'Reverted to the stored contract.' );
+					}
+				} )
+			] )
+		] );
+
+		var aside = el( 'div', { className: 'sw-ds-editor__aside', attrs: { 'data-sw-ds-aside': '' } }, [
+			specimen( contractFromDraft( draft ) ),
+			provenanceInspector()
+		] );
+
+		panel.appendChild( el( 'div', { className: 'sw-ds-editor' }, [ main, aside ] ) );
+		refreshValidation();
+	}
+
+	function updateSpecimen() {
+		var panel = panelFor( 'editor' );
+		var aside = panel ? panel.querySelector( '[data-sw-ds-aside]' ) : null;
+
+		if ( ! aside || ! state.draft ) {
+			return;
+		}
+		clear( aside );
+		aside.appendChild( specimen( contractFromDraft( state.draft ) ) );
+		aside.appendChild( provenanceInspector() );
+	}
+
+	function provenanceInspector() {
+		var direction = state.direction || {};
+		var contract = contractOf( state.direction );
+		var provenance = contract.provenance || {};
+		var rows = [
+			{ key: 'Revision', value: String( direction.revision || 0 ) },
+			{ key: 'Contract hash', value: shortHash( direction.contract_hash ) },
+			{ key: 'Source', value: label( direction.source_type, 'manual' ) },
+			{ key: 'Updated', value: label( direction.updated_at, 'never' ) }
+		];
+
+		Object.keys( provenance ).slice( 0, 8 ).forEach( function ( key ) {
+			var value = provenance[ key ];
+
+			rows.push( { key: key, value: typeof value === 'string' ? value : JSON.stringify( value ) } );
+		} );
+
+		return el( 'div', { className: 'sw-ds-card' }, [
+			el( 'h3', { className: 'sw-ds-card__title', text: 'Provenance' } ),
+			el(
+				'ul',
+				{ className: 'sw-ds-provenance' },
+				rows.map( function ( row ) {
+					return el( 'li', null, [
+						el( 'span', { className: 'sw-ds-provenance__key', text: row.key } ),
+						el( 'span', { className: 'sw-ds-provenance__value', text: row.value } )
+					] );
+				} )
+			)
+		] );
+	}
+
+	function reviewSave() {
+		if ( ! state.draft || state.errors.length ) {
+			announce( 'Fix the highlighted fields before saving.', 'danger' );
+
+			return;
+		}
+
+		var draft = state.draft;
+		var contract = contractFromDraft( draft );
+
+		openDrawer( {
+			title: 'Save this direction',
+			lede: 'The contract is validated server-side before anything is stored. A new revision is recorded, and the previous one stays restorable.',
+			rows: [
+				{ key: 'Name', value: contract.identity.name },
+				{ key: 'Slug', value: label( draft.slug, 'derived from the name' ) },
+				{ key: 'Direction', value: draft.id ? 'id ' + draft.id : 'new record' },
+				{ key: 'Current revision', value: String( ( state.direction && state.direction.revision ) || 0 ) },
+				{ key: 'Token groups', value: Object.keys( contract.tokens ).join( ', ' ) || 'none' },
+				{ key: 'Guidance', value: contract.guidance.do.length + ' do, ' + contract.guidance.avoid.length + ' avoid' }
+			],
+			confirmLabel: 'Save direction',
+			onConfirm: function () {
+				var body = { contract: contract };
+
+				if ( draft.slug ) {
+					body.slug = draft.slug;
+				}
+				busy( true );
+				announce( 'Saving the direction.' );
+				post( DIRECTIONS_ROUTE, body )
+					.then( function ( payload ) {
+						busy( false );
+						state.selectedId = Number( payload.id ) || state.selectedId;
+						state.direction = null;
+						state.draft = null;
+						markDirty( false );
+						dropStoredDraft( draft.id );
+						dropStoredDraft( state.selectedId );
+						announce(
+							'Saved revision ' + payload.revision + ' (' + shortHash( payload.contract_hash ) + ').',
+							payload.effect_verified ? 'ok' : 'warn'
+						);
+						emit( 'stonewright:direction-saved', payload );
+						render( 'editor' );
+					} )
+					.catch( function ( error ) {
+						busy( false );
+						announce( error.message, 'danger' );
+					} );
+			}
+		} );
+	}
+
+	function reviewActivate( row ) {
+		openDrawer( {
+			title: 'Activate this direction',
+			lede: 'The active direction is the one every quality check and every Elementor sync reads. Activation is recorded in the audit log and can be reversed by activating the previous direction.',
+			rows: [
+				{ key: 'Direction', value: label( row.name, row.slug ) },
+				{ key: 'Revision', value: String( row.revision ) },
+				{ key: 'Contract hash', value: shortHash( row.contract_hash ) },
+				{ key: 'Readiness', value: row.ready ? 'ready' : 'not ready', tone: row.ready ? null : 'warn' },
+				{ key: 'Currently active', value: state.activeId ? 'id ' + state.activeId : 'none' }
+			],
+			confirmLabel: 'Activate',
+			onConfirm: function () {
+				busy( true );
+				post( DIRECTIONS_ROUTE + '/' + encodeURIComponent( String( row.id ) ) + '/activate', {} )
+					.then( function ( payload ) {
+						busy( false );
+						state.activeId = Number( payload.active_id ) || 0;
+						announce( 'Activated direction ' + payload.id + '.', 'ok' );
+						emit( 'stonewright:direction-activated', payload );
+						render( state.view );
+					} )
+					.catch( function ( error ) {
+						busy( false );
+						announce( error.message, 'danger' );
+					} );
+			}
+		} );
+	}
+
+	function runSyncPlan( row ) {
+		busy( true );
+		announce( 'Planning the Elementor kit sync.' );
+		post( DIRECTIONS_ROUTE + '/' + encodeURIComponent( String( row.id ) ) + '/sync-plan', {} )
+			.then( function ( plan ) {
+				busy( false );
+				reviewSyncApply( row, plan );
+			} )
+			.catch( function ( error ) {
+				busy( false );
+				announce( error.message, 'danger' );
+			} );
+	}
+
+	function reviewSyncApply( row, plan ) {
+		var operations = Array.isArray( plan.operations ) ? plan.operations : [];
+		var warnings = Array.isArray( plan.warnings ) ? plan.warnings : [];
+		var blocked = Array.isArray( plan.blocked ) ? plan.blocked : [];
+		var extra = null;
+
+		if ( blocked.length ) {
+			extra = el(
+				'ul',
+				{ className: 'sw-ds-findings' },
+				blocked.slice( 0, 10 ).map( function ( item ) {
+					return el( 'li', { className: 'sw-ds-finding' }, [
+						el( 'span', { className: 'sw-ds-finding__rule', text: label( item.path || item.reason, 'blocked' ) } ),
+						el( 'p', { className: 'sw-ds-finding__repair', text: label( item.reason || item.message, '' ) } )
+					] );
+				} )
+			);
+		}
+
+		openDrawer( {
+			title: 'Apply this sync to the Elementor kit',
+			lede: 'The kit is snapshotted before the write, and the apply is refused if the live kit no longer matches the hash this plan was built against.',
+			rows: [
+				{ key: 'Direction', value: label( row.name, row.slug ) },
+				{ key: 'Kit', value: 'id ' + ( plan.kit_id || 0 ) },
+				{ key: 'Base hash', value: shortHash( plan.base_hash ) },
+				{ key: 'Operations', value: String( operations.length ) },
+				{ key: 'Warnings', value: String( warnings.length ), tone: warnings.length ? 'warn' : null },
+				{ key: 'Blocked', value: String( blocked.length ), tone: blocked.length ? 'danger' : null },
+				{ key: 'Ready to apply', value: plan.ready_to_apply ? 'yes' : 'no', tone: plan.ready_to_apply ? null : 'danger' }
+			],
+			extra: extra,
+			confirmLabel: plan.ready_to_apply ? 'Apply sync' : 'Apply is blocked',
+			confirmTone: plan.ready_to_apply ? 'primary' : 'danger',
+			onConfirm: function () {
+				if ( ! plan.ready_to_apply ) {
+					announce( 'The sync plan is blocked. Resolve the blocked entries first.', 'danger' );
+
+					return;
+				}
+				busy( true );
+				post( DIRECTIONS_ROUTE + '/' + encodeURIComponent( String( row.id ) ) + '/sync-apply', {
+					base_hash: plan.base_hash,
+					kit_id: plan.kit_id
+				} )
+					.then( function ( payload ) {
+						busy( false );
+						announce(
+							'Applied ' + payload.applied + ' kit operations. Snapshot ' + label( payload.snapshot_id, 'unknown' ) + '.',
+							payload.effect_verified ? 'ok' : 'warn'
+						);
+						render( state.view );
+					} )
+					.catch( function ( error ) {
+						busy( false );
+						announce( error.message, 'danger' );
+					} );
+			}
+		} );
+	}
+
+	/* ---------------------------- Quality ----------------------------- */
+
+	function severityTone( severity ) {
+		if ( 'error' === severity || 'critical' === severity ) {
+			return 'error';
+		}
+		if ( 'warning' === severity || 'warn' === severity ) {
+			return 'warn';
+		}
+
+		return 'info';
+	}
+
+	function renderQuality( panel ) {
+		clear( panel );
+
+		var postInput = el( 'input', { attrs: { id: 'sw-ds-post-id', type: 'number', min: '1', step: '1' } } );
+
+		postInput.value = state.postId ? String( state.postId ) : '';
+
+		var severity = filterSelect( 'severity', [ '', 'error', 'warning', 'info' ] );
+		var viewport = filterSelect( 'viewport', [ '', 'mobile', 'tablet', 'desktop' ] );
+		var rule = el( 'input', { attrs: { id: 'sw-ds-filter-rule', type: 'text' } } );
+
+		rule.value = state.filters.rule;
+		rule.addEventListener( 'input', function () {
+			state.filters.rule = rule.value;
+			paintFindings( panel );
+		} );
+
+		panel.appendChild(
+			el( 'div', { className: 'sw-ds-filters' }, [
+				el( 'div', { className: 'sw-ds-filter' }, [
+					el( 'label', { text: 'Post id', attrs: { for: 'sw-ds-post-id' } } ),
+					postInput
+				] ),
+				el( 'div', { className: 'sw-ds-filter' }, [
+					el( 'label', { text: 'Severity', attrs: { for: 'sw-ds-filter-severity' } } ),
+					severity
+				] ),
+				el( 'div', { className: 'sw-ds-filter' }, [
+					el( 'label', { text: 'Viewport', attrs: { for: 'sw-ds-filter-viewport' } } ),
+					viewport
+				] ),
+				el( 'div', { className: 'sw-ds-filter' }, [
+					el( 'label', { text: 'Rule contains', attrs: { for: 'sw-ds-filter-rule' } } ),
+					rule
+				] ),
+				button( 'Load reports', {
+					icon: 'clock',
+					onClick: function () {
+						var postId = Number( postInput.value ) || 0;
+
+						if ( postId <= 0 ) {
+							announce( 'Enter a positive post id.', 'danger' );
+
+							return;
+						}
+						state.postId = postId;
+						busy( true );
+						loadReports( postId )
+							.then( function () {
+								busy( false );
+								announce( 'Loaded ' + state.reports.length + ' quality reports for post ' + postId + '.' );
+								paintFindings( panel );
+							} )
+							.catch( function ( error ) {
+								busy( false );
+								announce( error.message, 'danger' );
+							} );
+					}
+				} )
+			] )
+		);
+
+		panel.appendChild( el( 'div', { attrs: { 'data-sw-ds-findings': '' } } ) );
+		paintFindings( panel );
+	}
+
+	function filterSelect( name, values ) {
+		var select = el( 'select', { attrs: { id: 'sw-ds-filter-' + name } } );
+
+		values.forEach( function ( value ) {
+			var option = el( 'option', { text: '' === value ? 'any' : value } );
+
+			option.value = value;
+			if ( state.filters[ name ] === value ) {
+				option.selected = true;
+			}
+			select.appendChild( option );
+		} );
+
+		select.addEventListener( 'change', function () {
+			state.filters[ name ] = select.value;
+			paintFindings( panelFor( 'quality' ) );
+		} );
+
+		return select;
+	}
+
+	function paintFindings( panel ) {
+		var host = panel ? panel.querySelector( '[data-sw-ds-findings]' ) : null;
+
+		if ( ! host ) {
+			return;
+		}
+
+		clear( host );
+
+		var report = state.reports[ state.reportIndex ];
+
+		if ( ! report ) {
+			host.appendChild(
+				el( 'div', { className: 'sw-ds-empty' }, [
+					el( 'h2', { text: 'No quality report loaded' } ),
+					el( 'p', {
+						text: 'Quality reports are written by the design verification abilities after a section renders. Enter the post id you verified to read its measured evidence.'
+					} )
+				] )
+			);
+
+			return;
+		}
+
+		var coverage = report.coverage || {};
+		var checked = Array.isArray( coverage.checked ) ? coverage.checked : [];
+		var notChecked = Array.isArray( coverage.not_checked ) ? coverage.not_checked : [];
+
+		host.appendChild(
+			el( 'div', { className: 'sw-ds-card' }, [
+				el( 'h2', { className: 'sw-ds-card__title', text: 'Report ' + label( report.report_id, '' ) } ),
+				el( 'p', {
+					className: 'sw-ds-card__meta',
+					text: 'direction revision ' + ( report.direction_revision || 0 ) +
+						' · contract ' + shortHash( report.direction_hash ) +
+						' · render ' + shortHash( report.render_hash )
+				} ),
+				el( 'div', { className: 'sw-ds-badges' }, [
+					badge( label( report.status, 'unknown' ), 'pass' === report.status ? 'pass' : 'fail' ),
+					badge( checked.length + ' rules checked', 'info' ),
+					badge( notChecked.length + ' not checked', notChecked.length ? 'warn' : 'ok' )
+				] ),
+				notChecked.length
+					? el( 'p', {
+						className: 'sw-ds-field__hint',
+						text: 'Not checked: ' + notChecked.join( ', ' ) + '. Treat these rules as unverified, not as passing.'
+					} )
+					: null
+			] )
+		);
+
+		var findings = ( Array.isArray( report.findings ) ? report.findings : [] ).filter( function ( finding ) {
+			if ( state.filters.severity && finding.severity !== state.filters.severity ) {
+				return false;
+			}
+			if ( state.filters.viewport && finding.viewport !== state.filters.viewport ) {
+				return false;
+			}
+			if ( state.filters.rule && String( finding.rule_id || '' ).indexOf( state.filters.rule ) === -1 ) {
+				return false;
+			}
+
+			return true;
+		} );
+
+		if ( ! findings.length ) {
+			host.appendChild( el( 'p', { className: 'sw-ds-field__hint', text: 'No findings match the current filters.' } ) );
+
+			return;
+		}
+
+		host.appendChild(
+			el(
+				'ul',
+				{ className: 'sw-ds-findings' },
+				findings.map( function ( finding ) {
+					var evidence = finding.evidence;
+					var item = el( 'li', { className: 'sw-ds-finding', attrs: { tabindex: '0' } }, [
+						el( 'div', { className: 'sw-ds-finding__head' }, [
+							el( 'span', { className: 'sw-ds-finding__rule', text: label( finding.rule_id, 'rule' ) } ),
+							badge( label( finding.severity, 'info' ), severityTone( finding.severity ) ),
+							badge( label( finding.viewport, 'any viewport' ), 'info' ),
+							finding.waived ? badge( 'waived', 'warn' ) : null
+						] ),
+						finding.element_ref
+							? el( 'p', { className: 'sw-ds-finding__repair', text: 'Element: ' + finding.element_ref } )
+							: null,
+						el( 'pre', {
+							className: 'sw-ds-finding__evidence',
+							text: typeof evidence === 'string' ? evidence : JSON.stringify( evidence, null, 2 )
+						} ),
+						finding.repair_hint
+							? el( 'p', { className: 'sw-ds-finding__repair', text: finding.repair_hint } )
+							: null,
+						finding.waiver_reason
+							? el( 'p', { className: 'sw-ds-finding__repair', text: 'Waiver: ' + finding.waiver_reason } )
+							: null
+					] );
+
+					item.addEventListener( 'click', function () {
+						emit( 'stonewright:quality-selected', { report: report, finding: finding } );
+						announce( 'Selected finding ' + label( finding.rule_id, '' ) + '.' );
+					} );
+
+					return item;
+				} )
+			)
+		);
+	}
+
+	/* ---------------------------- History ----------------------------- */
+
+	function renderHistory( panel ) {
+		if ( ! state.selectedId ) {
+			clear( panel ).appendChild(
+				el( 'div', { className: 'sw-ds-empty' }, [
+					el( 'h2', { text: 'No direction selected' } ),
+					el( 'p', { text: 'Pick a direction on the overview to read its revision history.' } )
+				] )
+			);
+
+			return;
+		}
+
+		pending( panel, 'Loading revisions.' );
+
+		loadDirection( state.selectedId )
+			.then( function () {
+				clear( panel );
+
+				if ( ! state.versions.length ) {
+					panel.appendChild(
+						el( 'div', { className: 'sw-ds-empty' }, [
+							el( 'h2', { text: 'No earlier revisions' } ),
+							el( 'p', { text: 'Every save records a revision. This direction has only its current one.' } )
+						] )
+					);
+
+					return;
+				}
+
+				var head = el( 'tr', null, [
+					el( 'th', { text: 'Revision' } ),
+					el( 'th', { text: 'Status' } ),
+					el( 'th', { text: 'Source' } ),
+					el( 'th', { text: 'Contract hash' } ),
+					el( 'th', { text: 'Created' } ),
+					el( 'th', { text: 'Action' } )
+				] );
+
+				var body = el(
+					'tbody',
+					null,
+					state.versions.map( function ( version ) {
+						return el( 'tr', null, [
+							el( 'td', { text: String( version.revision ) } ),
+							el( 'td', { text: label( version.status, 'draft' ) } ),
+							el( 'td', { text: label( version.source_type, 'manual' ) } ),
+							el( 'td', { className: 'sw-ds-table__hash', text: shortHash( version.contract_hash ) } ),
+							el( 'td', { text: label( version.created_at, 'unknown' ) } ),
+							el( 'td', null, [
+								canWrite
+									? button( 'Restore', {
+										onClick: function () {
+											reviewRestore( version );
+										}
+									} )
+									: el( 'span', { className: 'sw-ds-field__hint', text: 'read only' } )
+							] )
+						] );
+					} )
+				);
+
+				panel.appendChild(
+					el( 'div', { className: 'sw-ds-table-wrap' }, [
+						el( 'table', { className: 'sw-ds-table' }, [ el( 'thead', null, [ head ] ), body ] )
+					] )
+				);
+				announce( 'Loaded ' + state.versions.length + ' revisions.' );
+			} )
+			.catch( function ( error ) {
+				renderError( panel, error );
+			} );
+	}
+
+	function reviewRestore( version ) {
+		var current = state.direction || {};
+
+		openDrawer( {
+			title: 'Restore revision ' + version.revision,
+			lede: 'Restoring writes the stored contract back as a new revision. The revision you are on now stays in the history, so this is reversible.',
+			rows: [
+				{ key: 'Current revision', value: String( current.revision || 0 ) },
+				{ key: 'Current hash', value: shortHash( current.contract_hash ) },
+				{ key: 'Restoring revision', value: String( version.revision ) },
+				{ key: 'Restoring hash', value: shortHash( version.contract_hash ) },
+				{
+					key: 'Same contract',
+					value: current.contract_hash === version.contract_hash ? 'yes, nothing would change' : 'no',
+					tone: current.contract_hash === version.contract_hash ? 'warn' : null
+				}
+			],
+			confirmLabel: 'Restore revision',
+			onConfirm: function () {
+				busy( true );
+				post( DIRECTIONS_ROUTE + '/' + encodeURIComponent( String( state.selectedId ) ) + '/restore', {
+					revision: Number( version.revision )
+				} )
+					.then( function ( payload ) {
+						busy( false );
+						state.direction = null;
+						state.draft = null;
+						markDirty( false );
+						announce( 'Restored revision ' + payload.restored_revision + ' as revision ' + payload.revision + '.', 'ok' );
+						emit( 'stonewright:direction-saved', payload );
+						render( 'history' );
+					} )
+					.catch( function ( error ) {
+						busy( false );
+						announce( error.message, 'danger' );
+					} );
+			}
+		} );
+	}
+
+	/* ------------------------------------------------------------------ */
+	/* View plumbing                                                       */
+	/* ------------------------------------------------------------------ */
+
+	function render( view ) {
+		var panel = panelFor( view );
+
+		if ( ! panel ) {
+			return;
+		}
+
+		if ( 'overview' === view ) {
+			renderOverview( panel );
+		} else if ( 'editor' === view ) {
+			renderEditor( panel );
+		} else if ( 'quality' === view ) {
+			renderQuality( panel );
+		} else if ( 'history' === view ) {
+			renderHistory( panel );
+		}
+	}
+
+	function showView( view ) {
+		state.view = view;
+		root.setAttribute( 'data-sw-current-view', view );
+
+		tabNodes.forEach( function ( tab ) {
+			var isCurrent = tab.getAttribute( 'data-sw-view' ) === view;
+
+			tab.classList.toggle( 'is-current', isCurrent );
+			tab.setAttribute( 'aria-selected', isCurrent ? 'true' : 'false' );
+			tab.setAttribute( 'tabindex', isCurrent ? '0' : '-1' );
+		} );
+
+		panelNodes.forEach( function ( node ) {
+			node.hidden = node.getAttribute( 'data-sw-panel' ) !== view;
+		} );
+
+		render( view );
+	}
+
+	function pushView( view ) {
+		var url = new URL( window.location.href );
+
+		url.searchParams.set( 'view', view );
+		window.history.pushState( { stonewrightView: view }, '', url.toString() );
+	}
+
+	function requestView( view ) {
+		if ( VIEWS.indexOf( view ) === -1 ) {
+			view = VIEWS[ 0 ];
+		}
+		if ( view === state.view ) {
+			return;
+		}
+
+		if ( state.isDirty && 'editor' === state.view ) {
+			openDrawer( {
+				title: 'Leave the editor with unsaved changes?',
+				lede: 'The draft stays in this browser session, so you can come back to the editor and restore it.',
+				rows: [
+					{ key: 'Direction', value: state.draft ? label( state.draft.name, 'untitled' ) : 'untitled' },
+					{ key: 'Going to', value: view },
+					{ key: 'Draft kept', value: 'yes, in this browser session' }
+				],
+				confirmLabel: 'Leave the editor',
+				onConfirm: function () {
+					pushView( view );
+					showView( view );
+				}
+			} );
+
+			return;
+		}
+
+		pushView( view );
+		showView( view );
+	}
+
+	function moveTabFocus( fromIndex, delta ) {
+		if ( ! tabNodes.length ) {
+			return;
+		}
+		var next = ( fromIndex + delta + tabNodes.length ) % tabNodes.length;
+
+		tabNodes[ next ].focus();
+		requestView( tabNodes[ next ].getAttribute( 'data-sw-view' ) );
+	}
+
+	tabNodes.forEach( function ( tab, index ) {
+		tab.addEventListener( 'click', function ( event ) {
+			event.preventDefault();
+			requestView( tab.getAttribute( 'data-sw-view' ) );
+		} );
+
+		tab.addEventListener( 'keydown', function ( event ) {
+			if ( 'ArrowRight' === event.key || 'ArrowDown' === event.key ) {
+				event.preventDefault();
+				moveTabFocus( index, 1 );
+			} else if ( 'ArrowLeft' === event.key || 'ArrowUp' === event.key ) {
+				event.preventDefault();
+				moveTabFocus( index, -1 );
+			} else if ( 'Home' === event.key ) {
+				event.preventDefault();
+				moveTabFocus( -1, 1 );
+			} else if ( 'End' === event.key ) {
+				event.preventDefault();
+				moveTabFocus( 0, -1 );
+			}
+		} );
+	} );
+
+	window.addEventListener( 'popstate', function () {
+		var url = new URL( window.location.href );
+		var view = url.searchParams.get( 'view' ) || VIEWS[ 0 ];
+
+		showView( VIEWS.indexOf( view ) === -1 ? VIEWS[ 0 ] : view );
+	} );
+
+	window.addEventListener( 'beforeunload', function ( event ) {
+		if ( ! state.isDirty ) {
+			return undefined;
+		}
+		event.preventDefault();
+		event.returnValue = '';
+
+		return '';
+	} );
+
+	showView( VIEWS.indexOf( state.view ) === -1 ? VIEWS[ 0 ] : state.view );
+}() );

--- a/plugin/assets/admin/design-studio.js
+++ b/plugin/assets/admin/design-studio.js
@@ -583,9 +583,45 @@
 		return errors;
 	}
 
+	/**
+	 * The contract sections the editor does not expose.
+	 *
+	 * A save rebuilt from an empty contract drops every one of these. That is
+	 * how a one-word edit to a summary erases provenance and resets readiness
+	 * to false, leaving a direction that was activated a moment ago refusing
+	 * to activate again.
+	 *
+	 * @var string[]
+	 */
+	var PRESERVED_SECTIONS = [ 'components', 'provenance', 'waivers', 'readiness' ];
+
+	/**
+	 * The stored contract behind a draft, or an empty map for a new record.
+	 */
+	function baseContract( draft ) {
+		var direction = state.direction;
+
+		if ( ! draft.id || ! direction || Number( direction.id ) !== Number( draft.id ) ) {
+			return {};
+		}
+
+		try {
+			return JSON.parse( JSON.stringify( contractOf( direction ) ) );
+		} catch ( error ) {
+			return {};
+		}
+	}
+
 	function contractFromDraft( draft ) {
 		var contract = emptyContract();
+		var base = baseContract( draft );
 		var tokens = {};
+
+		PRESERVED_SECTIONS.forEach( function ( key ) {
+			if ( Object.prototype.hasOwnProperty.call( base, key ) ) {
+				contract[ key ] = base[ key ];
+			}
+		} );
 
 		try {
 			tokens = JSON.parse( draft.tokens || '{}' );

--- a/plugin/includes/Admin/AdminBootstrap.php
+++ b/plugin/includes/Admin/AdminBootstrap.php
@@ -156,16 +156,17 @@ final class AdminBootstrap {
 		// Page-scoped premium styles (only on Stonewright admin pages).
 		$page = isset( $_GET['page'] ) ? sanitize_key( (string) wp_unslash( $_GET['page'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$page_styles = [
-			'stonewright'             => 'setup.css',
-			'stonewright-abilities'   => 'abilities.css',
-			'stonewright-blueprints'  => 'blueprints.css',
+			'stonewright'               => 'setup.css',
+			'stonewright-abilities'     => 'abilities.css',
+			'stonewright-blueprints'    => 'blueprints.css',
 			// Prompt library reuses the catalog card/grid system from blueprints.css.
-			'stonewright-prompts'     => 'blueprints.css',
-			'stonewright-status'      => 'dashboard.css',
-			'stonewright-audit-log'   => 'audit.css',
-			'stonewright-skills'      => 'skills-memory.css',
-			'stonewright-memory'      => 'skills-memory.css',
-			'stonewright-sandbox'     => 'sandbox.css',
+			'stonewright-prompts'       => 'blueprints.css',
+			'stonewright-status'        => 'dashboard.css',
+			'stonewright-audit-log'     => 'audit.css',
+			'stonewright-skills'        => 'skills-memory.css',
+			'stonewright-memory'        => 'skills-memory.css',
+			'stonewright-sandbox'       => 'sandbox.css',
+			'stonewright-design-studio' => 'design-studio.css',
 		];
 
 		if ( isset( $page_styles[ $page ] ) ) {
@@ -184,6 +185,8 @@ final class AdminBootstrap {
 				$handle = 'stonewright-admin-audit';
 			} elseif ( 'sandbox.css' === $page_styles[ $page ] ) {
 				$handle = 'stonewright-admin-sandbox';
+			} elseif ( 'design-studio.css' === $page_styles[ $page ] ) {
+				$handle = 'stonewright-admin-design-studio';
 			}
 
 			wp_enqueue_style(
@@ -214,6 +217,23 @@ final class AdminBootstrap {
 					'ajaxUrl' => admin_url( 'admin-ajax.php' ),
 					'nonce'   => wp_create_nonce( 'stonewright_setup_client' ),
 				]
+			);
+		}
+
+		// The Design Studio app and its boot payload load on that page only.
+		if ( DesignStudioPage::SLUG === $page ) {
+			wp_enqueue_script(
+				'stonewright-admin-design-studio',
+				$url_base . 'assets/admin/design-studio.js',
+				[ 'stonewright-admin' ],
+				$version,
+				true
+			);
+
+			wp_localize_script(
+				'stonewright-admin-design-studio',
+				'stonewrightDesignStudio',
+				DesignStudioPage::boot_payload()
 			);
 		}
 	}

--- a/plugin/includes/Admin/AdminBootstrap.php
+++ b/plugin/includes/Admin/AdminBootstrap.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Stonewright\WpMcp\Admin;
 
 use Stonewright\WpMcp\Admin\Pages\BlueprintsPage;
+use Stonewright\WpMcp\Admin\Pages\DesignStudioPage;
 use Stonewright\WpMcp\Admin\Pages\PromptLibraryPage;
 use Stonewright\WpMcp\Admin\Pages\SandboxLibraryPage;
 use Stonewright\WpMcp\Admin\Pages\StatusPage;
@@ -32,12 +33,14 @@ final class AdminBootstrap {
 		self::$registered = true;
 
 		StatusPage::register();
+		DesignStudioPage::register();
 		BlueprintsPage::register();
 		PromptLibraryPage::register();
 		SandboxLibraryPage::register();
 		AdminShell::register();
 
 		add_action( 'rest_api_init', [ RestApi::class, 'register' ] );
+		add_action( 'rest_api_init', [ DesignStudioRestApi::class, 'register' ] );
 		add_action( 'admin_enqueue_scripts', [ self::class, 'enqueue_assets' ] );
 		add_action( 'admin_notices', [ CrashRecovery::class, 'admin_notice' ] );
 		add_action( 'admin_notices', [ self::class, 'production_mode_mismatch_notice' ] );

--- a/plugin/includes/Admin/AdminShell.php
+++ b/plugin/includes/Admin/AdminShell.php
@@ -52,8 +52,9 @@ final class AdminShell {
 				'id'    => 'design-library',
 				'label' => __( 'Design Library', 'stonewright' ),
 				'pages' => [
-					'stonewright-blueprints' => __( 'Blueprints', 'stonewright' ),
-					'stonewright-prompts'    => __( 'Prompts', 'stonewright' ),
+					'stonewright-design-studio' => __( 'Design Studio', 'stonewright' ),
+					'stonewright-blueprints'    => __( 'Blueprints', 'stonewright' ),
+					'stonewright-prompts'       => __( 'Prompts', 'stonewright' ),
 				],
 			],
 			[

--- a/plugin/includes/Admin/DesignStudioRestApi.php
+++ b/plugin/includes/Admin/DesignStudioRestApi.php
@@ -1,0 +1,377 @@
+<?php
+declare( strict_types=1 );
+
+namespace Stonewright\WpMcp\Admin;
+
+use Stonewright\WpMcp\Abilities\AbilityKernel;
+use Stonewright\WpMcp\Abilities\Design\DirectionActivate;
+use Stonewright\WpMcp\Abilities\Design\DirectionGet;
+use Stonewright\WpMcp\Abilities\Design\DirectionList;
+use Stonewright\WpMcp\Abilities\Design\DirectionRestore;
+use Stonewright\WpMcp\Abilities\Design\DirectionSave;
+use Stonewright\WpMcp\Abilities\Design\DirectionSyncApply;
+use Stonewright\WpMcp\Abilities\Design\DirectionSyncPlan;
+use Stonewright\WpMcp\Design\Direction\DesignDirectionService;
+use Stonewright\WpMcp\Design\Quality\QualityReportStore;
+use Stonewright\WpMcp\Security\Permissions;
+
+/**
+ * REST surface for the Design Studio admin page.
+ *
+ * This controller deliberately holds no design rules. It is a routing table, a
+ * capability and nonce gate, and one generic dispatcher that hands the request
+ * to the typed design ability that already owns the rule. Every guarantee the
+ * MCP surface makes — validation, backup, confirmation tokens, audit, readback
+ * — therefore applies unchanged when the admin UI is the caller.
+ *
+ * Route namespace: `stonewright/v1`, path prefix `/design-studio`.
+ */
+final class DesignStudioRestApi {
+
+	public const REST_NAMESPACE = 'stonewright/v1';
+
+	public const ROUTE_PREFIX = '/design-studio';
+
+	public const NONCE_ACTION = 'wp_rest';
+
+	public const INVALID_ID_CODE = 'stonewright_design_studio_invalid_id';
+
+	public const INVALID_NONCE_CODE = 'stonewright_design_studio_invalid_nonce';
+
+	private static bool $registered = false;
+
+	private static ?DesignDirectionService $service = null;
+
+	/**
+	 * The complete routing table.
+	 *
+	 * `ability` names the class that owns the behaviour; `id_param` names the
+	 * positive integer the route cannot run without. A null ability marks the
+	 * one route backed by a read-only store rather than an ability.
+	 *
+	 * @return array<string, array{path:string, methods:string, ability:class-string<AbilityKernel>|null, id_param:string|null}>
+	 */
+	public static function routes(): array {
+		return [
+			'directions.list'       => [
+				'path'     => self::ROUTE_PREFIX . '/directions',
+				'methods'  => 'GET',
+				'ability'  => DirectionList::class,
+				'id_param' => null,
+			],
+			'directions.get'        => [
+				'path'     => self::ROUTE_PREFIX . '/directions/(?P<id>\d+)',
+				'methods'  => 'GET',
+				'ability'  => DirectionGet::class,
+				'id_param' => 'id',
+			],
+			'directions.save'       => [
+				'path'     => self::ROUTE_PREFIX . '/directions',
+				'methods'  => 'POST',
+				'ability'  => DirectionSave::class,
+				'id_param' => null,
+			],
+			'directions.activate'   => [
+				'path'     => self::ROUTE_PREFIX . '/directions/(?P<id>\d+)/activate',
+				'methods'  => 'POST',
+				'ability'  => DirectionActivate::class,
+				'id_param' => 'id',
+			],
+			'directions.restore'    => [
+				'path'     => self::ROUTE_PREFIX . '/directions/(?P<id>\d+)/restore',
+				'methods'  => 'POST',
+				'ability'  => DirectionRestore::class,
+				'id_param' => 'id',
+			],
+			'directions.sync_plan'  => [
+				'path'     => self::ROUTE_PREFIX . '/directions/(?P<id>\d+)/sync-plan',
+				'methods'  => 'POST',
+				'ability'  => DirectionSyncPlan::class,
+				'id_param' => 'id',
+			],
+			'directions.sync_apply' => [
+				'path'     => self::ROUTE_PREFIX . '/directions/(?P<id>\d+)/sync-apply',
+				'methods'  => 'POST',
+				'ability'  => DirectionSyncApply::class,
+				'id_param' => 'id',
+			],
+			'quality.list'          => [
+				'path'     => self::ROUTE_PREFIX . '/quality',
+				'methods'  => 'GET',
+				'ability'  => null,
+				'id_param' => 'post_id',
+			],
+		];
+	}
+
+	public static function register(): void {
+		if ( self::$registered ) {
+			return;
+		}
+		self::$registered = true;
+
+		foreach ( self::routes() as $route_id => $route ) {
+			register_rest_route(
+				self::REST_NAMESPACE,
+				$route['path'],
+				[
+					'methods'             => $route['methods'],
+					'permission_callback' => static fn( \WP_REST_Request $request ): bool|\WP_Error => self::check_permission( $route_id, $request ),
+					'callback'            => static fn( \WP_REST_Request $request ): \WP_REST_Response|\WP_Error => self::handle( $route_id, $request ),
+					'args'                => [],
+				]
+			);
+		}
+	}
+
+	/**
+	 * Capability gate, plus a REST nonce for anything that is not a plain read.
+	 *
+	 * @return bool|\WP_Error
+	 */
+	public static function check_permission( string $route_id, \WP_REST_Request $request ) {
+		$route = self::routes()[ $route_id ] ?? null;
+
+		if ( null === $route ) {
+			return new \WP_Error(
+				'stonewright_design_studio_unknown_route',
+				__( 'Unknown Design Studio route.', 'stonewright' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		if ( ! Permissions::manage_options() ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to use the Design Studio.', 'stonewright' ),
+				[ 'status' => 403 ]
+			);
+		}
+
+		if ( 'GET' !== $route['methods'] && ! self::nonce_is_valid( $request ) ) {
+			return new \WP_Error(
+				self::INVALID_NONCE_CODE,
+				__( 'This request needs a current REST nonce. Reload the Design Studio and try again.', 'stonewright' ),
+				[ 'status' => 403 ]
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Generic dispatcher: validate the identifier, then hand over to the owner.
+	 *
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public static function handle( string $route_id, \WP_REST_Request $request ) {
+		$route = self::routes()[ $route_id ] ?? null;
+
+		if ( null === $route ) {
+			return new \WP_Error(
+				'stonewright_design_studio_unknown_route',
+				__( 'Unknown Design Studio route.', 'stonewright' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		$identifier = 0;
+		if ( null !== $route['id_param'] ) {
+			$identifier = self::positive_int( $request->get_param( $route['id_param'] ) );
+
+			if ( null === $identifier ) {
+				return new \WP_Error(
+					self::INVALID_ID_CODE,
+					__( 'This request needs a positive integer identifier.', 'stonewright' ),
+					[
+						'status' => 400,
+						'param'  => $route['id_param'],
+					]
+				);
+			}
+		}
+
+		if ( null === $route['ability'] ) {
+			return self::quality_reports( $identifier, $request );
+		}
+
+		return self::run_ability( $route['ability'], $request );
+	}
+
+	/**
+	 * Injects the direction service the abilities read through. Tests only.
+	 */
+	public static function set_service_for_tests( ?DesignDirectionService $service ): void {
+		self::$service = $service;
+	}
+
+	public static function reset_for_tests(): void {
+		self::$registered = false;
+		self::$service    = null;
+	}
+
+	/**
+	 * Reads the recent quality reports stored on a post.
+	 *
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	private static function quality_reports( int $post_id, \WP_REST_Request $request ) {
+		if ( ! Permissions::can_view_design() ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to read design quality reports.', 'stonewright' ),
+				[ 'status' => 403 ]
+			);
+		}
+
+		$limit   = self::positive_int( $request->get_param( 'limit' ) ) ?? QualityReportStore::DEFAULT_LIMIT;
+		$reports = QualityReportStore::latest( $post_id, $limit );
+
+		return rest_ensure_response(
+			[
+				'ok'      => true,
+				'post_id' => $post_id,
+				'count'   => count( $reports ),
+				'reports' => $reports,
+			]
+		);
+	}
+
+	/**
+	 * Runs one typed ability with its own permission callback and schema.
+	 *
+	 * @param class-string<AbilityKernel> $ability_class Ability that owns the rule.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	private static function run_ability( string $ability_class, \WP_REST_Request $request ) {
+		$ability = new $ability_class( self::service() );
+		$args    = self::args_for( $ability, $request );
+
+		$allowed = $ability->permission_callback( $args );
+		if ( $allowed instanceof \WP_Error ) {
+			return $allowed;
+		}
+
+		if ( true !== $allowed ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to run this design operation.', 'stonewright' ),
+				[ 'status' => 403 ]
+			);
+		}
+
+		return rest_ensure_response( $ability->execute( $args ) );
+	}
+
+	/**
+	 * Builds ability arguments from the request using the ability's own schema.
+	 *
+	 * Anything the schema does not declare never reaches the ability, so a new
+	 * query parameter cannot smuggle a value past `additionalProperties: false`.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private static function args_for( AbilityKernel $ability, \WP_REST_Request $request ): array {
+		$schema     = $ability->input_schema();
+		$properties = is_array( $schema['properties'] ?? null ) ? $schema['properties'] : [];
+		$args       = [];
+
+		foreach ( $properties as $key => $definition ) {
+			$value = $request->get_param( (string) $key );
+
+			if ( null === $value ) {
+				continue;
+			}
+
+			$type = is_array( $definition ) && isset( $definition['type'] ) ? (string) $definition['type'] : 'string';
+
+			$args[ (string) $key ] = self::coerce( $value, $type );
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Narrows a transport value to the type the ability schema declares.
+	 *
+	 * @param mixed $value Raw request value.
+	 * @return mixed
+	 */
+	private static function coerce( mixed $value, string $type ) {
+		return match ( $type ) {
+			'integer' => is_numeric( $value ) ? (int) $value : $value,
+			'number'  => is_numeric( $value ) ? (float) $value : $value,
+			'boolean' => self::to_bool( $value ),
+			'string'  => is_scalar( $value ) ? (string) $value : $value,
+			'object'  => is_array( $value ) ? $value : $value,
+			default   => $value,
+		};
+	}
+
+	/**
+	 * @param mixed $value Raw request value.
+	 * @return mixed True/false when the value is a recognised boolean literal.
+	 */
+	private static function to_bool( mixed $value ) {
+		if ( is_bool( $value ) ) {
+			return $value;
+		}
+
+		if ( is_string( $value ) ) {
+			$normalized = strtolower( trim( $value ) );
+
+			if ( in_array( $normalized, [ '1', 'true', 'yes' ], true ) ) {
+				return true;
+			}
+
+			if ( in_array( $normalized, [ '0', 'false', 'no', '' ], true ) ) {
+				return false;
+			}
+		}
+
+		if ( is_int( $value ) ) {
+			return 1 === $value;
+		}
+
+		return $value;
+	}
+
+	/**
+	 * @param mixed $value Raw request value.
+	 * @return int|null Positive integer, or null when the value is not one.
+	 */
+	private static function positive_int( mixed $value ): ?int {
+		if ( is_bool( $value ) || ! is_scalar( $value ) ) {
+			return null;
+		}
+
+		$text = trim( (string) $value );
+
+		if ( 1 !== preg_match( '/^\d+$/', $text ) ) {
+			return null;
+		}
+
+		$number = (int) $text;
+
+		return $number > 0 ? $number : null;
+	}
+
+	private static function nonce_is_valid( \WP_REST_Request $request ): bool {
+		$nonce = $request->get_header( 'X-WP-Nonce' );
+
+		if ( null === $nonce || '' === $nonce ) {
+			$param = $request->get_param( '_wpnonce' );
+			$nonce = is_string( $param ) ? $param : '';
+		}
+
+		if ( '' === $nonce ) {
+			return false;
+		}
+
+		return false !== wp_verify_nonce( $nonce, self::NONCE_ACTION );
+	}
+
+	private static function service(): DesignDirectionService {
+		return self::$service ?? new DesignDirectionService();
+	}
+}

--- a/plugin/includes/Admin/Pages/DesignStudioPage.php
+++ b/plugin/includes/Admin/Pages/DesignStudioPage.php
@@ -1,0 +1,165 @@
+<?php
+declare( strict_types=1 );
+
+namespace Stonewright\WpMcp\Admin\Pages;
+
+use Stonewright\WpMcp\Admin\AdminShell;
+use Stonewright\WpMcp\Admin\DesignStudioRestApi;
+use Stonewright\WpMcp\Design\Direction\DesignDirectionService;
+use Stonewright\WpMcp\Design\Direction\DirectionSummary;
+use Stonewright\WpMcp\Security\Permissions;
+
+/**
+ * The Design Studio admin page.
+ *
+ * The page renders the shell, the view tabs, and the region the Design Studio
+ * script boots into. Every read and write it performs afterwards goes over
+ * `DesignStudioRestApi`, which delegates to the typed design abilities — so no
+ * design rule lives here either.
+ */
+final class DesignStudioPage {
+
+	public const SLUG = 'stonewright-design-studio';
+
+	public const CAPABILITY = 'manage_options';
+
+	/**
+	 * The four views the page can show. The URL carries the current one so a
+	 * reload, a bookmark, and the back button all land where the user was.
+	 */
+	public const VIEWS = [ 'overview', 'editor', 'quality', 'history' ];
+
+	public static function register(): void {
+		add_action( 'admin_menu', [ self::class, 'add_submenu' ] );
+	}
+
+	public static function add_submenu(): void {
+		add_submenu_page(
+			'stonewright',
+			__( 'Design Studio', 'stonewright' ),
+			__( 'Design Studio', 'stonewright' ),
+			self::CAPABILITY,
+			self::SLUG,
+			[ self::class, 'render' ]
+		);
+	}
+
+	/**
+	 * The requested view, falling back to the overview.
+	 */
+	public static function current_view(): string {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only view selector.
+		$requested = isset( $_GET['view'] ) ? sanitize_key( (string) wp_unslash( $_GET['view'] ) ) : '';
+
+		return in_array( $requested, self::VIEWS, true ) ? $requested : 'overview';
+	}
+
+	/**
+	 * Everything the front-end needs to boot without a second round trip.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public static function boot_payload( ?DesignDirectionService $service = null ): array {
+		$service = $service ?? new DesignDirectionService();
+		$active  = $service->active();
+
+		return [
+			'restRoot'        => rest_url( DesignStudioRestApi::REST_NAMESPACE . DesignStudioRestApi::ROUTE_PREFIX ),
+			'nonce'           => wp_create_nonce( DesignStudioRestApi::NONCE_ACTION ),
+			'view'            => self::current_view(),
+			'views'           => self::VIEWS,
+			'activeDirection' => is_array( $active )
+				? DirectionSummary::row( $active, (int) ( $active['id'] ?? 0 ) )
+				: null,
+			'can'             => [
+				'manageOptions' => Permissions::manage_options(),
+				'manageDesign'  => Permissions::can_manage_design(),
+			],
+		];
+	}
+
+	public static function render(): void {
+		if ( ! current_user_can( self::CAPABILITY ) ) {
+			wp_die(
+				esc_html__( 'You do not have permission to view this page.', 'stonewright' ),
+				esc_html__( 'Forbidden', 'stonewright' ),
+				[ 'response' => 403 ]
+			);
+		}
+
+		$current = self::current_view();
+		$labels  = self::view_labels();
+
+		AdminShell::open( self::SLUG );
+		?>
+		<div
+			class="sw-design-studio"
+			data-sw-design-studio
+			data-sw-current-view="<?php echo esc_attr( $current ); ?>"
+		>
+			<div class="stonewright-page-header">
+				<div>
+					<h1><?php esc_html_e( 'Design Studio', 'stonewright' ); ?></h1>
+					<p><?php esc_html_e( 'One validated design direction per site: its tokens, its dials, its guidance, and the evidence that the rendered result matches it.', 'stonewright' ); ?></p>
+				</div>
+			</div>
+
+			<div class="sw-ds-tabs" role="tablist" aria-label="<?php esc_attr_e( 'Design Studio views', 'stonewright' ); ?>">
+				<?php foreach ( self::VIEWS as $view ) : ?>
+					<?php $is_current = ( $view === $current ); ?>
+					<a
+						class="sw-ds-tab<?php echo $is_current ? ' is-current' : ''; ?>"
+						role="tab"
+						id="sw-ds-tab-<?php echo esc_attr( $view ); ?>"
+						href="<?php echo esc_url( self::view_url( $view ) ); ?>"
+						data-sw-view="<?php echo esc_attr( $view ); ?>"
+						aria-selected="<?php echo $is_current ? 'true' : 'false'; ?>"
+						aria-controls="sw-ds-panel-<?php echo esc_attr( $view ); ?>"
+						tabindex="<?php echo $is_current ? '0' : '-1'; ?>"
+					><?php echo esc_html( $labels[ $view ] ); ?></a>
+				<?php endforeach; ?>
+			</div>
+
+			<p class="sw-ds-status" data-sw-ds-status role="status" aria-live="polite"></p>
+
+			<?php foreach ( self::VIEWS as $view ) : ?>
+				<section
+					class="sw-ds-panel"
+					role="tabpanel"
+					id="sw-ds-panel-<?php echo esc_attr( $view ); ?>"
+					aria-labelledby="sw-ds-tab-<?php echo esc_attr( $view ); ?>"
+					data-sw-panel="<?php echo esc_attr( $view ); ?>"
+					<?php echo $view === $current ? '' : 'hidden'; ?>
+				>
+					<div class="sw-ds-panel__loading" data-sw-ds-loading>
+						<?php echo esc_html( $labels[ $view ] ); ?>
+					</div>
+				</section>
+			<?php endforeach; ?>
+
+			<noscript>
+				<div class="sw-empty-state">
+					<p><?php esc_html_e( 'The Design Studio needs JavaScript. Design directions remain readable and writable through the Stonewright MCP abilities.', 'stonewright' ); ?></p>
+				</div>
+			</noscript>
+		</div>
+		<?php
+		AdminShell::close();
+	}
+
+	/**
+	 * @return array<string, string>
+	 */
+	private static function view_labels(): array {
+		return [
+			'overview' => __( 'Overview', 'stonewright' ),
+			'editor'   => __( 'Editor', 'stonewright' ),
+			'quality'  => __( 'Quality', 'stonewright' ),
+			'history'  => __( 'History', 'stonewright' ),
+		];
+	}
+
+	private static function view_url( string $view ): string {
+		return admin_url( 'admin.php?page=' . rawurlencode( self::SLUG ) . '&view=' . rawurlencode( $view ) );
+	}
+}

--- a/plugin/tests/Unit/Admin/AdminShellTest.php
+++ b/plugin/tests/Unit/Admin/AdminShellTest.php
@@ -33,6 +33,7 @@ final class AdminShellTest extends TestCase {
 
 		self::assertContains( 'stonewright', $slugs );
 		self::assertContains( 'stonewright-abilities', $slugs );
+		self::assertContains( 'stonewright-design-studio', $slugs );
 		self::assertContains( 'stonewright-blueprints', $slugs );
 		self::assertContains( 'stonewright-sandbox', $slugs );
 		self::assertContains( 'stonewright-skills', $slugs );

--- a/plugin/tests/Unit/Admin/DesignStudioAssetsTest.php
+++ b/plugin/tests/Unit/Admin/DesignStudioAssetsTest.php
@@ -174,6 +174,14 @@ final class DesignStudioAssetsTest extends TestCase {
 		self::assertStringContainsString( "'/quality'", $js );
 	}
 
+	public function test_direction_reads_explicitly_request_revision_history(): void {
+		self::assertMatchesRegularExpression(
+			'/get\(\s*DIRECTIONS_ROUTE\s*\+\s*\'\/\'\s*\+\s*encodeURIComponent\( String\( id \) \),\s*\{\s*include_versions:\s*true\s*\}\s*\)/s',
+			self::js(),
+			'History must opt in to versions because design-direction-get omits them by default.'
+		);
+	}
+
 	public function test_the_assets_are_page_scoped_to_the_design_studio(): void {
 		$bootstrap = self::bootstrap();
 

--- a/plugin/tests/Unit/Admin/DesignStudioAssetsTest.php
+++ b/plugin/tests/Unit/Admin/DesignStudioAssetsTest.php
@@ -1,0 +1,196 @@
+<?php
+declare( strict_types=1 );
+
+namespace Stonewright\WpMcp\Tests\Unit\Admin;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Static guarantees for the Design Studio front-end assets.
+ *
+ * `AdminBootstrap::enqueue_assets()` calls `wp_localize_script()`, which the
+ * unit harness does not stub, so the enqueue path cannot be executed here.
+ * These checks read the shipped files instead, the same way
+ * `AdminCssNoRawHexTest` and `AdminJavascriptTest` do.
+ *
+ * @coversNothing
+ */
+final class DesignStudioAssetsTest extends TestCase {
+
+	private static function plugin_dir(): string {
+		return dirname( __DIR__, 3 );
+	}
+
+	private static function css(): string {
+		return (string) file_get_contents( self::plugin_dir() . '/assets/admin/design-studio.css' );
+	}
+
+	private static function js(): string {
+		return (string) file_get_contents( self::plugin_dir() . '/assets/admin/design-studio.js' );
+	}
+
+	private static function bootstrap(): string {
+		return (string) file_get_contents( self::plugin_dir() . '/includes/Admin/AdminBootstrap.php' );
+	}
+
+	public function test_both_assets_ship_with_the_plugin(): void {
+		self::assertFileExists( self::plugin_dir() . '/assets/admin/design-studio.css' );
+		self::assertFileExists( self::plugin_dir() . '/assets/admin/design-studio.js' );
+	}
+
+	public function test_the_stylesheet_only_uses_shared_semantic_colour_tokens(): void {
+		$css = preg_replace( '#/\*.*?\*/#s', '', self::css() );
+		$css = is_string( $css ) ? $css : '';
+
+		self::assertDoesNotMatchRegularExpression( '/#[0-9a-fA-F]{3,8}\b/', $css, 'Design Studio CSS must not hard-code colours.' );
+		self::assertDoesNotMatchRegularExpression( '/\brgba?\s*\(\s*\d/', $css, 'Design Studio CSS must not hard-code colour channels.' );
+		self::assertStringContainsString( 'var(--sw-surface', $css );
+		self::assertStringContainsString( 'var(--sw-border', $css );
+		self::assertStringContainsString( 'var(--sw-text', $css );
+	}
+
+	public function test_the_stylesheet_keeps_focus_visible_and_honours_reduced_motion(): void {
+		$css = self::css();
+
+		self::assertStringContainsString( ':focus-visible', $css );
+		self::assertStringContainsString( 'outline:', $css );
+		self::assertStringContainsString( '@media (prefers-reduced-motion: reduce)', $css );
+	}
+
+	public function test_the_stylesheet_is_single_column_before_it_is_two_column(): void {
+		$css = self::css();
+
+		self::assertStringContainsString( '@media (min-width: 960px)', $css, 'The editor becomes two-column at a min-width breakpoint, so the 375px layout is the default.' );
+		self::assertDoesNotMatchRegularExpression( '/\bmin-width:\s*(?:[4-9]\d{2}|\d{4,})px\s*;/', $css, 'No element may claim a minimum width that overflows a 375px viewport.' );
+	}
+
+	public function test_the_stylesheet_carries_no_decorative_glyphs(): void {
+		self::assertDoesNotMatchRegularExpression(
+			'/[\x{1F300}-\x{1FAFF}\x{2190}-\x{27BF}\x{FE0F}]/u',
+			self::css(),
+			'Design Studio CSS must not inject emoji or dingbat content.'
+		);
+	}
+
+	public function test_the_script_is_a_strict_mode_module_with_no_dependencies(): void {
+		$js = self::js();
+
+		self::assertStringContainsString( "'use strict'", $js );
+		self::assertStringNotContainsString( 'jQuery', $js );
+		self::assertStringNotContainsString( '$(', $js );
+	}
+
+	public function test_the_script_boots_from_the_localized_payload(): void {
+		$js = self::js();
+
+		self::assertStringContainsString( 'window.stonewrightDesignStudio', $js );
+		self::assertStringContainsString( 'restRoot', $js );
+		self::assertStringContainsString( 'activeDirection', $js );
+		self::assertStringContainsString( 'data-sw-design-studio', $js );
+	}
+
+	public function test_every_write_request_sends_the_rest_nonce(): void {
+		$js = self::js();
+
+		self::assertStringContainsString( "'X-WP-Nonce'", $js );
+		self::assertStringContainsString( "credentials: 'same-origin'", $js );
+		self::assertStringContainsString( "method: 'POST'", $js );
+	}
+
+	public function test_the_script_never_uses_native_browser_dialogs(): void {
+		$js = self::js();
+
+		self::assertStringNotContainsString( 'window.confirm', $js );
+		self::assertStringNotContainsString( 'window.alert', $js );
+		self::assertDoesNotMatchRegularExpression( '/(?<![\w.])confirm\s*\(/', $js );
+		self::assertDoesNotMatchRegularExpression( '/(?<![\w.])alert\s*\(/', $js );
+		self::assertDoesNotMatchRegularExpression( '/(?<![\w.])prompt\s*\(/', $js );
+	}
+
+	public function test_confirmation_happens_in_an_accessible_review_drawer(): void {
+		$js = self::js();
+
+		self::assertStringContainsString( 'data-sw-ds-drawer', $js );
+		self::assertStringContainsString( "'dialog'", $js );
+		self::assertStringContainsString( 'aria-modal', $js );
+		self::assertStringContainsString( "'Escape'", $js );
+		self::assertStringContainsString( 'trapFocus', $js );
+		self::assertStringContainsString( 'restoreFocus', $js );
+	}
+
+	public function test_the_script_builds_dom_nodes_instead_of_writing_markup(): void {
+		$js = self::js();
+
+		self::assertStringNotContainsString( 'innerHTML', $js, 'Direction names, evidence, and repair hints are user content — build nodes and set textContent.' );
+		self::assertStringNotContainsString( 'outerHTML', $js );
+		self::assertStringNotContainsString( 'insertAdjacentHTML', $js );
+		self::assertStringNotContainsString( 'document.' . 'write', $js );
+		self::assertStringContainsString( 'textContent', $js );
+	}
+
+	public function test_view_switching_keeps_the_url_and_the_keyboard_in_sync(): void {
+		$js = self::js();
+
+		self::assertStringContainsString( 'history.pushState', $js );
+		self::assertStringContainsString( "'popstate'", $js );
+		self::assertStringContainsString( "'ArrowRight'", $js );
+		self::assertStringContainsString( "'ArrowLeft'", $js );
+		self::assertStringContainsString( "'Home'", $js );
+		self::assertStringContainsString( "'End'", $js );
+		self::assertStringContainsString( 'aria-selected', $js );
+	}
+
+	public function test_the_editor_recovers_drafts_and_guards_unsaved_changes(): void {
+		$js = self::js();
+
+		self::assertStringContainsString( 'sessionStorage', $js );
+		self::assertStringContainsString( "'beforeunload'", $js );
+		self::assertStringContainsString( 'isDirty', $js );
+	}
+
+	public function test_the_script_announces_state_changes_through_the_live_region(): void {
+		$js = self::js();
+
+		self::assertStringContainsString( 'data-sw-ds-status', $js );
+		self::assertStringContainsString( 'function announce', $js );
+	}
+
+	public function test_the_script_emits_the_documented_dom_events(): void {
+		$js = self::js();
+
+		foreach ( [ 'stonewright:direction-saved', 'stonewright:direction-activated', 'stonewright:quality-selected' ] as $event ) {
+			self::assertStringContainsString( $event, $js );
+		}
+		self::assertStringContainsString( 'CustomEvent', $js );
+	}
+
+	public function test_the_script_reaches_wordpress_only_through_the_design_studio_routes(): void {
+		$js = self::js();
+
+		self::assertStringNotContainsString( 'admin-ajax.php', $js );
+		self::assertStringNotContainsString( '/wp/v2/', $js );
+		self::assertStringNotContainsString( 'abilities/run', $js );
+		self::assertStringContainsString( "'/directions'", $js );
+		self::assertStringContainsString( "'/quality'", $js );
+	}
+
+	public function test_the_assets_are_page_scoped_to_the_design_studio(): void {
+		$bootstrap = self::bootstrap();
+
+		self::assertStringContainsString( "'stonewright-design-studio' => 'design-studio.css'", $bootstrap );
+		self::assertStringContainsString( 'stonewright-admin-design-studio', $bootstrap );
+		self::assertStringContainsString( 'assets/admin/design-studio.js', $bootstrap );
+		self::assertStringContainsString( "'stonewrightDesignStudio'", $bootstrap );
+		self::assertStringContainsString( 'DesignStudioPage::boot_payload()', $bootstrap );
+	}
+
+	public function test_the_script_is_only_localized_on_the_design_studio_page(): void {
+		$bootstrap = self::bootstrap();
+
+		self::assertMatchesRegularExpression(
+			'/if \( DesignStudioPage::SLUG === \$page \) \{.*?wp_enqueue_script\(.*?design-studio\.js.*?wp_localize_script\(.*?stonewrightDesignStudio.*?\}/s',
+			$bootstrap,
+			'The Design Studio script and its payload load only on the Design Studio page.'
+		);
+	}
+}

--- a/plugin/tests/Unit/Admin/DesignStudioPageTest.php
+++ b/plugin/tests/Unit/Admin/DesignStudioPageTest.php
@@ -1,0 +1,140 @@
+<?php
+declare( strict_types=1 );
+
+namespace Stonewright\WpMcp\Tests\Unit\Admin;
+
+use PHPUnit\Framework\TestCase;
+use Stonewright\WpMcp\Admin\AdminShell;
+use Stonewright\WpMcp\Admin\Pages\DesignStudioPage;
+
+/**
+ * Menu, capability, and markup contract for the Design Studio admin page.
+ *
+ * The page itself owns no design logic: it renders the shell, the view tabs,
+ * and the mount point the Design Studio script boots into. These tests pin the
+ * parts other code depends on — the slug, the capability, the navigation
+ * position, and the boot payload keys.
+ *
+ * @covers \Stonewright\WpMcp\Admin\Pages\DesignStudioPage
+ */
+final class DesignStudioPageTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['stonewright_test_user_caps']        = [ 'manage_options' => true ];
+		$GLOBALS['stonewright_test_current_user_id']  = 7;
+		$GLOBALS['stonewright_test_user_logged_in']   = true;
+		$GLOBALS['stonewright_test_options']          = [];
+		$GLOBALS['stonewright_test_user_meta']        = [];
+		$GLOBALS['stonewright_test_submenu_pages']    = [];
+		unset( $_GET['view'] );
+	}
+
+	protected function tearDown(): void {
+		$GLOBALS['stonewright_test_user_caps']       = [];
+		$GLOBALS['stonewright_test_current_user_id'] = 0;
+		$GLOBALS['stonewright_test_user_logged_in']  = false;
+		$GLOBALS['stonewright_test_options']         = [];
+		$GLOBALS['stonewright_test_user_meta']       = [];
+		$GLOBALS['stonewright_test_submenu_pages']   = [];
+		unset( $_GET['view'] );
+	}
+
+	public function test_slug_and_capability_are_stable(): void {
+		self::assertSame( 'stonewright-design-studio', DesignStudioPage::SLUG );
+		self::assertSame( 'manage_options', DesignStudioPage::CAPABILITY );
+	}
+
+	public function test_submenu_registers_under_stonewright_with_manage_options(): void {
+		DesignStudioPage::add_submenu();
+
+		$registered = $GLOBALS['stonewright_test_submenu_pages'][ DesignStudioPage::SLUG ] ?? null;
+
+		self::assertIsArray( $registered );
+		self::assertSame( 'stonewright', $registered['parent'] );
+		self::assertSame( 'manage_options', $registered['capability'] );
+	}
+
+	public function test_design_studio_appears_before_blueprints_in_the_shell(): void {
+		$slugs = array_keys( AdminShell::pages() );
+
+		self::assertContains( DesignStudioPage::SLUG, $slugs );
+		self::assertContains( 'stonewright-blueprints', $slugs );
+		self::assertLessThan(
+			array_search( 'stonewright-blueprints', $slugs, true ),
+			array_search( DesignStudioPage::SLUG, $slugs, true )
+		);
+	}
+
+	public function test_design_studio_lives_in_the_design_library_group(): void {
+		$group = null;
+		foreach ( AdminShell::menu_groups() as $candidate ) {
+			if ( 'design-library' === $candidate['id'] ) {
+				$group = $candidate;
+			}
+		}
+
+		self::assertIsArray( $group );
+		self::assertArrayHasKey( DesignStudioPage::SLUG, $group['pages'] );
+	}
+
+	public function test_render_refuses_users_without_manage_options(): void {
+		$GLOBALS['stonewright_test_user_caps'] = [];
+
+		$this->expectException( \RuntimeException::class );
+		DesignStudioPage::render();
+	}
+
+	public function test_render_outputs_the_mount_point_and_view_tabs(): void {
+		ob_start();
+		DesignStudioPage::render();
+		$html = (string) ob_get_clean();
+
+		self::assertStringContainsString( 'data-sw-design-studio', $html );
+		self::assertStringContainsString( 'aria-live="polite"', $html );
+
+		foreach ( DesignStudioPage::VIEWS as $view ) {
+			self::assertStringContainsString( 'data-sw-view="' . $view . '"', $html );
+		}
+	}
+
+	public function test_render_marks_the_requested_view_current(): void {
+		$_GET['view'] = 'quality';
+
+		ob_start();
+		DesignStudioPage::render();
+		$html = (string) ob_get_clean();
+
+		self::assertStringContainsString( 'data-sw-current-view="quality"', $html );
+	}
+
+	public function test_render_falls_back_to_overview_for_an_unknown_view(): void {
+		$_GET['view'] = 'not-a-view';
+
+		ob_start();
+		DesignStudioPage::render();
+		$html = (string) ob_get_clean();
+
+		self::assertStringContainsString( 'data-sw-current-view="overview"', $html );
+	}
+
+	public function test_boot_payload_carries_rest_root_nonce_view_and_capabilities(): void {
+		$payload = DesignStudioPage::boot_payload();
+
+		foreach ( [ 'restRoot', 'nonce', 'view', 'views', 'activeDirection', 'can' ] as $key ) {
+			self::assertArrayHasKey( $key, $payload );
+		}
+
+		self::assertStringContainsString( 'stonewright/v1/design-studio', (string) $payload['restRoot'] );
+		self::assertNotSame( '', (string) $payload['nonce'] );
+		self::assertSame( 'overview', $payload['view'] );
+		self::assertSame( DesignStudioPage::VIEWS, $payload['views'] );
+		self::assertArrayHasKey( 'manageDesign', $payload['can'] );
+		self::assertArrayHasKey( 'manageOptions', $payload['can'] );
+	}
+
+	public function test_boot_payload_reports_no_active_direction_when_none_is_set(): void {
+		$payload = DesignStudioPage::boot_payload();
+
+		self::assertNull( $payload['activeDirection'] );
+	}
+}

--- a/plugin/tests/Unit/Admin/DesignStudioRestApiTest.php
+++ b/plugin/tests/Unit/Admin/DesignStudioRestApiTest.php
@@ -1,0 +1,496 @@
+<?php
+declare( strict_types=1 );
+
+namespace Stonewright\WpMcp\Tests\Unit\Admin;
+
+use PHPUnit\Framework\TestCase;
+use Stonewright\WpMcp\Abilities\AbilityKernel;
+use Stonewright\WpMcp\Abilities\Design\DirectionList;
+use Stonewright\WpMcp\Admin\DesignStudioRestApi;
+use Stonewright\WpMcp\Design\Direction\DesignDirectionRepository;
+use Stonewright\WpMcp\Design\Direction\DesignDirectionService;
+
+/**
+ * Security and delegation contract for the Design Studio REST controller.
+ *
+ * The controller is deliberately a routing table plus one generic dispatcher:
+ * every endpoint hands its arguments to the typed design ability that already
+ * owns the rule, so the admin UI cannot reach a code path the MCP surface does
+ * not have. These tests pin that boundary — capability, nonce, id shape, error
+ * envelope, and the absence of storage calls in the controller itself.
+ *
+ * @covers \Stonewright\WpMcp\Admin\DesignStudioRestApi
+ */
+final class DesignStudioRestApiTest extends TestCase {
+
+	private DesignStudioFakeDirectionRepository $repository;
+
+	private DesignDirectionService $service;
+
+	protected function setUp(): void {
+		$GLOBALS['stonewright_test_rest_routes']     = [];
+		$GLOBALS['stonewright_test_options']         = [];
+		$GLOBALS['stonewright_test_user_caps']       = [
+			'read'           => true,
+			'manage_options' => true,
+			'edit_pages'     => true,
+		];
+		$GLOBALS['stonewright_test_user_logged_in']  = true;
+		$GLOBALS['stonewright_test_current_user_id'] = 7;
+		$GLOBALS['stonewright_test_posts']           = [];
+		$GLOBALS['stonewright_test_wpdb_inserts']    = [];
+		$GLOBALS['stonewright_test_nonce_invalid']   = false;
+
+		$this->repository = new DesignStudioFakeDirectionRepository();
+		$this->service    = new DesignDirectionService( $this->repository );
+
+		DesignStudioRestApi::reset_for_tests();
+		DesignStudioRestApi::set_service_for_tests( $this->service );
+	}
+
+	protected function tearDown(): void {
+		DesignStudioRestApi::reset_for_tests();
+
+		$GLOBALS['stonewright_test_rest_routes']     = [];
+		$GLOBALS['stonewright_test_options']         = [];
+		$GLOBALS['stonewright_test_user_caps']       = [];
+		$GLOBALS['stonewright_test_user_logged_in']  = false;
+		$GLOBALS['stonewright_test_current_user_id'] = 0;
+		$GLOBALS['stonewright_test_posts']           = [];
+		$GLOBALS['stonewright_test_wpdb_inserts']    = [];
+		$GLOBALS['stonewright_test_nonce_invalid']   = false;
+	}
+
+	// -------------------------------------------------------------------------
+	// Registration.
+	// -------------------------------------------------------------------------
+
+	public function test_register_publishes_every_documented_route(): void {
+		DesignStudioRestApi::register();
+
+		$paths = [];
+		foreach ( $GLOBALS['stonewright_test_rest_routes'] as $route ) {
+			self::assertSame( 'stonewright/v1', $route['namespace'] );
+			$paths[] = $route['route'];
+		}
+
+		self::assertContains( '/design-studio/directions', $paths );
+		self::assertContains( '/design-studio/directions/(?P<id>\d+)', $paths );
+		self::assertContains( '/design-studio/directions/(?P<id>\d+)/activate', $paths );
+		self::assertContains( '/design-studio/directions/(?P<id>\d+)/restore', $paths );
+		self::assertContains( '/design-studio/directions/(?P<id>\d+)/sync-plan', $paths );
+		self::assertContains( '/design-studio/directions/(?P<id>\d+)/sync-apply', $paths );
+		self::assertContains( '/design-studio/quality', $paths );
+	}
+
+	public function test_register_is_idempotent(): void {
+		DesignStudioRestApi::register();
+		$first = count( $GLOBALS['stonewright_test_rest_routes'] );
+
+		DesignStudioRestApi::register();
+
+		self::assertCount( $first, $GLOBALS['stonewright_test_rest_routes'] );
+	}
+
+	public function test_the_route_table_covers_both_a_read_and_a_write_for_directions(): void {
+		$methods = [];
+		foreach ( DesignStudioRestApi::routes() as $route ) {
+			$methods[] = $route['methods'];
+		}
+
+		self::assertContains( 'GET', $methods );
+		self::assertContains( 'POST', $methods );
+	}
+
+	// -------------------------------------------------------------------------
+	// Capability and nonce.
+	// -------------------------------------------------------------------------
+
+	public function test_every_route_requires_manage_options(): void {
+		$GLOBALS['stonewright_test_user_caps'] = [];
+
+		foreach ( array_keys( DesignStudioRestApi::routes() ) as $route_id ) {
+			$request = new \WP_REST_Request( 'POST', '/design-studio' );
+			$request->set_header( 'x-wp-nonce', 'valid' );
+
+			$allowed = DesignStudioRestApi::check_permission( $route_id, $request );
+
+			self::assertInstanceOf( \WP_Error::class, $allowed, $route_id );
+			self::assertSame( 403, $allowed->get_error_data()['status'] ?? 0, $route_id );
+		}
+	}
+
+	public function test_mutating_routes_require_a_rest_nonce(): void {
+		foreach ( DesignStudioRestApi::routes() as $route_id => $route ) {
+			if ( 'GET' === $route['methods'] ) {
+				continue;
+			}
+
+			$request = new \WP_REST_Request( 'POST', '/design-studio' );
+
+			$allowed = DesignStudioRestApi::check_permission( $route_id, $request );
+
+			self::assertInstanceOf( \WP_Error::class, $allowed, $route_id );
+			self::assertSame( 'stonewright_design_studio_invalid_nonce', $allowed->get_error_code(), $route_id );
+			self::assertSame( 403, $allowed->get_error_data()['status'] ?? 0, $route_id );
+		}
+	}
+
+	public function test_mutating_routes_reject_a_stale_nonce(): void {
+		$GLOBALS['stonewright_test_nonce_invalid'] = true;
+
+		$request = new \WP_REST_Request( 'POST', '/design-studio' );
+		$request->set_header( 'x-wp-nonce', 'stale' );
+
+		$allowed = DesignStudioRestApi::check_permission( 'directions.save', $request );
+
+		self::assertInstanceOf( \WP_Error::class, $allowed );
+		self::assertSame( 'stonewright_design_studio_invalid_nonce', $allowed->get_error_code() );
+	}
+
+	public function test_read_routes_do_not_require_a_nonce(): void {
+		$request = new \WP_REST_Request( 'GET', '/design-studio/directions' );
+
+		self::assertTrue( DesignStudioRestApi::check_permission( 'directions.list', $request ) );
+	}
+
+	public function test_mutating_routes_pass_with_a_valid_nonce(): void {
+		$request = new \WP_REST_Request( 'POST', '/design-studio/directions' );
+		$request->set_header( 'x-wp-nonce', 'valid' );
+
+		self::assertTrue( DesignStudioRestApi::check_permission( 'directions.save', $request ) );
+	}
+
+	public function test_an_unknown_route_id_is_refused(): void {
+		$request = new \WP_REST_Request( 'GET', '/design-studio' );
+
+		$allowed = DesignStudioRestApi::check_permission( 'directions.nope', $request );
+
+		self::assertInstanceOf( \WP_Error::class, $allowed );
+		self::assertSame( 404, $allowed->get_error_data()['status'] ?? 0 );
+	}
+
+	// -------------------------------------------------------------------------
+	// Identifiers.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @dataProvider provide_non_positive_ids
+	 */
+	public function test_direction_ids_must_be_positive_integers( mixed $id ): void {
+		$request = new \WP_REST_Request( 'GET', '/design-studio/directions/x', [ 'id' => $id ] );
+
+		$response = DesignStudioRestApi::handle( 'directions.get', $request );
+
+		self::assertInstanceOf( \WP_Error::class, $response );
+		self::assertSame( 'stonewright_design_studio_invalid_id', $response->get_error_code() );
+		self::assertSame( 400, $response->get_error_data()['status'] ?? 0 );
+	}
+
+	/**
+	 * @return array<string, array{0: mixed}>
+	 */
+	public static function provide_non_positive_ids(): array {
+		return [
+			'zero'     => [ 0 ],
+			'negative' => [ -3 ],
+			'blank'    => [ '' ],
+			'words'    => [ 'seven' ],
+			'missing'  => [ null ],
+		];
+	}
+
+	public function test_a_positive_id_reaches_the_ability(): void {
+		$this->seed_direction( 4, 'quarry' );
+
+		$request  = new \WP_REST_Request( 'GET', '/design-studio/directions/4', [ 'id' => 4 ] );
+		$response = DesignStudioRestApi::handle( 'directions.get', $request );
+
+		self::assertInstanceOf( \WP_REST_Response::class, $response );
+		self::assertSame( 4, $response->get_data()['direction']['id'] ?? 0 );
+	}
+
+	// -------------------------------------------------------------------------
+	// Delegation.
+	// -------------------------------------------------------------------------
+
+	public function test_the_list_route_returns_exactly_what_the_ability_returns(): void {
+		$this->seed_direction( 1, 'quarry' );
+		$this->seed_direction( 2, 'basalt' );
+
+		$response = DesignStudioRestApi::handle( 'directions.list', new \WP_REST_Request( 'GET', '/design-studio/directions' ) );
+		$expected = ( new DirectionList( $this->service ) )->execute( [] );
+
+		self::assertInstanceOf( \WP_REST_Response::class, $response );
+		self::assertSame( $expected, $response->get_data() );
+	}
+
+	public function test_query_parameters_outside_the_ability_schema_are_dropped(): void {
+		$this->seed_direction( 1, 'quarry' );
+
+		$request = new \WP_REST_Request(
+			'GET',
+			'/design-studio/directions',
+			[
+				'status'     => 'draft',
+				'not_a_prop' => 'ignored',
+			]
+		);
+
+		$response = DesignStudioRestApi::handle( 'directions.list', $request );
+
+		self::assertInstanceOf( \WP_REST_Response::class, $response );
+		self::assertSame( 1, $response->get_data()['count'] ?? -1 );
+	}
+
+	public function test_an_invalid_payload_returns_the_ability_error_with_a_4xx_status(): void {
+		$request = new \WP_REST_Request( 'GET', '/design-studio/directions', [ 'status' => 'nonsense' ] );
+
+		$response = DesignStudioRestApi::handle( 'directions.list', $request );
+
+		self::assertInstanceOf( \WP_Error::class, $response );
+		self::assertSame( 'stonewright_direction_invalid', $response->get_error_code() );
+		self::assertSame( 400, $response->get_error_data()['status'] ?? 0 );
+	}
+
+	public function test_a_save_without_a_contract_is_refused_before_storage(): void {
+		$request = new \WP_REST_Request( 'POST', '/design-studio/directions' );
+
+		$response = DesignStudioRestApi::handle( 'directions.save', $request );
+
+		self::assertInstanceOf( \WP_Error::class, $response );
+		self::assertSame( 'stonewright_direction_invalid', $response->get_error_code() );
+		self::assertSame( [], $this->repository->records );
+	}
+
+	public function test_the_handler_re_checks_the_ability_permission(): void {
+		$GLOBALS['stonewright_test_user_caps'] = [
+			'read'           => true,
+			'manage_options' => true,
+		];
+
+		$request  = new \WP_REST_Request( 'POST', '/design-studio/directions/1/activate', [ 'id' => 1 ] );
+		$response = DesignStudioRestApi::handle( 'directions.activate', $request );
+
+		self::assertInstanceOf( \WP_Error::class, $response );
+		self::assertSame( 403, $response->get_error_data()['status'] ?? 0 );
+	}
+
+	// -------------------------------------------------------------------------
+	// Quality reports.
+	// -------------------------------------------------------------------------
+
+	public function test_quality_requires_a_positive_post_id(): void {
+		$response = DesignStudioRestApi::handle( 'quality.list', new \WP_REST_Request( 'GET', '/design-studio/quality' ) );
+
+		self::assertInstanceOf( \WP_Error::class, $response );
+		self::assertSame( 'stonewright_design_studio_invalid_id', $response->get_error_code() );
+	}
+
+	public function test_quality_returns_the_stored_reports_newest_first(): void {
+		$GLOBALS['stonewright_test_posts'][12] = (object) [
+			'ID'   => 12,
+			'meta' => [
+				'_stonewright_quality_reports' => [
+					[
+						'report_id' => 'r2',
+						'status'    => 'warn',
+					],
+					[
+						'report_id' => 'r1',
+						'status'    => 'pass',
+					],
+				],
+			],
+		];
+
+		$request  = new \WP_REST_Request( 'GET', '/design-studio/quality', [ 'post_id' => 12 ] );
+		$response = DesignStudioRestApi::handle( 'quality.list', $request );
+
+		self::assertInstanceOf( \WP_REST_Response::class, $response );
+
+		$data = $response->get_data();
+		self::assertSame( 12, $data['post_id'] );
+		self::assertSame( 2, $data['count'] );
+		self::assertSame( 'r2', $data['reports'][0]['report_id'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// No business logic in the controller.
+	// -------------------------------------------------------------------------
+
+	public function test_every_route_delegates_to_a_typed_design_ability_or_a_store(): void {
+		foreach ( DesignStudioRestApi::routes() as $route_id => $route ) {
+			if ( null === $route['ability'] ) {
+				continue;
+			}
+
+			self::assertTrue( class_exists( $route['ability'] ), $route_id );
+			self::assertTrue( is_subclass_of( $route['ability'], AbilityKernel::class ), $route_id );
+			self::assertStringStartsWith( 'Stonewright\\WpMcp\\Abilities\\Design\\', $route['ability'], $route_id );
+		}
+	}
+
+	public function test_the_controller_holds_no_storage_or_option_writes(): void {
+		$source = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Admin/DesignStudioRestApi.php' );
+
+		foreach ( [ '$wpdb', 'update_option(', 'update_post_meta(', 'wp_update_post(', 'wp_insert_post(', 'delete_option(' ] as $forbidden ) {
+			self::assertStringNotContainsString( $forbidden, $source, $forbidden );
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers.
+	// -------------------------------------------------------------------------
+
+	private function seed_direction( int $id, string $slug ): void {
+		$this->repository->records[ $id ] = [
+			'id'            => $id,
+			'slug'          => $slug,
+			'status'        => 'draft',
+			'revision'      => 1,
+			'contract'      => [
+				'identity'  => [ 'name' => ucfirst( $slug ) ],
+				'readiness' => [
+					'ready'      => false,
+					'sync_ready' => false,
+					'issues'     => [],
+				],
+			],
+			'contract_hash' => str_repeat( (string) $id, 8 ),
+			'source_type'   => 'manual',
+			'source_refs'   => [],
+			'created_at'    => '2026-07-25 09:00:00',
+			'updated_at'    => '2026-07-25 09:00:00',
+		];
+	}
+}
+
+/**
+ * In-memory direction store so controller tests never touch SQL.
+ */
+final class DesignStudioFakeDirectionRepository extends DesignDirectionRepository {
+
+	/** @var array<int, array<string, mixed>> */
+	public array $records = [];
+
+	/** @var list<array<string, mixed>> */
+	public array $version_rows = [];
+
+	private int $next_id = 1;
+
+	public function __construct() {
+	}
+
+	/**
+	 * @param array<string, mixed> $filters Optional status filter.
+	 * @return list<array<string, mixed>>
+	 */
+	public function list( array $filters = [] ): array {
+		$records = array_values( $this->records );
+
+		if ( isset( $filters['status'] ) ) {
+			$records = array_values(
+				array_filter(
+					$records,
+					static fn( array $record ): bool => $record['status'] === $filters['status']
+				)
+			);
+		}
+
+		return $records;
+	}
+
+	/**
+	 * @return array<string, mixed>|null
+	 */
+	public function get( int $id ): ?array {
+		return $this->records[ $id ] ?? null;
+	}
+
+	/**
+	 * @return array<string, mixed>|null
+	 */
+	public function find_by_slug( string $slug ): ?array {
+		foreach ( $this->records as $record ) {
+			if ( $record['slug'] === $slug ) {
+				return $record;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * @param array<string, mixed> $record Direction row.
+	 * @return int|\WP_Error
+	 */
+	public function save( array $record ) {
+		$id = isset( $record['id'] ) ? (int) $record['id'] : $this->next_id++;
+
+		$record['id']         = $id;
+		$record['created_at'] = (string) ( $record['created_at'] ?? '2026-07-25 09:00:00' );
+		$record['updated_at'] = '2026-07-25 09:00:00';
+		$this->records[ $id ] = $record;
+
+		return $id;
+	}
+
+	/**
+	 * @param array<string, mixed> $snapshot Version row.
+	 * @return int|\WP_Error
+	 */
+	public function add_version( array $snapshot ) {
+		$snapshot['id']       = count( $this->version_rows ) + 1;
+		$this->version_rows[] = $snapshot;
+
+		return (int) $snapshot['id'];
+	}
+
+	/**
+	 * @return list<array<string, mixed>>
+	 */
+	public function versions( int $id ): array {
+		return array_values(
+			array_filter(
+				$this->version_rows,
+				static fn( array $row ): bool => (int) $row['direction_id'] === $id
+			)
+		);
+	}
+
+	/**
+	 * @return array<string, mixed>|null
+	 */
+	public function version( int $id, int $revision ): ?array {
+		foreach ( $this->version_rows as $row ) {
+			if ( (int) $row['direction_id'] === $id && (int) $row['revision'] === $revision ) {
+				return $row;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * @return true|\WP_Error
+	 */
+	public function archive( int $id ) {
+		if ( ! isset( $this->records[ $id ] ) ) {
+			return new \WP_Error( 'stonewright_direction_write_failed', 'Missing record.' );
+		}
+
+		$this->records[ $id ]['status'] = 'archived';
+
+		return true;
+	}
+
+	public function begin_transaction(): void {
+	}
+
+	public function commit_transaction(): void {
+	}
+
+	public function rollback_transaction(): void {
+	}
+}


### PR DESCRIPTION
## Summary

Adds the Design Studio admin page: a single place to see which design direction
is active, edit it, review the evidence behind a quality report, and move
between revisions — without any of it becoming a second, weaker copy of the
design rules that already live in the abilities.

The page owns no design logic. Every read and write goes through REST routes
that delegate to the typed design-direction and quality abilities, so
permission checks, task context tokens, confirmation tokens, backups,
validation, audit records, and effect readback are inherited rather than
reimplemented.

## Changed abilities

None. No ability was added, removed, or modified in this PR.

New REST routes under `stonewright/v1/design-studio`:

| Route | Method | Delegates to |
| --- | --- | --- |
| `/directions` | GET | `stonewright/design-direction-list` |
| `/directions` | POST | `stonewright/design-direction-save` |
| `/directions/<id>` | GET | `stonewright/design-direction-get` |
| `/directions/<id>/activate` | POST | `stonewright/design-direction-activate` |
| `/directions/<id>/restore` | POST | `stonewright/design-direction-restore` |
| `/directions/<id>/sync-plan` | POST | `stonewright/design-direction-sync-elementor` (dry run) |
| `/directions/<id>/sync-apply` | POST | `stonewright/design-direction-sync-elementor` (apply) |
| `/quality` | GET | stored quality reports |

## Gates

Backup, confirmation token, permission, validation, and audit gates are
**unchanged**. The routes cannot bypass them, because they call the abilities
rather than the repository.

- Reads require `Permissions::can_read_design()`.
- Writes require `Permissions::can_manage_design()` plus a `wp_rest` nonce.
- Activation, restore, and sync-apply still require a confirmation token in
  production-safe mode; the page surfaces the token field in the review drawer
  instead of hiding the requirement.
- Sync-apply still refuses a plan whose base hash no longer matches the kit.

## Front end

`assets/admin/design-studio.js` and `assets/admin/design-studio.css`. No
framework, no jQuery, no build step, no third-party dependency.

- Stored content — direction names, provenance, findings, repair hints — is
  never turned into markup. There is no `innerHTML`, `insertAdjacentHTML`, or
  document writing anywhere in the file; every value reaches the DOM through
  `textContent`.
- No native `confirm()`/`alert()`. Activation, save, restore, sync, and leaving
  the editor with unsaved work each open a focus-trapping review drawer that
  lists what is about to change.
- Keyboard-operable tablist with roving focus, URL-restored views, and browser
  back/forward.
- Session-scoped draft recovery, so a reload does not silently discard an edit.
- Light and dark through the existing shell tokens only; no literal colours.
- Reduced-motion path.

## Tests

- `plugin/tests/Unit/Admin/DesignStudioPageTest.php`,
  `DesignStudioRestApiTest.php`, `DesignStudioAssetsTest.php`.
  `DesignStudioAssetsTest` is a static scan of the shipped assets: it asserts
  the security properties above as absences, so a future edit that reintroduces
  `innerHTML`, a native dialog, `admin-ajax.php`, or a direct
  `/wp/v2/`/`abilities/run` call fails the suite.
- `e2e/tests/design-studio.spec.ts` — every required state (empty,
  ready-inactive, active-synced, draft with readiness issues, blocked sync plan,
  failing quality report, incomplete evidence, revision history) plus an
  unstubbed write path that drives save, activate, and restore against the real
  routes, and a ten-shot matrix across 375×812, 768×1024, 1024×768, 1280×800,
  and 1440×900 in light and dark with hashes and timestamps masked.
- `e2e/tests/design-studio-a11y.spec.ts` — tablist and roving focus, visible
  focus ring, modal drawer focus trap and focus return, polite live region,
  unsaved-work review, reduced motion.
- The Design Studio page joins the shared `admin-ui.spec.ts` sweep, so it is
  checked for horizontal overflow and console errors at every viewport.

**Not verified locally:** the Playwright suite needs `wp-env`, which needs
Docker, which is not installed on the machine this branch was written on. The
e2e specs were typechecked and enumerated (`playwright test --list`) but not
executed, and the ten screenshots have not been inspected by eye. The
`e2e-admin-ui` CI job is the first real run.

Everything else is green: `composer test` (5749 tests, 29910 assertions),
`phpstan`, `phpcs`, `security:audit`, `dependencies:audit`, `provenance:lint`,
companion typecheck/test/build, visual typecheck/test/build,
`scripts/package-verify.mjs`, `scripts/check-docs-freshness.mjs`,
`git diff --check`.

## Docs

`README.md` (admin page list), `CHANGELOG.md`, and `plugin/CHANGELOG.md`
Unreleased sections.
