### PR TITLE
Visible interface for Stonewright Visual

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,12 @@ jobs:
       - run: npm run typecheck
       - run: npm test
       - run: npm run build
+      - name: Verify the packaged plugin can carry the built bundle
+        working-directory: .
+        run: |
+          mkdir -p plugin/assets/visual
+          cp visual/dist/workspace-browser.js plugin/assets/visual/workspace-browser.js
+          node scripts/package-verify.mjs --require-visual-bundle
 
   e2e-admin-ui:
     runs-on: ubuntu-latest
@@ -113,6 +119,16 @@ jobs:
           cache-dependency-path: e2e/package-lock.json
       - run: npm ci
       - run: npx playwright install --with-deps chromium
+      - name: Build the Stonewright Visual bundle
+        working-directory: visual
+        run: |
+          npm ci
+          npm run build
+      - name: Stage the bundle into the plugin
+        working-directory: .
+        run: |
+          mkdir -p plugin/assets/visual
+          cp visual/dist/workspace-browser.js plugin/assets/visual/workspace-browser.js
       - name: Start wp-env
         run: npx wp-env start
       - name: Run admin-ui Playwright suite

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,14 @@ jobs:
           npm test
           npm run build
 
+      - name: Stage Stonewright Visual into the plugin
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p plugin/assets/visual
+          cp visual/dist/workspace-browser.js plugin/assets/visual/workspace-browser.js
+          node scripts/package-verify.mjs --require-visual-bundle --strict-vendor
+
       - name: Package release assets
         shell: bash
         run: |
@@ -85,6 +93,10 @@ jobs:
           (cd visual && npm pack --pack-destination ../dist)
           if unzip -Z1 "dist/stonewright-${version}.zip" | grep -Eq '^stonewright/(tests|bin)/|^stonewright/(phpunit|phpstan|phpcs)|^stonewright/composer\.lock$'; then
             echo "Plugin archive contains development-only files" >&2
+            exit 1
+          fi
+          if ! unzip -Z1 "dist/stonewright-${version}.zip" | grep -q '^stonewright/assets/visual/workspace-browser\.js$'; then
+            echo "Plugin archive is missing the Stonewright Visual bundle" >&2
             exit 1
           fi
           (cd dist && sha256sum "stonewright-${version}.zip" stonewright-companion-*.tgz stonewright-visual-*.tgz > SHA256SUMS.txt)

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ visual/dist/
 visual/coverage/
 dist/
 
+# Built Stonewright Visual bundle, staged into the plugin during packaging
+plugin/assets/visual/
+
 # Local
 *.log
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ Unreleased); older history lives in git tags and GitHub releases.
 
 ### Added
 
+- A Visual Workspace page in wp-admin. Stonewright Visual could previously be
+  driven by an AI client and by nothing else; now a person can open a post in it
+  and watch the same steps. It names the editor it found, refuses to guess when
+  an editor is present but cannot be driven, and walks read, preview, explicit
+  confirmation, apply, and verify in that order. The confirmation panel states
+  the target, the breakpoint, and the before and after text for every change,
+  with the active design direction named beside it. Applying without evidence
+  behind it is reported as unverified rather than as a success. The inspector
+  collapses into a keyboard-operable drawer on narrow screens, and there are no
+  browser confirm dialogs anywhere in the flow.
 - A Design Studio page in wp-admin. It shows which direction is active, whether
   it is ready and whether it matches the Elementor kit, and where each token
   came from. Directions are edited in a structured form with a live specimen

--- a/README.md
+++ b/README.md
@@ -297,7 +297,9 @@ Stonewright speaks standard MCP (stdio via the companion, and HTTP MCP when the 
 
 ## Admin interface
 
-Plugin mode admin pages include Setup, Dashboard (Site Pulse), Abilities, Blueprints, Design Studio, Skills, Memory, Sandbox, and Audit Log. Theme toggle lives in the admin shell header.
+Plugin mode admin pages include Setup, Dashboard (Site Pulse), Abilities, Blueprints, Design Studio, Visual Workspace, Skills, Memory, Sandbox, and Audit Log. Theme toggle lives in the admin shell header.
+
+Design Studio holds design directions: the validated design intent a site works to, versioned, with provenance and revisions. Visual Workspace opens a post in the browser workspace, resolves the live editor adapter, and walks read → preview → confirm → apply → verify with the active direction on screen. Neither page certifies that a page looks right; a change applied without evidence behind it is reported as unverified rather than as a success. See [docs/visual.md](docs/visual.md).
 
 <!-- Maintainer: add the Dashboard or Site Pulse screenshot here. Do not remove this comment until the asset is available. -->
 <!-- Maintainer: add the Blueprints or brand-kit screenshot here. Do not remove this comment until the asset is available. -->

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -299,6 +299,68 @@ sections of one page, because the decision the user made was about the visual
 direction, not about section two. `checkpoint_token` is in the kernel's default
 redaction list, so no ability writes it into an audit row.
 
+## Visual Workspace in wp-admin
+
+`Stonewright Visual` is a browser workspace, and until this release it had no
+visible surface: it could be driven by an MCP client and by nothing else. The
+Visual Workspace admin page hosts it, so a person can watch the same ladder an
+agent walks.
+
+The page owns the chrome and the bundle owns the workspace. PHP renders the
+heading, the post it is pointed at, the editor it expects, the canvas, and the
+inspector, then hands the bundle three slots to fill: the adapter chip, the
+canvas body, and the inspector body. Nothing else in the page is replaced, so
+the screen still reads correctly while the bundle is connecting, and it still
+reads correctly if the bundle never loads. A missing bundle is stated on the
+page, with the command that builds it, rather than producing an empty frame.
+
+What reaches the browser is deliberately thin. The boot payload carries the REST
+base, a `wp_rest` nonce, the post id, the requested editor, and the active
+direction *row* — identity, revision, and contract hash. The contract itself
+stays on the server: the workspace states which direction is in force, it does
+not re-derive its rules in JavaScript. The page is gated on `edit_posts` and, for
+the post it targets, on `Permissions::can_edit_post()`.
+
+Adapter resolution is honest about failure. Detection walks Elementor V4 atomic,
+then Elementor V3, then Gutenberg, and an editor that is present but cannot be
+driven stops the walk instead of falling through — editing an Elementor page as
+if it were Gutenberg is precisely the outcome that must not happen. The admin
+page is not an editor screen, so "no supported editor was found on this page" is
+a normal, reported state, and the stored quality report is still read and shown
+so the screen says what was last observed.
+
+The write ladder is enforced by the controller, not by the markup: read, then
+preview, then an explicit confirmation, then apply, then verify. Every editor
+write goes through one private dispatch that refuses to run outside the applying
+state. A proposed operation carries both a human-readable diff and the exact
+arguments the editor tool will receive, so the confirmation panel shows what a
+person needs and the adapter gets what its schema requires — with no second,
+looser schema invented in the middle. Applying with no evidence behind it does
+not report success: it reports the change as unverified, which is the same
+contract `stonewright/design-quality-check` uses on the server.
+
+The bundle is built from `visual/` and staged into `plugin/assets/visual/` at
+packaging time; it is not committed. `scripts/package-verify.mjs` warns about a
+missing bundle in a source checkout and fails on it under
+`--require-visual-bundle`, which CI and the release workflow pass after staging.
+The same check rejects Node build inputs from the archive, and the release job
+asserts the built zip actually contains the bundle.
+
+### Where each part's authority ends
+
+| Part | Supplies | Does not supply |
+|---|---|---|
+| Design Direction | Validated design intent, versioned, with provenance | Any claim about what a page currently looks like |
+| DesignEvidence | Normalized observations of a source design | Permission to write anything |
+| NativePlanner | A mapping from evidence to native Gutenberg/Elementor schemas | A guarantee the mapping is what the user wanted |
+| `design-quality-check` | Measurements of a supplied render, with coverage | A score, or a pass for anything unmeasured |
+| Visual Workspace | Browser-side evidence and the confirmation gate | Correctness of the design it is showing |
+| Typed Elementor abilities | Guarded, backed-up, readback-verified writes | Visual judgement |
+
+No part of this subsystem certifies that a page looks right. Together they make
+the intent explicit, the observations measurable, the writes reversible, and the
+unverified parts visible as unverified.
+
 ## Direct + plugin REST parity surfaces
 
 Plugin abilities and Direct tools cover comments, users (including application passwords), widgets, allowlisted settings, themes, plugin lifecycle, revisions (with restore on the plugin), site health tests, search/oEmbed, and WooCommerce product/order/sales reads.

--- a/docs/visual.md
+++ b/docs/visual.md
@@ -22,3 +22,75 @@ npm run typecheck
 npm test
 npm run build
 ```
+
+## Visual Workspace admin page
+
+The same workspace runs in the browser under **Stonewright → Visual Workspace**
+(`admin.php?page=stonewright-visual-workspace`). The page exists so a person can
+see and drive the ladder an MCP client would otherwise walk alone. It requires
+`edit_posts`, and pointing it at a post additionally requires
+`Permissions::can_edit_post()` for that post.
+
+Open it with `&post_id=<id>`, or use the picker on the page when no post id is
+supplied. The requested editor can be pinned with `&editor=elementor-v3`,
+`&editor=elementor-v4`, or `&editor=gutenberg`; the default `auto` leaves it to
+detection, which is the honest default because only the browser can see which
+editor actually loaded.
+
+PHP renders the chrome — heading, target post, expected editor, canvas,
+inspector — and the browser bundle fills three slots: the adapter chip, the
+canvas body, and the inspector body. If the bundle is not present the page says
+so and prints the command that builds it, rather than showing an empty frame.
+
+### Adapter detection
+
+Detection walks Elementor V4 atomic, then Elementor V3, then Gutenberg. An
+editor that is present but cannot be driven stops the walk instead of falling
+through to the next candidate — treating an Elementor page as Gutenberg is the
+outcome this ordering exists to prevent. The admin screen is not an editor
+screen, so "no supported editor was found on this page" is a normal reported
+state; the stored quality report is still fetched and shown so the page can say
+what was last observed.
+
+### Write ladder
+
+Every editor write follows read → preview → confirm → apply → verify, enforced
+by the controller rather than by the markup:
+
+| Step | What happens |
+|---|---|
+| Read | The adapter reads the page. Nothing can be proposed before this. |
+| Preview | Operations are staged. No editor call is made. |
+| Confirm | The confirmation panel states target, breakpoint, before → after, and the direction in force. |
+| Apply | The one private dispatch runs, and only from the applying state. |
+| Verify | Evidence is summarized. Missing evidence is reported as unverified. |
+
+A proposed operation carries both a human-readable diff and the exact arguments
+the editor tool will receive, so the panel shows what a person needs while the
+adapter still gets what its own schema requires. Applying with no evidence
+behind it does not report success: the change may well have landed, and the
+workspace says the claim of correctness failed. That is the same contract
+`stonewright/design-quality-check` uses on the server.
+
+### Evidence
+
+The inspector reads the stored quality report for the post through
+`design-studio/quality` and renders one row per failing or unchecked rule. A
+report counts as verified only when it has findings, none failed, and no rule
+went unchecked. Rules with no evidence to run against are listed as unverified
+instead of being folded into a pass.
+
+### Accessibility
+
+The viewport group is a keyboard-operable toolbar with `aria-pressed` state.
+At 1024 px and below the inspector collapses into a drawer with an `aria-expanded`
+toggle, `aria-modal` content, Escape to close, and focus returned to the toggle.
+There are no `window.confirm()` dialogs; confirmation is the panel described
+above. Transitions respect `prefers-reduced-motion`.
+
+### Build and packaging
+
+`plugin/assets/visual/` is generated, not committed. Build it from `visual/` and
+stage it before packaging. `scripts/package-verify.mjs` warns when the bundle is
+missing from a source checkout and fails under `--require-visual-bundle`, which
+CI and the release workflow pass after staging.

--- a/e2e/tests/visual-workspace.spec.ts
+++ b/e2e/tests/visual-workspace.spec.ts
@@ -1,0 +1,637 @@
+import { expect, test, type Page } from '@playwright/test';
+import { login } from './helpers/design-studio';
+import { restGet, restPost, wpRestNonce } from './helpers/wp-rest';
+
+/**
+ * Visual Workspace — adapter detection, the write ladder, and the drawer.
+ *
+ * The workspace host page is not an editor screen, so the editor runtimes are
+ * installed with an init script before the bundle boots. They are the same
+ * globals the adapters read in a real editor (`window.elementor` + `window.$e`,
+ * or `window.wp.blocks` + `window.wp.data`), which is what makes detection
+ * provable here; the Gutenberg double is complete enough for the read and the
+ * write to run through the real adapter, schema validation, and readback.
+ *
+ * Nothing here asserts that a design looks right. It asserts the ladder holds:
+ * no write without a read, a preview, and an explicit allow, and no "complete"
+ * without evidence.
+ */
+
+const WORKSPACE_URL = '/wp-admin/admin.php?page=stonewright-visual-workspace';
+const SLUG = 'sw-visual-workspace-target';
+const WIDE = 'desktop-1440-light';
+const NARROW = ['desktop-1024-light', 'tablet-782-light', 'mobile-390-light'];
+
+/** A report whose findings are observations that passed, so evidence exists. */
+const VERIFIED_REPORT = {
+	report_id: 'qr-visual-01',
+	schema_version: '1.0',
+	status: 'pass',
+	coverage: { checked: ['contrast.text'], not_checked: [], not_checked_rules: [] },
+	findings: [
+		{
+			rule_id: 'contrast.text',
+			severity: 'pass',
+			viewport: 'desktop',
+			element_ref: 'hero > h1',
+			evidence: { ratio: 7.1, required: 4.5 },
+			waived: false,
+		},
+	],
+	truncated_findings: 0,
+	direction_revision: 4,
+	direction_hash: 'a1b2c3d4e5f60718293a4b5c6d7e8f90',
+	render_hash: '99887766554433221100ffeeddccbbaa',
+};
+
+const FAILING_REPORT = {
+	...VERIFIED_REPORT,
+	report_id: 'qr-visual-02',
+	status: 'fail',
+	coverage: {
+		checked: ['contrast.text', 'target.size'],
+		not_checked: ['state.focus'],
+		not_checked_rules: ['state.focus'],
+	},
+	findings: [
+		{
+			rule_id: 'contrast.text',
+			severity: 'error',
+			viewport: 'mobile',
+			element_ref: 'hero > h1',
+			evidence: { ratio: 3.02, required: 4.5 },
+			repair_hint: 'Raise the heading colour.',
+			waived: false,
+		},
+	],
+};
+
+/** Serves the read-only quality route the workspace reads its evidence from. */
+async function stubQuality(page: Page, reports: unknown[]): Promise<void> {
+	await page.route(
+		(url) =>
+			url.href.includes('design-studio/quality') &&
+			(url.pathname.includes('/wp-json/') || url.searchParams.has('rest_route')),
+		async (route) =>
+			route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({ ok: true, count: reports.length, reports }),
+			}),
+	);
+}
+
+/**
+ * A Gutenberg double: one registered paragraph type, one block, and the two
+ * stores the runtime talks to. Writes land in the same object the reads come
+ * from, so the adapter's readback is a real check rather than a formality.
+ *
+ * Unknown stores resolve to no-op members instead of `undefined`, so an
+ * unrelated admin script asking for `core/notices` cannot break the page.
+ */
+async function installGutenberg(page: Page): Promise<void> {
+	await page.addInitScript(() => {
+		type Block = {
+			clientId: string;
+			name: string;
+			attributes: Record<string, unknown>;
+			innerBlocks: Block[];
+		};
+
+		const blocks: Block[] = [
+			{
+				clientId: 'block-1',
+				name: 'core/paragraph',
+				attributes: { content: 'Original copy', fontSize: 'medium' },
+				innerBlocks: [],
+			},
+		];
+		const applied: Array<Record<string, unknown>> = [];
+		const paragraph = {
+			name: 'core/paragraph',
+			title: 'Paragraph',
+			category: 'text',
+			attributes: { content: { type: 'string' }, fontSize: { type: 'string' } },
+			supports: {},
+		};
+
+		const blocksApi = {
+			getBlockTypes: () => [paragraph],
+			getBlockType: (name: string) => (name === paragraph.name ? paragraph : undefined),
+			createBlock: (name: string, attributes: Record<string, unknown> = {}) => ({
+				clientId: `block-${blocks.length + 1}`,
+				name,
+				attributes,
+				innerBlocks: [],
+			}),
+			serialize: () => '<!-- wp:paragraph --><p>Original copy</p><!-- /wp:paragraph -->',
+		};
+
+		const stores: Record<string, Record<string, unknown>> = {
+			'select:core/editor': { getCurrentPostId: () => 1, isEditedPostDirty: () => false },
+			'select:core/block-editor': {
+				getBlocks: () => blocks,
+				getBlock: (clientId: string) => blocks.find((item) => item.clientId === clientId) || null,
+				getBlockRootClientId: () => '',
+				getBlockIndex: () => 0,
+			},
+			'dispatch:core/editor': { savePost: async () => undefined },
+			'dispatch:core/block-editor': {
+				insertBlock: (block: Block) => blocks.push(block),
+				updateBlockAttributes: (clientId: string, attributes: Record<string, unknown>) => {
+					const block = blocks.find((item) => item.clientId === clientId);
+					if (block) {
+						Object.assign(block.attributes, attributes);
+						applied.push({ clientId, attributes });
+					}
+				},
+				moveBlockToPosition: () => undefined,
+				removeBlock: () => undefined,
+				undo: () => undefined,
+				redo: () => undefined,
+			},
+		};
+
+		const inert = () => new Proxy({}, { get: () => () => undefined });
+		const dataApi = {
+			select: (store: string) => stores[`select:${store}`] || inert(),
+			dispatch: (store: string) => stores[`dispatch:${store}`] || inert(),
+		};
+
+		const scope = window as unknown as Record<string, unknown>;
+		const wp = (scope.wp as Record<string, unknown>) || {};
+		// Locked so a late admin script cannot replace the doubles mid-test.
+		Object.defineProperty(wp, 'blocks', { get: () => blocksApi, set: () => undefined });
+		Object.defineProperty(wp, 'data', { get: () => dataApi, set: () => undefined });
+		scope.wp = wp;
+		scope.swAppliedWrites = applied;
+	});
+}
+
+/** Enough Elementor for detection and adapter construction, nothing more. */
+async function installElementor(page: Page, atomic: boolean): Promise<void> {
+	await page.addInitScript((isAtomic: boolean) => {
+		const container = { id: 'document', type: 'document', children: [] as unknown[] };
+		const scope = window as unknown as Record<string, unknown>;
+		scope.elementor = {
+			config: { version: isAtomic ? '4.0.0' : '3.25.0', controls: {}, elements: {} },
+			widgetsCache: isAtomic
+				? {
+						'e-paragraph': {
+							name: 'e-paragraph',
+							title: 'Paragraph',
+							atomic: true,
+							atomic_props_schema: {},
+							controls: {},
+						},
+					}
+				: { heading: { name: 'heading', title: 'Heading', controls: {} } },
+			getContainer: () => container,
+			getPreviewContainer: () => container,
+			documents: { getCurrent: () => ({ id: 1, container }) },
+		};
+		scope.$e = {
+			run: async () => ({}),
+			commands: { getAll: () => [] },
+			components: { get: () => ({ isEditorChanged: () => false }) },
+		};
+	}, atomic);
+}
+
+/** Creates (or reuses) the post the workspace is opened against. */
+async function targetPostId(page: Page): Promise<number> {
+	const nonce = await wpRestNonce(page);
+	const existing = await restGet(
+		page,
+		`/wp/v2/pages?slug=${encodeURIComponent(SLUG)}&status=publish,draft`,
+		nonce,
+	);
+	if (existing.ok && Array.isArray(existing.body) && existing.body.length > 0) {
+		return Number((existing.body[0] as { id: number }).id);
+	}
+
+	const created = await restPost(
+		page,
+		'/wp/v2/pages',
+		{
+			status: 'publish',
+			slug: SLUG,
+			title: 'Visual workspace target',
+			content: '<p>Original copy</p>',
+		},
+		nonce,
+	);
+	if (!created.ok) {
+		throw new Error(`Could not seed the workspace target page: HTTP ${created.status}`);
+	}
+	return Number((created.body as { id?: number }).id || 0);
+}
+
+async function openWorkspace(page: Page, postId: number): Promise<void> {
+	await page.goto(`${WORKSPACE_URL}&post_id=${postId}`, { waitUntil: 'domcontentloaded' });
+	await expect(page.locator('[data-sw-visual-workspace]')).toBeVisible();
+	// The bundle stamps state onto the root as soon as it paints.
+	await expect(page.locator('[data-sw-visual-workspace][data-sw-state]')).toHaveCount(1);
+}
+
+/**
+ * Opens the workspace and waits for the adapter to attach.
+ *
+ * Connecting is asynchronous, so driving the controller straight after the
+ * first paint would race the boot and read an `idle` workspace.
+ */
+async function openConnected(page: Page, postId: number): Promise<void> {
+	await openWorkspace(page, postId);
+	await expect(page.locator('[data-sw-visual-workspace]')).toHaveAttribute(
+		'data-sw-state',
+		'connected',
+	);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Driving the controller                                                     */
+/* -------------------------------------------------------------------------- */
+
+type Step = 'read' | 'preview' | 'confirm' | 'allow' | 'deny';
+
+const OPERATION = {
+	tool: 'update_block',
+	target: 'core/paragraph block-1',
+	summary: 'Set the paragraph copy from the direction voice',
+	before: 'Original copy',
+	after: 'Direction copy',
+	args: {
+		client_id: 'block-1',
+		attributes: { content: 'Direction copy' },
+		idempotency_key: 'e2e-visual-1',
+		confirm_write: true,
+	},
+};
+
+interface DriveResult {
+	state: string;
+	errors: string[];
+}
+
+/**
+ * Runs named steps against the controller the bundle exposed.
+ *
+ * Steps are an enum rather than a script string: the page must never be handed
+ * arbitrary code to evaluate, and a fixed set is enough to walk the ladder.
+ */
+async function drive(page: Page, steps: Step[], stopOnError = true): Promise<DriveResult> {
+	return page.evaluate(
+		async (input: { steps: Step[]; operation: typeof OPERATION; stopOnError: boolean }) => {
+			const controller = (
+				window as unknown as {
+					stonewrightVisual?: {
+						getState: () => string;
+						read: () => Promise<void>;
+						preview: (operations: unknown[]) => void;
+						requestConfirmation: () => void;
+						decide: (decision: 'allow' | 'deny') => Promise<void>;
+					};
+				}
+			).stonewrightVisual;
+			if (!controller) {
+				throw new Error('The workspace controller was not exposed on window.');
+			}
+
+			const errors: string[] = [];
+			for (const step of input.steps) {
+				try {
+					if (step === 'read') {
+						await controller.read();
+					} else if (step === 'preview') {
+						controller.preview([input.operation]);
+					} else if (step === 'confirm') {
+						controller.requestConfirmation();
+					} else {
+						await controller.decide(step);
+					}
+				} catch (cause) {
+					errors.push(cause instanceof Error ? cause.message : String(cause));
+					if (input.stopOnError) {
+						break;
+					}
+				}
+			}
+
+			return { state: controller.getState(), errors };
+		},
+		{ steps, operation: OPERATION, stopOnError },
+	);
+}
+
+async function appliedWrites(page: Page): Promise<Array<Record<string, unknown>>> {
+	return page.evaluate(
+		() => (window as unknown as { swAppliedWrites: Array<Record<string, unknown>> }).swAppliedWrites,
+	);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Adapter detection                                                          */
+/* -------------------------------------------------------------------------- */
+
+test.describe('Visual Workspace adapters', () => {
+	test.beforeEach(async ({ page }, testInfo) => {
+		test.skip(testInfo.project.name !== WIDE, 'Adapter detection is proven once.');
+		await login(page);
+		await stubQuality(page, []);
+	});
+
+	test('reports that no editor is attached instead of pretending one is', async ({ page }) => {
+		const postId = await targetPostId(page);
+		await openWorkspace(page, postId);
+
+		const adapter = page.locator('[data-sw-visual-adapter] [data-sw-adapter]');
+		await expect(adapter).toHaveAttribute('data-sw-adapter', 'none');
+		await expect(adapter).toContainText('No supported editor was found on this page.');
+		await expect(page.locator('[data-sw-visual-workspace]')).toHaveAttribute(
+			'data-sw-state',
+			'failed',
+		);
+	});
+
+	test('detects a classic Elementor runtime as V3', async ({ page }) => {
+		const postId = await targetPostId(page);
+		await installElementor(page, false);
+		await openWorkspace(page, postId);
+
+		const adapter = page.locator('[data-sw-visual-adapter] [data-sw-adapter]');
+		await expect(adapter).toHaveAttribute('data-sw-adapter', 'elementor-v3');
+		await expect(adapter).toContainText('Elementor V3');
+	});
+
+	test('detects an atomic Elementor runtime as V4', async ({ page }) => {
+		const postId = await targetPostId(page);
+		await installElementor(page, true);
+		await openWorkspace(page, postId);
+
+		const adapter = page.locator('[data-sw-visual-adapter] [data-sw-adapter]');
+		await expect(adapter).toHaveAttribute('data-sw-adapter', 'elementor-v4');
+		await expect(adapter).toContainText('Elementor V4 Atomic');
+	});
+
+	test('detects the block editor and reports it connected', async ({ page }) => {
+		const postId = await targetPostId(page);
+		await installGutenberg(page);
+		await openWorkspace(page, postId);
+
+		const adapter = page.locator('[data-sw-visual-adapter] [data-sw-adapter]');
+		await expect(adapter).toHaveAttribute('data-sw-adapter', 'gutenberg');
+		await expect(page.locator('[data-sw-visual-workspace]')).toHaveAttribute(
+			'data-sw-state',
+			'connected',
+		);
+	});
+});
+
+/* -------------------------------------------------------------------------- */
+/* The write ladder                                                           */
+/* -------------------------------------------------------------------------- */
+
+test.describe('Visual Workspace write ladder', () => {
+	test.beforeEach(async ({ page }, testInfo) => {
+		test.skip(testInfo.project.name !== WIDE, 'The ladder is proven once.');
+		await login(page);
+		await installGutenberg(page);
+	});
+
+	test('refuses to preview, confirm, or apply out of order', async ({ page }) => {
+		await stubQuality(page, [VERIFIED_REPORT]);
+		const postId = await targetPostId(page);
+		await openConnected(page, postId);
+
+		const result = await drive(page, ['preview', 'confirm', 'allow'], false);
+
+		expect(result.errors).toHaveLength(3);
+		expect(result.errors[0]).toMatch(/must read the page before it can preview/i);
+		expect(result.errors[1]).toMatch(/nothing to confirm/i);
+		expect(result.errors[2]).toMatch(/no confirmation is pending/i);
+		expect(result.state).toBe('connected');
+		expect(await appliedWrites(page)).toHaveLength(0);
+	});
+
+	test('previews the diff, applies on allow, and completes on evidence', async ({ page }) => {
+		await stubQuality(page, [VERIFIED_REPORT]);
+		const postId = await targetPostId(page);
+		await openConnected(page, postId);
+
+		const previewed = await drive(page, ['read', 'preview']);
+		expect(previewed.errors).toEqual([]);
+		expect(previewed.state).toBe('previewing');
+
+		const confirm = page.locator('.sw-visual-confirm');
+		await expect(confirm.getByRole('heading')).toContainText('Apply 1 change(s)');
+		await expect(confirm.locator('.sw-visual-confirm__change')).toContainText(
+			'Original copy → Direction copy',
+		);
+		const apply = confirm.getByRole('button', { name: 'Apply changes' });
+		await expect(apply).toBeEnabled();
+
+		await drive(page, ['confirm']);
+		await expect(page.locator('[data-sw-visual-workspace]')).toHaveAttribute(
+			'data-sw-state',
+			'awaiting_confirmation',
+		);
+
+		await apply.click();
+
+		await expect(page.locator('[data-sw-visual-workspace]')).toHaveAttribute(
+			'data-sw-state',
+			'complete',
+		);
+		const applied = await appliedWrites(page);
+		expect(applied).toHaveLength(1);
+		expect(applied[0]).toMatchObject({ clientId: 'block-1' });
+		await expect(page.locator('.sw-visual-evidence')).toHaveAttribute(
+			'data-sw-evidence',
+			'verified',
+		);
+	});
+
+	test('cancelling a confirmation writes nothing and returns to connected', async ({ page }) => {
+		await stubQuality(page, [VERIFIED_REPORT]);
+		const postId = await targetPostId(page);
+		await openConnected(page, postId);
+
+		await drive(page, ['read', 'preview', 'confirm']);
+		await page.locator('.sw-visual-confirm').getByRole('button', { name: 'Cancel' }).click();
+
+		await expect(page.locator('[data-sw-visual-workspace]')).toHaveAttribute(
+			'data-sw-state',
+			'connected',
+		);
+		await expect(page.locator('.sw-visual-confirm')).toHaveCount(0);
+		expect(await appliedWrites(page)).toHaveLength(0);
+	});
+
+	test('an applied change with no evidence is reported unverified, not complete', async ({
+		page,
+	}) => {
+		await stubQuality(page, []);
+		const postId = await targetPostId(page);
+		await openConnected(page, postId);
+
+		await drive(page, ['read', 'preview', 'confirm']);
+		await page.locator('.sw-visual-confirm').getByRole('button', { name: 'Apply changes' }).click();
+
+		await expect(page.locator('[data-sw-visual-workspace]')).toHaveAttribute(
+			'data-sw-state',
+			'failed',
+		);
+		await expect(page.locator('.sw-visual__status')).toContainText('unverified');
+		// The write did happen; what failed is any claim that it is correct.
+		expect(await appliedWrites(page)).toHaveLength(1);
+	});
+});
+
+/* -------------------------------------------------------------------------- */
+/* Evidence, viewports, direction                                             */
+/* -------------------------------------------------------------------------- */
+
+test.describe('Visual Workspace evidence and controls', () => {
+	test.beforeEach(async ({ page }, testInfo) => {
+		test.skip(testInfo.project.name !== WIDE, 'Control behaviour is proven once.');
+		await login(page);
+		await installGutenberg(page);
+		await stubQuality(page, [FAILING_REPORT]);
+	});
+
+	test('shows the stored quality findings, including what was never checked', async ({ page }) => {
+		const postId = await targetPostId(page);
+		await openWorkspace(page, postId);
+
+		const evidence = page.locator('.sw-visual-evidence');
+		await expect(evidence).toHaveAttribute('data-sw-evidence', 'unverified');
+		await expect(evidence.locator('[data-sw-evidence-status="fail"]')).toHaveCount(1);
+		await expect(evidence.locator('[data-sw-evidence-status="not_checked"]')).toHaveCount(1);
+		await expect(evidence.locator('.sw-visual-evidence__notice')).toContainText('unverified');
+	});
+
+	test('viewport controls are a keyboard-operable pressed-state group', async ({ page }) => {
+		const postId = await targetPostId(page);
+		await openWorkspace(page, postId);
+
+		const group = page.getByRole('group', { name: 'Viewport' });
+		await expect(group.getByRole('button', { name: 'Desktop' })).toHaveAttribute(
+			'aria-pressed',
+			'true',
+		);
+
+		const mobile = group.getByRole('button', { name: 'Mobile' });
+		await mobile.focus();
+		await page.keyboard.press('Enter');
+
+		await expect(mobile).toHaveAttribute('aria-pressed', 'true');
+		await expect(page.locator('[data-sw-visual-workspace]')).toHaveAttribute(
+			'data-sw-viewport',
+			'mobile',
+		);
+	});
+
+	test('names the active direction without shipping the contract to the browser', async ({
+		page,
+	}) => {
+		const postId = await targetPostId(page);
+		await openWorkspace(page, postId);
+
+		await expect(page.locator('.sw-visual__direction')).toContainText('Direction:');
+		const keys = await page.evaluate(() => {
+			const payload = (
+				window as unknown as { stonewrightVisualWorkspace?: { direction?: unknown } }
+			).stonewrightVisualWorkspace?.direction;
+			return payload !== null && typeof payload === 'object'
+				? Object.keys(payload as Record<string, unknown>)
+				: [];
+		});
+		expect(keys).not.toContain('contract');
+		expect(keys).not.toContain('tokens');
+	});
+});
+
+/* -------------------------------------------------------------------------- */
+/* Narrow-screen drawer                                                       */
+/* -------------------------------------------------------------------------- */
+
+test.describe('Visual Workspace inspector drawer', () => {
+	test.beforeEach(async ({ page }, testInfo) => {
+		test.skip(!NARROW.includes(testInfo.project.name), 'Drawer behaviour needs a narrow viewport.');
+		await login(page);
+		await installGutenberg(page);
+		await stubQuality(page, []);
+	});
+
+	test('opens from the toggle, closes on Escape, and returns focus', async ({ page }) => {
+		const postId = await targetPostId(page);
+		await openWorkspace(page, postId);
+
+		const toggle = page.locator('[data-sw-visual-inspector-toggle]');
+		const inspector = page.locator('#sw-visual-inspector');
+
+		await expect(toggle).toBeVisible();
+		await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+		await expect(inspector).toBeHidden();
+
+		await toggle.click();
+		await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+		await expect(inspector).toBeVisible();
+		await expect(inspector).toHaveAttribute('aria-modal', 'true');
+
+		await page.keyboard.press('Escape');
+		await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+		await expect(inspector).toBeHidden();
+		await expect(toggle).toBeFocused();
+	});
+
+	test('keeps the workspace usable with motion reduced', async ({ page }) => {
+		await page.emulateMedia({ reducedMotion: 'reduce' });
+		const postId = await targetPostId(page);
+		await openWorkspace(page, postId);
+
+		const toggle = page.locator('[data-sw-visual-inspector-toggle]');
+		await toggle.click();
+		await expect(page.locator('#sw-visual-inspector')).toBeVisible();
+	});
+});
+
+/* -------------------------------------------------------------------------- */
+/* Entry points                                                               */
+/* -------------------------------------------------------------------------- */
+
+test.describe('Visual Workspace entry points', () => {
+	test.beforeEach(async ({ page }, testInfo) => {
+		test.skip(testInfo.project.name !== WIDE, 'Entry behaviour is proven once.');
+		await login(page);
+	});
+
+	test('asks for a post when the URL names none', async ({ page }) => {
+		await page.goto(WORKSPACE_URL, { waitUntil: 'domcontentloaded' });
+
+		await expect(page.locator('[data-sw-visual-picker]')).toBeVisible();
+		await expect(page.locator('[data-sw-visual-workspace]')).toHaveCount(0);
+		await expect(page.getByRole('button', { name: 'Open workspace' })).toBeVisible();
+	});
+
+	test('an unusable post id lands on the picker rather than a broken workspace', async ({
+		page,
+	}) => {
+		await page.goto(`${WORKSPACE_URL}&post_id=not-a-number`, { waitUntil: 'domcontentloaded' });
+
+		await expect(page.locator('[data-sw-visual-picker]')).toBeVisible();
+	});
+
+	test('the picker opens the workspace for the post it was given', async ({ page }) => {
+		const postId = await targetPostId(page);
+		await page.goto(WORKSPACE_URL, { waitUntil: 'domcontentloaded' });
+
+		await page.locator('#sw-visual-post-id').fill(String(postId));
+		await page.getByRole('button', { name: 'Open workspace' }).click();
+
+		await expect(page.locator('[data-sw-visual-workspace]')).toHaveAttribute(
+			'data-sw-post-id',
+			String(postId),
+		);
+	});
+});

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -145,6 +145,11 @@
 
 ### Fixed
 
+- The Visual Workspace no longer reports a connected block editor on a page
+  that has none. Adapter detection treated the presence of `wp.blocks` and
+  `wp.data` as proof of an editor, and both load on plain admin screens
+  including the workspace host page itself. Detection now requires the store
+  members the Gutenberg runtime calls.
 - Saving a design direction from the Design Studio editor no longer drops the
   contract sections the editor does not expose. `components`, `provenance`,
   `waivers`, and `readiness` are carried over from the stored contract, so

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -4,6 +4,26 @@
 
 ### Added
 
+- Admin page `stonewright-visual-workspace` (`Admin\Pages\VisualWorkspacePage`),
+  gated on `edit_posts` and, for a targeted post, on
+  `Permissions::can_edit_post()`. PHP renders the chrome and hands the browser
+  bundle three slots: adapter chip, canvas body, inspector body. The boot payload
+  carries only the REST base, a `wp_rest` nonce, the post id, the requested
+  editor, and the active direction row (identity, revision, contract hash) — the
+  contract itself stays on the server. A missing bundle is stated on the page
+  with the command that builds it. No abilities were added, changed, or removed.
+- Visual Workspace front end (`assets/admin/visual-workspace.js`,
+  `assets/admin/visual-workspace.css`) plus the `visual/` workspace UI it boots:
+  adapter detection that stops on an undrivable editor instead of falling
+  through, a controller-enforced read → preview → confirm → apply → verify
+  ladder with a single private write dispatch, a confirmation panel carrying both
+  the human diff and the exact adapter arguments, and an evidence panel that
+  keeps failed and unchecked rules visible as unverified.
+- `plugin/assets/visual/` is staged at packaging time and is not committed.
+  `scripts/package-verify.mjs` warns on a missing bundle in a source checkout and
+  fails under `--require-visual-bundle`; CI and the release workflow pass that
+  flag after staging, and the release job asserts the built zip contains the
+  bundle.
 - Admin page `stonewright-design-studio` with four views (overview, editor,
   quality, history) and REST routes under `stonewright/v1/design-studio`. Every
   route delegates to the typed design-direction and quality abilities, so

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -156,6 +156,28 @@ OAuth or generate a WordPress Application Password, then copy client-specific
 instructions. It also includes copyable real-world prompt
 examples for Elementor, content modeling, WooCommerce, and Gutenberg/FSE work.
 
+### Design Studio And Visual Workspace
+
+Design Studio stores design directions — validated design intent, versioned,
+with provenance — and lets you create, capture, or import one, mark it ready,
+activate it, dry-run a sync against the Elementor Kit, apply that sync with a
+backup and readback, inspect the recorded quality evidence, and restore an
+earlier revision. Every activation, sync, and restore goes through a review
+drawer that states what will change before anything is written.
+
+Visual Workspace opens a post in the browser workspace under
+`admin.php?page=stonewright-visual-workspace&post_id=<id>`. It requires
+`edit_posts`, plus edit rights on the target post. The workspace resolves the
+live editor adapter — Elementor V4 atomic, then Elementor V3, then Gutenberg —
+and enforces read → preview → confirm → apply → verify for every write.
+
+Neither page claims that a page looks correct. Design directions supply intent,
+quality reports supply measurements with their own coverage, and a change
+applied with no evidence behind it is reported as unverified. The browser bundle
+is generated into `assets/visual/` at packaging time; when it is absent the page
+says so and prints the build command. See
+[docs/visual.md](../docs/visual.md).
+
 ## Adding An Ability
 
 1. Create a class extending `AbilityKernel` in `includes/Abilities/<Category>/`.

--- a/plugin/assets/admin/design-studio.js
+++ b/plugin/assets/admin/design-studio.js
@@ -1354,9 +1354,38 @@
 		return 'info';
 	}
 
+	/**
+	 * Link from a quality report to the Visual Workspace for the same post.
+	 *
+	 * The workspace is where a finding gets fixed with the editor open, so the
+	 * link only appears once a post is loaded. `editor=auto` leaves adapter
+	 * detection to the browser: only the live page knows which editor loaded.
+	 */
+	function workspaceLink() {
+		var base = boot.visualWorkspaceUrl || '';
+		var node = el( 'a', { className: 'sw-ds-button', text: 'Open Visual Workspace' } );
+
+		node.hidden = true;
+
+		return {
+			node: node,
+			sync: function ( postId ) {
+				if ( ! base || ! postId || postId <= 0 ) {
+					node.hidden = true;
+					node.removeAttribute( 'href' );
+
+					return;
+				}
+				node.href = base + '&post_id=' + encodeURIComponent( String( postId ) ) + '&editor=' + encodeURIComponent( 'auto' );
+				node.hidden = false;
+			}
+		};
+	}
+
 	function renderQuality( panel ) {
 		clear( panel );
 
+		var openWorkspace = workspaceLink();
 		var postInput = el( 'input', { attrs: { id: 'sw-ds-post-id', type: 'number', min: '1', step: '1' } } );
 
 		postInput.value = state.postId ? String( state.postId ) : '';
@@ -1405,6 +1434,7 @@
 							.then( function () {
 								busy( false );
 								announce( 'Loaded ' + state.reports.length + ' quality reports for post ' + postId + '.' );
+								openWorkspace.sync( postId );
 								paintFindings( panel );
 							} )
 							.catch( function ( error ) {
@@ -1412,10 +1442,12 @@
 								announce( error.message, 'danger' );
 							} );
 					}
-				} )
+				} ),
+				openWorkspace.node
 			] )
 		);
 
+		openWorkspace.sync( state.postId );
 		panel.appendChild( el( 'div', { attrs: { 'data-sw-ds-findings': '' } } ) );
 		paintFindings( panel );
 	}

--- a/plugin/assets/admin/visual-workspace.css
+++ b/plugin/assets/admin/visual-workspace.css
@@ -1,0 +1,283 @@
+/**
+ * Visual Workspace — stone & precision.
+ *
+ * Same palette, spacing, and elevation tokens as the Design Studio, so the two
+ * pages read as one product and follow the light/dark toggle without owning a
+ * palette. The layout is mobile-first: header, canvas, and inspector stack in a
+ * single column, and the inspector only becomes a side column once there is
+ * room for it. Below that width it is a drawer, which is why the drawer rules
+ * live in a max-width query rather than the default cascade.
+ */
+
+.sw-visual-page {
+	--sw-vw-radius: 12px;
+	--sw-vw-radius-sm: 10px;
+	--sw-vw-rule: 1px solid var(--sw-border);
+	--sw-vw-serif: 'Iowan Old Style', 'Palatino Linotype', Palatino, 'Book Antiqua', Georgia, serif;
+	--sw-vw-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+
+	max-width: var(--sw-shell-content-max, 1200px);
+	color: var(--sw-text);
+	font-family: var(--sw-vw-sans);
+	font-size: var(--sw-text-md);
+	line-height: 1.5;
+}
+
+.sw-visual-page h1 {
+	margin: 0 0 var(--sw-space-2);
+	font-family: var(--sw-vw-serif);
+	font-size: var(--sw-text-2xl);
+	font-weight: 600;
+	letter-spacing: -0.015em;
+	line-height: 1.2;
+	color: var(--sw-text);
+}
+
+.sw-visual-page :focus-visible {
+	outline: var(--sw-focus-ring);
+	outline-offset: 2px;
+}
+
+/* ============ Header ============ */
+
+.sw-visual-page__header {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--sw-space-3);
+	align-items: flex-start;
+	justify-content: space-between;
+	padding: 0 0 var(--sw-space-4);
+	border-bottom: var(--sw-vw-rule);
+}
+
+.sw-visual-page__post {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--sw-space-2);
+	align-items: center;
+	margin: 0;
+	font-size: var(--sw-text-sm);
+	color: var(--sw-text-secondary);
+}
+
+.sw-visual-page__post-title {
+	font-weight: 600;
+	color: var(--sw-text);
+}
+
+.sw-visual-page__post-id,
+.sw-visual-page__editor {
+	padding: var(--sw-space-1) var(--sw-space-2);
+	border: var(--sw-vw-rule);
+	border-radius: var(--sw-radius-pill);
+	background: var(--sw-surface-raised);
+	font-family: var(--sw-font-mono);
+	font-size: var(--sw-text-xs);
+}
+
+.sw-visual-page__header-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--sw-space-2);
+	align-items: center;
+}
+
+.sw-visual-page__adapter {
+	font-size: var(--sw-text-sm);
+	color: var(--sw-text-secondary);
+}
+
+.sw-visual-page__status {
+	min-height: 1.5em;
+	margin: var(--sw-space-3) 0 0;
+	font-size: var(--sw-text-sm);
+	color: var(--sw-text-secondary);
+}
+
+/* ============ Body ============ */
+
+.sw-visual-page__body {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: var(--sw-space-4);
+	margin-top: var(--sw-space-4);
+}
+
+.sw-visual-page__canvas,
+.sw-visual-page__inspector {
+	padding: var(--sw-space-4);
+	border: var(--sw-vw-rule);
+	border-radius: var(--sw-vw-radius);
+	background: var(--sw-surface);
+}
+
+.sw-visual-page__inspector-heading {
+	margin: 0 0 var(--sw-space-3);
+	font-family: var(--sw-vw-serif);
+	font-size: var(--sw-text-lg);
+	font-weight: 600;
+	color: var(--sw-text);
+}
+
+.sw-visual-page__placeholder {
+	margin: 0;
+	font-size: var(--sw-text-sm);
+	color: var(--sw-text-secondary);
+}
+
+/* ============ Picker ============ */
+
+.sw-visual-picker {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--sw-space-2);
+	align-items: flex-end;
+	padding: var(--sw-space-4);
+	border: var(--sw-vw-rule);
+	border-radius: var(--sw-vw-radius);
+	background: var(--sw-surface);
+}
+
+.sw-visual-picker label {
+	flex-basis: 100%;
+	font-size: var(--sw-text-sm);
+	font-weight: 600;
+	color: var(--sw-text);
+}
+
+.sw-visual-picker__input {
+	width: 10rem;
+	padding: var(--sw-space-2);
+	border: 1px solid var(--sw-border-strong);
+	border-radius: var(--sw-vw-radius-sm);
+	background: var(--sw-bg);
+	color: var(--sw-text);
+	font-family: var(--sw-font-mono);
+}
+
+.sw-visual-picker__hint {
+	margin: var(--sw-space-3) 0 0;
+	font-size: var(--sw-text-sm);
+	color: var(--sw-text-secondary);
+}
+
+/* ============ Workspace regions rendered by the browser bundle ============ */
+
+.sw-visual__viewports {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--sw-space-2);
+	margin: 0 0 var(--sw-space-3);
+}
+
+.sw-visual__viewport {
+	padding: var(--sw-space-1) var(--sw-space-3);
+	border: var(--sw-vw-rule);
+	border-radius: var(--sw-radius-pill);
+	background: var(--sw-surface-raised);
+	color: var(--sw-text);
+	font-size: var(--sw-text-sm);
+	cursor: pointer;
+	transition: background var(--sw-dur) var(--sw-ease);
+}
+
+.sw-visual__viewport[aria-pressed='true'] {
+	border-color: var(--sw-border-strong);
+	background: var(--sw-brand-fill);
+	color: var(--sw-on-brand);
+}
+
+.sw-visual__evidence,
+.sw-visual-confirm {
+	display: block;
+	margin: 0 0 var(--sw-space-3);
+	font-size: var(--sw-text-sm);
+}
+
+.sw-visual__evidence-row,
+.sw-visual-confirm__row {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--sw-space-2);
+	padding: var(--sw-space-2) 0;
+	border-bottom: var(--sw-vw-rule);
+}
+
+.sw-visual__evidence-row[data-status='fail'] {
+	color: var(--sw-danger-text);
+}
+
+.sw-visual__evidence-row[data-status='pass'] {
+	color: var(--sw-ok-text);
+}
+
+.sw-visual__evidence-row[data-status='not_checked'] {
+	color: var(--sw-text-secondary);
+}
+
+.sw-visual-confirm__warning {
+	padding: var(--sw-space-2) var(--sw-space-3);
+	border-radius: var(--sw-vw-radius-sm);
+	background: var(--sw-danger-soft);
+	color: var(--sw-danger-text);
+}
+
+.sw-visual-confirm__actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--sw-space-2);
+	margin-top: var(--sw-space-3);
+}
+
+.sw-visual-confirm__actions button[disabled] {
+	background: var(--sw-disabled-bg);
+	color: var(--sw-disabled-fg);
+	cursor: not-allowed;
+}
+
+/* ============ Two columns once there is room ============ */
+
+@media (min-width: 1025px) {
+	.sw-visual-page__body {
+		grid-template-columns: minmax(0, 1fr) 22rem;
+		align-items: start;
+	}
+
+	.sw-visual-page__inspector-toggle {
+		display: none;
+	}
+}
+
+/* ============ Drawer below 1024px ============ */
+
+@media (max-width: 1024px) {
+	.sw-visual-page__inspector {
+		position: fixed;
+		z-index: 100;
+		top: var(--sw-shell-offset, 0);
+		right: 0;
+		bottom: 0;
+		width: min(24rem, 100%);
+		overflow-y: auto;
+		border-radius: 0;
+		border-left: var(--sw-vw-rule);
+		box-shadow: var(--sw-shadow-3);
+		transform: translateX(100%);
+		transition: transform var(--sw-dur) var(--sw-ease);
+	}
+
+	.sw-visual-page__inspector.is-open {
+		transform: translateX(0);
+	}
+
+	.sw-visual-page__inspector[hidden] {
+		display: none;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.sw-visual-page__inspector,
+	.sw-visual__viewport {
+		transition: none;
+	}
+}

--- a/plugin/assets/admin/visual-workspace.js
+++ b/plugin/assets/admin/visual-workspace.js
@@ -1,0 +1,119 @@
+/**
+ * Visual Workspace page chrome.
+ *
+ * The browser bundle owns the workspace itself: adapter resolution, proposed
+ * operations, confirmation, and verification. This file owns only the parts of
+ * the page that must keep working when the bundle is absent — the inspector
+ * drawer on narrow viewports, its keyboard contract, and focus restoration.
+ */
+( function () {
+	'use strict';
+
+	var NARROW = '(max-width: 1024px)';
+
+	function ready( fn ) {
+		if ( 'loading' === document.readyState ) {
+			document.addEventListener( 'DOMContentLoaded', fn, { once: true } );
+		} else {
+			fn();
+		}
+	}
+
+	function initInspectorDrawer() {
+		var toggle = document.querySelector( '[data-sw-visual-inspector-toggle]' );
+		var inspector = document.querySelector( '[data-sw-visual-inspector]' );
+
+		if ( ! toggle || ! inspector ) {
+			return;
+		}
+
+		var narrow = window.matchMedia ? window.matchMedia( NARROW ) : null;
+		var lastFocus = null;
+
+		function isDrawer() {
+			return null !== narrow && narrow.matches;
+		}
+
+		function setOpen( open ) {
+			toggle.setAttribute( 'aria-expanded', open ? 'true' : 'false' );
+			inspector.classList.toggle( 'is-open', open );
+
+			if ( isDrawer() ) {
+				inspector.setAttribute( 'role', 'dialog' );
+				inspector.setAttribute( 'aria-modal', open ? 'true' : 'false' );
+				if ( open ) {
+					inspector.removeAttribute( 'hidden' );
+				} else {
+					inspector.setAttribute( 'hidden', '' );
+				}
+			} else {
+				inspector.removeAttribute( 'role' );
+				inspector.removeAttribute( 'aria-modal' );
+				inspector.removeAttribute( 'hidden' );
+			}
+		}
+
+		function open() {
+			lastFocus = document.activeElement;
+			setOpen( true );
+			inspector.setAttribute( 'tabindex', '-1' );
+			inspector.focus();
+		}
+
+		function close() {
+			setOpen( false );
+			if ( lastFocus && 'function' === typeof lastFocus.focus ) {
+				lastFocus.focus();
+			} else {
+				toggle.focus();
+			}
+			lastFocus = null;
+		}
+
+		function isOpen() {
+			return 'true' === toggle.getAttribute( 'aria-expanded' );
+		}
+
+		toggle.addEventListener( 'click', function ( event ) {
+			event.preventDefault();
+			if ( isOpen() ) {
+				close();
+			} else {
+				open();
+			}
+		} );
+
+		document.addEventListener( 'keydown', function ( event ) {
+			if ( 'Escape' === event.key && isOpen() && isDrawer() ) {
+				event.preventDefault();
+				close();
+			}
+		} );
+
+		function syncToViewport() {
+			// On a wide viewport the inspector is a permanent column: no drawer
+			// semantics, always visible, and the toggle only reports state.
+			if ( isDrawer() ) {
+				setOpen( isOpen() );
+			} else {
+				setOpen( true );
+			}
+		}
+
+		if ( narrow ) {
+			if ( 'function' === typeof narrow.addEventListener ) {
+				narrow.addEventListener( 'change', syncToViewport );
+			} else if ( 'function' === typeof narrow.addListener ) {
+				narrow.addListener( syncToViewport );
+			}
+		}
+
+		if ( isDrawer() ) {
+			setOpen( false );
+		} else {
+			setOpen( true );
+		}
+	}
+
+	ready( initInspectorDrawer );
+}() );

--- a/plugin/includes/Admin/AdminBootstrap.php
+++ b/plugin/includes/Admin/AdminBootstrap.php
@@ -8,6 +8,7 @@ use Stonewright\WpMcp\Admin\Pages\DesignStudioPage;
 use Stonewright\WpMcp\Admin\Pages\PromptLibraryPage;
 use Stonewright\WpMcp\Admin\Pages\SandboxLibraryPage;
 use Stonewright\WpMcp\Admin\Pages\StatusPage;
+use Stonewright\WpMcp\Admin\Pages\VisualWorkspacePage;
 use Stonewright\WpMcp\Admin\RestApi;
 use Stonewright\WpMcp\Sandbox\CrashRecovery;
 
@@ -34,6 +35,7 @@ final class AdminBootstrap {
 
 		StatusPage::register();
 		DesignStudioPage::register();
+		VisualWorkspacePage::register();
 		BlueprintsPage::register();
 		PromptLibraryPage::register();
 		SandboxLibraryPage::register();
@@ -168,6 +170,7 @@ final class AdminBootstrap {
 			'stonewright-memory'        => 'skills-memory.css',
 			'stonewright-sandbox'       => 'sandbox.css',
 			'stonewright-design-studio' => 'design-studio.css',
+			'stonewright-visual-workspace' => 'visual-workspace.css',
 		];
 
 		if ( isset( $page_styles[ $page ] ) ) {
@@ -236,6 +239,41 @@ final class AdminBootstrap {
 				'stonewrightDesignStudio',
 				DesignStudioPage::boot_payload()
 			);
+		}
+
+		// The workspace page chrome — the inspector drawer and its focus
+		// handling — works with or without the browser bundle.
+		if ( VisualWorkspacePage::SLUG === $page ) {
+			wp_enqueue_script(
+				'stonewright-admin-visual-workspace',
+				$url_base . 'assets/admin/visual-workspace.js',
+				[ 'stonewright-admin' ],
+				$version,
+				true
+			);
+
+			// The Stonewright Visual browser bundle is built from the `visual`
+			// package and staged during packaging, so a source checkout does
+			// not carry it. The page reports that instead of requesting a file
+			// that is not there.
+			if ( VisualWorkspacePage::bundle_ready( VisualWorkspacePage::bundle_path() ) ) {
+				wp_enqueue_script(
+					'stonewright-visual-workspace',
+					$url_base . 'assets/visual/workspace-browser.js',
+					[ 'stonewright-admin-visual-workspace' ],
+					$version,
+					true
+				);
+
+				wp_localize_script(
+					'stonewright-visual-workspace',
+					'stonewrightVisualWorkspace',
+					VisualWorkspacePage::boot_payload(
+						VisualWorkspacePage::current_post_id(),
+						VisualWorkspacePage::requested_editor()
+					)
+				);
+			}
 		}
 
 		// The skill lifecycle app and its boot payload load on that page only.

--- a/plugin/includes/Admin/AdminShell.php
+++ b/plugin/includes/Admin/AdminShell.php
@@ -63,9 +63,10 @@ final class AdminShell {
 				'id'    => 'design-library',
 				'label' => __( 'Design Library', 'stonewright' ),
 				'pages' => [
-					'stonewright-design-studio' => __( 'Design Studio', 'stonewright' ),
-					'stonewright-blueprints'    => __( 'Blueprints', 'stonewright' ),
-					'stonewright-prompts'       => __( 'Prompts', 'stonewright' ),
+					'stonewright-design-studio'    => __( 'Design Studio', 'stonewright' ),
+					'stonewright-visual-workspace' => __( 'Visual Workspace', 'stonewright' ),
+					'stonewright-blueprints'       => __( 'Blueprints', 'stonewright' ),
+					'stonewright-prompts'          => __( 'Prompts', 'stonewright' ),
 				],
 			],
 			[

--- a/plugin/includes/Admin/Pages/DesignStudioPage.php
+++ b/plugin/includes/Admin/Pages/DesignStudioPage.php
@@ -64,14 +64,17 @@ final class DesignStudioPage {
 		$active  = $service->active();
 
 		return [
-			'restRoot'        => rest_url( DesignStudioRestApi::REST_NAMESPACE . DesignStudioRestApi::ROUTE_PREFIX ),
-			'nonce'           => wp_create_nonce( DesignStudioRestApi::NONCE_ACTION ),
-			'view'            => self::current_view(),
-			'views'           => self::VIEWS,
-			'activeDirection' => is_array( $active )
+			'restRoot'           => rest_url( DesignStudioRestApi::REST_NAMESPACE . DesignStudioRestApi::ROUTE_PREFIX ),
+			'nonce'              => wp_create_nonce( DesignStudioRestApi::NONCE_ACTION ),
+			'view'               => self::current_view(),
+			'views'              => self::VIEWS,
+			// The quality view appends `post_id` and `editor` to this base so a
+			// finding can be opened in the workspace that produced it.
+			'visualWorkspaceUrl' => VisualWorkspacePage::url(),
+			'activeDirection'    => is_array( $active )
 				? DirectionSummary::row( $active, (int) ( $active['id'] ?? 0 ) )
 				: null,
-			'can'             => [
+			'can'                => [
 				'manageOptions' => Permissions::manage_options(),
 				'manageDesign'  => Permissions::can_manage_design(),
 			],

--- a/plugin/includes/Admin/Pages/VisualWorkspacePage.php
+++ b/plugin/includes/Admin/Pages/VisualWorkspacePage.php
@@ -273,7 +273,7 @@ final class VisualWorkspacePage {
 	 */
 	private static function render_workspace( int $post_id ): void {
 		$post    = get_post( $post_id );
-		$title   = is_object( $post ) && isset( $post->post_title ) ? (string) $post->post_title : '';
+		$title   = is_object( $post ) && property_exists( $post, 'post_title' ) ? (string) $post->post_title : '';
 		$context = self::editor_context( $post_id );
 		$edit    = (string) get_edit_post_link( $post_id, 'url' );
 		$ready   = self::bundle_ready( self::bundle_path() );

--- a/plugin/includes/Admin/Pages/VisualWorkspacePage.php
+++ b/plugin/includes/Admin/Pages/VisualWorkspacePage.php
@@ -1,0 +1,359 @@
+<?php
+declare( strict_types=1 );
+
+namespace Stonewright\WpMcp\Admin\Pages;
+
+use Stonewright\WpMcp\Admin\AdminShell;
+use Stonewright\WpMcp\Admin\DesignStudioRestApi;
+use Stonewright\WpMcp\Design\Direction\DesignDirectionService;
+use Stonewright\WpMcp\Design\Direction\DirectionSummary;
+use Stonewright\WpMcp\Security\Permissions;
+
+/**
+ * The admin host for the Stonewright Visual workspace.
+ *
+ * The page owns no editor knowledge. It answers three questions before the
+ * browser bundle boots — which post is being worked on, whether the current
+ * user may edit it, and which builder the post uses — then renders the three
+ * regions the bundle mounts into. Everything after that is the bundle's job:
+ * it resolves the live editor adapter, proposes operations, asks for explicit
+ * confirmation, and reads verification evidence back from the quality route.
+ *
+ * The active design direction reaches the bundle as a summary that carries the
+ * contract hash. The contract itself stays on the server: the workspace needs
+ * to prove which direction it is working under, not to re-read its source.
+ */
+final class VisualWorkspacePage {
+
+	public const SLUG = 'stonewright-visual-workspace';
+
+	/**
+	 * Menu capability. Per-post authority is checked separately, because a
+	 * user who may edit some posts may not edit the one in the URL.
+	 */
+	public const CAPABILITY = 'edit_posts';
+
+	/**
+	 * Editor kinds a caller may pin through the URL. `auto` means the bundle
+	 * detects the live editor itself, which is the honest default: only the
+	 * browser can see which editor actually loaded.
+	 */
+	public const EDITOR_KINDS = [ 'auto', 'elementor-v3', 'elementor-v4', 'gutenberg' ];
+
+	private const BUNDLE_RELATIVE = 'assets/visual/workspace-browser.js';
+
+	public static function register(): void {
+		add_action( 'admin_menu', [ self::class, 'add_submenu' ] );
+	}
+
+	public static function add_submenu(): void {
+		add_submenu_page(
+			'stonewright',
+			__( 'Visual Workspace', 'stonewright' ),
+			__( 'Visual Workspace', 'stonewright' ),
+			self::CAPABILITY,
+			self::SLUG,
+			[ self::class, 'render' ]
+		);
+	}
+
+	/**
+	 * The post the workspace targets, or 0 when the URL names none.
+	 *
+	 * Anything that is not a plain positive integer is treated as absent
+	 * rather than coerced, so `9 OR 1=1` and `4.5` both land on the picker.
+	 */
+	public static function current_post_id(): int {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only target selector.
+		$raw = isset( $_GET['post_id'] ) ? sanitize_text_field( (string) wp_unslash( $_GET['post_id'] ) ) : '';
+
+		if ( 1 !== preg_match( '/^[1-9][0-9]*$/', $raw ) ) {
+			return 0;
+		}
+
+		return (int) $raw;
+	}
+
+	/**
+	 * The editor kind requested through the URL, falling back to detection.
+	 */
+	public static function requested_editor(): string {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only editor hint.
+		$raw = isset( $_GET['editor'] ) ? sanitize_key( (string) wp_unslash( $_GET['editor'] ) ) : '';
+
+		return in_array( $raw, self::EDITOR_KINDS, true ) ? $raw : 'auto';
+	}
+
+	/**
+	 * Admin URL for the workspace, optionally pinned to a post and an editor.
+	 */
+	public static function url( int $post_id = 0, string $editor = 'auto' ): string {
+		$url = admin_url( 'admin.php?page=' . rawurlencode( self::SLUG ) );
+
+		if ( $post_id > 0 ) {
+			$url .= '&post_id=' . rawurlencode( (string) $post_id );
+		}
+
+		if ( in_array( $editor, self::EDITOR_KINDS, true ) && 'auto' !== $editor ) {
+			$url .= '&editor=' . rawurlencode( $editor );
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Everything the browser bundle needs to boot.
+	 *
+	 * @param int                        $post_id Target post.
+	 * @param string                     $editor  Requested editor kind.
+	 * @param DesignDirectionService|null $service Injected for tests.
+	 * @return array<string, mixed>
+	 */
+	public static function boot_payload( int $post_id, string $editor = 'auto', ?DesignDirectionService $service = null ): array {
+		$service = $service ?? new DesignDirectionService();
+		$active  = $service->active();
+
+		return [
+			'restBase'   => rest_url( DesignStudioRestApi::REST_NAMESPACE ),
+			'nonce'      => wp_create_nonce( DesignStudioRestApi::NONCE_ACTION ),
+			'postId'     => $post_id,
+			'editorKind' => in_array( $editor, self::EDITOR_KINDS, true ) ? $editor : 'auto',
+			'direction'  => self::direction_summary( is_array( $active ) ? $active : null ),
+			'can'        => [
+				'editPost'     => Permissions::can_edit_post( $post_id ),
+				'manageDesign' => Permissions::can_manage_design(),
+			],
+		];
+	}
+
+	/**
+	 * Projection of the active direction record for the workspace.
+	 *
+	 * `DirectionSummary::row()` returns identity, status, and the contract
+	 * hash — never the contract. The workspace shows which direction is in
+	 * force and can prove the revision; it does not re-derive design rules in
+	 * the browser.
+	 *
+	 * @param array<string, mixed>|null $record Stored direction record.
+	 * @return array<string, mixed>|null
+	 */
+	public static function direction_summary( ?array $record ): ?array {
+		if ( null === $record ) {
+			return null;
+		}
+
+		return DirectionSummary::row( $record, (int) ( $record['id'] ?? 0 ) );
+	}
+
+	/**
+	 * Which builder owns the post, resolved on the server.
+	 *
+	 * This is context for the header, not a decision: the bundle still detects
+	 * the adapter from the live editor, because a post can be opened in either
+	 * editor regardless of what its meta says.
+	 *
+	 * @return array{builder: string, label: string}
+	 */
+	public static function editor_context( int $post_id ): array {
+		if ( $post_id <= 0 || null === get_post( $post_id ) ) {
+			return [
+				'builder' => 'unknown',
+				'label'   => __( 'No post selected', 'stonewright' ),
+			];
+		}
+
+		$mode = (string) get_post_meta( $post_id, '_elementor_edit_mode', true );
+
+		if ( 'builder' === $mode ) {
+			return [
+				'builder' => 'elementor',
+				'label'   => __( 'Elementor', 'stonewright' ),
+			];
+		}
+
+		return [
+			'builder' => 'block-editor',
+			'label'   => __( 'Block editor', 'stonewright' ),
+		];
+	}
+
+	/**
+	 * Absolute path of the packaged browser bundle.
+	 *
+	 * The bundle is built from `visual/` and staged into the plugin during
+	 * packaging, so it is absent from a plain source checkout.
+	 */
+	public static function bundle_path(): string {
+		$base = defined( 'STONEWRIGHT_PATH' ) ? (string) constant( 'STONEWRIGHT_PATH' ) : dirname( __DIR__, 3 ) . '/';
+
+		return rtrim( $base, '/' ) . '/' . self::BUNDLE_RELATIVE;
+	}
+
+	/**
+	 * True when a non-empty, readable bundle is on disk.
+	 */
+	public static function bundle_ready( string $path ): bool {
+		return is_file( $path ) && is_readable( $path ) && filesize( $path ) > 0;
+	}
+
+	public static function render(): void {
+		if ( ! current_user_can( self::CAPABILITY ) ) {
+			wp_die(
+				esc_html__( 'You do not have permission to view this page.', 'stonewright' ),
+				esc_html__( 'Forbidden', 'stonewright' ),
+				[ 'response' => 403 ]
+			);
+		}
+
+		$post_id = self::current_post_id();
+
+		if ( $post_id > 0 && ! Permissions::can_edit_post( $post_id ) ) {
+			wp_die(
+				esc_html__( 'You do not have permission to edit this post.', 'stonewright' ),
+				esc_html__( 'Forbidden', 'stonewright' ),
+				[ 'response' => 403 ]
+			);
+		}
+
+		AdminShell::open( self::SLUG );
+
+		if ( 0 === $post_id ) {
+			self::render_picker();
+			AdminShell::close();
+
+			return;
+		}
+
+		self::render_workspace( $post_id );
+		AdminShell::close();
+	}
+
+	/**
+	 * Shown when the URL names no usable post.
+	 */
+	private static function render_picker(): void {
+		?>
+		<div class="sw-visual-page" data-sw-visual-picker>
+			<div class="stonewright-page-header">
+				<div>
+					<h1><?php esc_html_e( 'Visual Workspace', 'stonewright' ); ?></h1>
+					<p><?php esc_html_e( 'Open a post in its editor, then work on it here with the active design direction, an explicit confirmation step, and evidence read back from the quality reports.', 'stonewright' ); ?></p>
+				</div>
+			</div>
+
+			<form class="sw-visual-picker" method="get" action="<?php echo esc_url( admin_url( 'admin.php' ) ); ?>">
+				<input type="hidden" name="page" value="<?php echo esc_attr( self::SLUG ); ?>" />
+				<label for="sw-visual-post-id"><?php esc_html_e( 'Post id', 'stonewright' ); ?></label>
+				<input
+					id="sw-visual-post-id"
+					class="sw-visual-picker__input"
+					type="number"
+					name="post_id"
+					min="1"
+					step="1"
+					required
+					inputmode="numeric"
+				/>
+				<button type="submit" class="sw-button sw-button--primary"><?php esc_html_e( 'Open workspace', 'stonewright' ); ?></button>
+			</form>
+
+			<p class="sw-visual-picker__hint">
+				<?php esc_html_e( 'The Design Studio quality view links straight here once you load reports for a post.', 'stonewright' ); ?>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * The three regions the browser bundle mounts into.
+	 *
+	 * Server-rendered content stays outside the bundle's slots, so the page
+	 * still states what it is about when the bundle is missing or JavaScript
+	 * is off.
+	 */
+	private static function render_workspace( int $post_id ): void {
+		$post    = get_post( $post_id );
+		$title   = is_object( $post ) && isset( $post->post_title ) ? (string) $post->post_title : '';
+		$context = self::editor_context( $post_id );
+		$edit    = (string) get_edit_post_link( $post_id, 'url' );
+		$ready   = self::bundle_ready( self::bundle_path() );
+		?>
+		<div
+			class="sw-visual-page"
+			data-sw-visual-workspace
+			data-sw-post-id="<?php echo esc_attr( (string) $post_id ); ?>"
+			data-sw-visual-editor="<?php echo esc_attr( $context['builder'] ); ?>"
+		>
+			<header class="sw-visual-page__header" data-sw-visual-header>
+				<div class="sw-visual-page__identity">
+					<h1><?php esc_html_e( 'Visual Workspace', 'stonewright' ); ?></h1>
+					<p class="sw-visual-page__post">
+						<?php if ( '' !== $title ) : ?>
+							<span class="sw-visual-page__post-title"><?php echo esc_html( $title ); ?></span>
+						<?php endif; ?>
+						<span class="sw-visual-page__post-id">
+							<?php
+							printf(
+								/* translators: %d: post id */
+								esc_html__( 'Post %d', 'stonewright' ),
+								(int) $post_id
+							);
+							?>
+						</span>
+						<span class="sw-visual-page__editor"><?php echo esc_html( $context['label'] ); ?></span>
+					</p>
+				</div>
+
+				<div class="sw-visual-page__header-actions">
+					<div class="sw-visual-page__adapter" data-sw-visual-adapter></div>
+					<?php if ( '' !== $edit ) : ?>
+						<a class="sw-button" href="<?php echo esc_url( $edit ); ?>"><?php esc_html_e( 'Open editor', 'stonewright' ); ?></a>
+					<?php endif; ?>
+					<button
+						type="button"
+						class="sw-button sw-visual-page__inspector-toggle"
+						data-sw-visual-inspector-toggle
+						aria-controls="sw-visual-inspector"
+						aria-expanded="false"
+					><?php esc_html_e( 'Inspector', 'stonewright' ); ?></button>
+				</div>
+			</header>
+
+			<p class="sw-visual-page__status" data-sw-visual-status role="status" aria-live="polite"></p>
+
+			<div class="sw-visual-page__body">
+				<section class="sw-visual-page__canvas" data-sw-visual-canvas aria-label="<?php esc_attr_e( 'Evidence canvas', 'stonewright' ); ?>">
+					<div data-sw-visual-workspace-canvas>
+						<p class="sw-visual-page__placeholder"><?php esc_html_e( 'Connecting to the editor…', 'stonewright' ); ?></p>
+					</div>
+				</section>
+
+				<aside
+					id="sw-visual-inspector"
+					class="sw-visual-page__inspector"
+					data-sw-visual-inspector
+					aria-label="<?php esc_attr_e( 'Inspector', 'stonewright' ); ?>"
+				>
+					<h2 class="sw-visual-page__inspector-heading"><?php esc_html_e( 'Inspector', 'stonewright' ); ?></h2>
+					<div data-sw-visual-workspace-inspector>
+						<p class="sw-visual-page__placeholder"><?php esc_html_e( 'The active direction, the proposed changes, and the verification receipt appear here.', 'stonewright' ); ?></p>
+					</div>
+				</aside>
+			</div>
+
+			<?php if ( ! $ready ) : ?>
+				<div class="sw-empty-state" data-sw-visual-missing>
+					<p><?php esc_html_e( 'The Stonewright Visual browser bundle is not present in this install. It is built from the visual package and staged during packaging; a source checkout does not carry it.', 'stonewright' ); ?></p>
+					<p><code>npm ci &amp;&amp; npm run build</code></p>
+				</div>
+			<?php endif; ?>
+
+			<noscript>
+				<div class="sw-empty-state">
+					<p><?php esc_html_e( 'The Visual Workspace needs JavaScript. Design directions, quality reports, and Elementor writes stay available through the Stonewright MCP abilities.', 'stonewright' ); ?></p>
+				</div>
+			</noscript>
+		</div>
+		<?php
+	}
+}

--- a/plugin/tests/Unit/Admin/VisualWorkspacePageTest.php
+++ b/plugin/tests/Unit/Admin/VisualWorkspacePageTest.php
@@ -354,13 +354,19 @@ final class VisualWorkspacePageTest extends TestCase {
 		$file = $dir . '/workspace-browser.js';
 		mkdir( $dir, 0o777, true );
 
+		// PHP caches stat results per request, and this test rewrites the same
+		// path three times. Production reads the bundle once per request, so
+		// only the test has to invalidate the cache between states.
 		try {
+			clearstatcache( true, $file );
 			self::assertFalse( VisualWorkspacePage::bundle_ready( $file ), 'A missing bundle is not ready.' );
 
 			file_put_contents( $file, '' );
+			clearstatcache( true, $file );
 			self::assertFalse( VisualWorkspacePage::bundle_ready( $file ), 'An empty bundle is not ready.' );
 
 			file_put_contents( $file, 'var StonewrightVisual = (() => {})();' );
+			clearstatcache( true, $file );
 			self::assertTrue( VisualWorkspacePage::bundle_ready( $file ) );
 		} finally {
 			if ( is_file( $file ) ) {

--- a/plugin/tests/Unit/Admin/VisualWorkspacePageTest.php
+++ b/plugin/tests/Unit/Admin/VisualWorkspacePageTest.php
@@ -1,0 +1,508 @@
+<?php
+declare( strict_types=1 );
+
+namespace Stonewright\WpMcp\Tests\Unit\Admin;
+
+use PHPUnit\Framework\TestCase;
+use Stonewright\WpMcp\Admin\AdminShell;
+use Stonewright\WpMcp\Admin\Pages\VisualWorkspacePage;
+
+/**
+ * Contract for the admin host of the Stonewright Visual workspace.
+ *
+ * The page owns no editor logic. It resolves which post the workspace targets,
+ * proves the current user may edit that post, renders the three regions the
+ * browser bundle mounts into, and hands the bundle a boot payload that carries
+ * the active direction's hash rather than its contract.
+ *
+ * The enqueue path itself calls `wp_localize_script()`, which the unit harness
+ * does not stub, so the page-scoping guarantees are asserted by reading the
+ * shipped `AdminBootstrap` source — the same approach `DesignStudioAssetsTest`
+ * takes.
+ *
+ * @covers \Stonewright\WpMcp\Admin\Pages\VisualWorkspacePage
+ */
+final class VisualWorkspacePageTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['stonewright_test_user_caps']       = [
+			'edit_posts' => true,
+			'edit_post'  => true,
+		];
+		$GLOBALS['stonewright_test_current_user_id'] = 7;
+		$GLOBALS['stonewright_test_user_logged_in']  = true;
+		$GLOBALS['stonewright_test_options']         = [];
+		$GLOBALS['stonewright_test_user_meta']       = [];
+		$GLOBALS['stonewright_test_submenu_pages']   = [];
+		$GLOBALS['stonewright_test_posts']           = [];
+		unset( $_GET['post_id'], $_GET['editor'] );
+	}
+
+	protected function tearDown(): void {
+		$GLOBALS['stonewright_test_user_caps']       = [];
+		$GLOBALS['stonewright_test_current_user_id'] = 0;
+		$GLOBALS['stonewright_test_user_logged_in']  = false;
+		$GLOBALS['stonewright_test_options']         = [];
+		$GLOBALS['stonewright_test_user_meta']       = [];
+		$GLOBALS['stonewright_test_submenu_pages']   = [];
+		$GLOBALS['stonewright_test_posts']           = [];
+		unset( $_GET['post_id'], $_GET['editor'] );
+	}
+
+	private static function plugin_dir(): string {
+		return dirname( __DIR__, 3 );
+	}
+
+	private static function css(): string {
+		return (string) file_get_contents( self::plugin_dir() . '/assets/admin/visual-workspace.css' );
+	}
+
+	private static function bootstrap(): string {
+		return (string) file_get_contents( self::plugin_dir() . '/includes/Admin/AdminBootstrap.php' );
+	}
+
+	/**
+	 * Registers a fake post the capability and editor-context helpers can read.
+	 *
+	 * @param array<string, mixed> $meta Post meta to expose.
+	 */
+	private function fake_post( int $id, array $meta = [] ): void {
+		$post                                       = new \stdClass();
+		$post->ID                                   = $id;
+		$post->post_title                           = 'Landing page';
+		$post->post_type                            = 'page';
+		$post->post_status                          = 'publish';
+		$post->meta                                 = $meta;
+		$GLOBALS['stonewright_test_posts'][ $id ]   = $post;
+	}
+
+	// -----------------------------------------------------------------
+	// Identity and navigation
+	// -----------------------------------------------------------------
+
+	public function test_slug_and_capability_are_stable(): void {
+		self::assertSame( 'stonewright-visual-workspace', VisualWorkspacePage::SLUG );
+		self::assertSame( 'edit_posts', VisualWorkspacePage::CAPABILITY );
+	}
+
+	public function test_submenu_registers_under_stonewright_with_the_edit_capability(): void {
+		VisualWorkspacePage::add_submenu();
+
+		$registered = $GLOBALS['stonewright_test_submenu_pages'][ VisualWorkspacePage::SLUG ] ?? null;
+
+		self::assertIsArray( $registered );
+		self::assertSame( 'stonewright', $registered['parent'] );
+		self::assertSame( 'edit_posts', $registered['capability'] );
+	}
+
+	public function test_the_workspace_sits_next_to_the_design_studio_in_the_shell(): void {
+		$slugs = array_keys( AdminShell::pages() );
+
+		self::assertContains( VisualWorkspacePage::SLUG, $slugs );
+		self::assertSame(
+			array_search( 'stonewright-design-studio', $slugs, true ) + 1,
+			array_search( VisualWorkspacePage::SLUG, $slugs, true ),
+			'The workspace is the second entry of the design group, right after the Design Studio.'
+		);
+	}
+
+	// -----------------------------------------------------------------
+	// Request parsing
+	// -----------------------------------------------------------------
+
+	public function test_a_missing_post_id_resolves_to_zero(): void {
+		self::assertSame( 0, VisualWorkspacePage::current_post_id() );
+	}
+
+	/**
+	 * @dataProvider provide_rejected_post_ids
+	 */
+	public function test_only_positive_integers_are_accepted_as_post_ids( string $raw ): void {
+		$_GET['post_id'] = $raw;
+
+		self::assertSame( 0, VisualWorkspacePage::current_post_id() );
+	}
+
+	/**
+	 * @return array<string, array{0: string}>
+	 */
+	public static function provide_rejected_post_ids(): array {
+		return [
+			'zero'      => [ '0' ],
+			'negative'  => [ '-12' ],
+			'text'      => [ 'latest' ],
+			'empty'     => [ '' ],
+			'float'     => [ '4.5' ],
+			'injection' => [ '9 OR 1=1' ],
+		];
+	}
+
+	public function test_a_positive_post_id_survives_parsing(): void {
+		$_GET['post_id'] = '412';
+
+		self::assertSame( 412, VisualWorkspacePage::current_post_id() );
+	}
+
+	public function test_the_editor_parameter_is_an_allowlist_defaulting_to_auto(): void {
+		self::assertSame( 'auto', VisualWorkspacePage::requested_editor() );
+
+		$_GET['editor'] = 'gutenberg';
+		self::assertSame( 'gutenberg', VisualWorkspacePage::requested_editor() );
+
+		$_GET['editor'] = 'wordpad';
+		self::assertSame( 'auto', VisualWorkspacePage::requested_editor(), 'Unknown editors fall back to runtime detection.' );
+	}
+
+	public function test_the_url_helper_carries_the_post_and_the_editor_context(): void {
+		$url = VisualWorkspacePage::url( 412, 'elementor-v3' );
+
+		self::assertStringContainsString( 'page=stonewright-visual-workspace', $url );
+		self::assertStringContainsString( 'post_id=412', $url );
+		self::assertStringContainsString( 'editor=elementor-v3', $url );
+	}
+
+	public function test_the_url_helper_omits_an_unusable_post_id(): void {
+		$url = VisualWorkspacePage::url( 0, 'auto' );
+
+		self::assertStringContainsString( 'page=stonewright-visual-workspace', $url );
+		self::assertStringNotContainsString( 'post_id=', $url );
+	}
+
+	// -----------------------------------------------------------------
+	// Capability
+	// -----------------------------------------------------------------
+
+	public function test_render_refuses_users_without_the_edit_capability(): void {
+		$GLOBALS['stonewright_test_user_caps'] = [];
+
+		$this->expectException( \RuntimeException::class );
+		VisualWorkspacePage::render();
+	}
+
+	public function test_render_refuses_a_post_the_user_may_not_edit(): void {
+		$this->fake_post( 412 );
+		$_GET['post_id'] = '412';
+
+		$GLOBALS['stonewright_test_user_can_callback'] = static function ( string $cap ): bool {
+			return 'edit_posts' === $cap;
+		};
+
+		try {
+			$this->expectException( \RuntimeException::class );
+			VisualWorkspacePage::render();
+		} finally {
+			unset( $GLOBALS['stonewright_test_user_can_callback'] );
+		}
+	}
+
+	public function test_render_asks_for_a_post_instead_of_dying_when_none_was_given(): void {
+		ob_start();
+		VisualWorkspacePage::render();
+		$html = (string) ob_get_clean();
+
+		self::assertStringContainsString( 'data-sw-visual-picker', $html );
+		self::assertStringNotContainsString( 'data-sw-visual-workspace', $html, 'Nothing mounts until a post is chosen.' );
+	}
+
+	// -----------------------------------------------------------------
+	// Boot payload
+	// -----------------------------------------------------------------
+
+	public function test_boot_payload_carries_everything_the_bundle_needs(): void {
+		$this->fake_post( 412 );
+		$payload = VisualWorkspacePage::boot_payload( 412, 'auto', null );
+
+		foreach ( [ 'restBase', 'nonce', 'postId', 'editorKind', 'direction', 'can' ] as $key ) {
+			self::assertArrayHasKey( $key, $payload );
+		}
+
+		self::assertStringContainsString( 'stonewright/v1', (string) $payload['restBase'] );
+		self::assertStringNotContainsString( 'design-studio', (string) $payload['restBase'], 'The bundle appends its own route segment.' );
+		self::assertNotSame( '', (string) $payload['nonce'] );
+		self::assertSame( 412, $payload['postId'] );
+		self::assertSame( 'auto', $payload['editorKind'] );
+		self::assertArrayHasKey( 'editPost', $payload['can'] );
+		self::assertArrayHasKey( 'manageDesign', $payload['can'] );
+	}
+
+	public function test_boot_payload_reports_no_direction_when_none_is_active(): void {
+		$payload = VisualWorkspacePage::boot_payload( 412, 'auto', null );
+
+		self::assertNull( $payload['direction'] );
+	}
+
+	public function test_the_direction_summary_passes_the_hash_and_never_the_contract(): void {
+		$summary = VisualWorkspacePage::direction_summary(
+			[
+				'id'            => 9,
+				'slug'          => 'quarry',
+				'status'        => 'active',
+				'revision'      => 4,
+				'contract_hash' => 'sha256:9f2c',
+				'source_type'   => 'authored',
+				'updated_at'    => '2026-07-24 10:00:00',
+				'contract'      => [
+					'identity' => [ 'name' => 'Quarry' ],
+					'tokens'   => [ 'color' => [ 'ink' => '#101010' ] ],
+				],
+			]
+		);
+
+		self::assertIsArray( $summary );
+		self::assertSame( 'sha256:9f2c', $summary['contract_hash'] );
+		self::assertSame( 'Quarry', $summary['name'] );
+		self::assertArrayNotHasKey( 'contract', $summary, 'The workspace receives the hash, not the source contract.' );
+		self::assertArrayNotHasKey( 'tokens', $summary );
+	}
+
+	public function test_the_direction_summary_is_null_without_an_active_record(): void {
+		self::assertNull( VisualWorkspacePage::direction_summary( null ) );
+	}
+
+	// -----------------------------------------------------------------
+	// Editor context
+	// -----------------------------------------------------------------
+
+	public function test_editor_context_reports_elementor_for_a_builder_post(): void {
+		$this->fake_post( 412, [ '_elementor_edit_mode' => 'builder' ] );
+
+		$context = VisualWorkspacePage::editor_context( 412 );
+
+		self::assertSame( 'elementor', $context['builder'] );
+		self::assertNotSame( '', $context['label'] );
+	}
+
+	public function test_editor_context_reports_the_block_editor_for_a_plain_post(): void {
+		$this->fake_post( 413 );
+
+		self::assertSame( 'block-editor', VisualWorkspacePage::editor_context( 413 )['builder'] );
+	}
+
+	public function test_editor_context_stays_unknown_for_a_missing_post(): void {
+		self::assertSame( 'unknown', VisualWorkspacePage::editor_context( 999 )['builder'] );
+	}
+
+	// -----------------------------------------------------------------
+	// Rendered regions
+	// -----------------------------------------------------------------
+
+	private function render_for_post( int $post_id ): string {
+		$this->fake_post( $post_id, [ '_elementor_edit_mode' => 'builder' ] );
+		$_GET['post_id'] = (string) $post_id;
+
+		ob_start();
+		VisualWorkspacePage::render();
+
+		return (string) ob_get_clean();
+	}
+
+	public function test_render_emits_the_three_workspace_regions(): void {
+		$html = $this->render_for_post( 412 );
+
+		self::assertStringContainsString( 'data-sw-visual-workspace', $html );
+		self::assertStringContainsString( 'data-sw-visual-header', $html );
+		self::assertStringContainsString( 'data-sw-visual-canvas', $html );
+		self::assertStringContainsString( 'data-sw-visual-inspector', $html );
+	}
+
+	public function test_render_states_the_post_and_editor_context_in_the_header(): void {
+		$html = $this->render_for_post( 412 );
+
+		self::assertStringContainsString( 'Landing page', $html );
+		self::assertStringContainsString( 'data-sw-visual-editor="elementor"', $html );
+	}
+
+	public function test_the_inspector_is_a_labelled_drawer_with_a_toggle(): void {
+		$html = $this->render_for_post( 412 );
+
+		self::assertStringContainsString( 'data-sw-visual-inspector-toggle', $html );
+		self::assertStringContainsString( 'aria-expanded=', $html );
+		self::assertStringContainsString( 'aria-controls="sw-visual-inspector"', $html );
+		self::assertStringContainsString( 'id="sw-visual-inspector"', $html );
+	}
+
+	public function test_render_announces_workspace_state_through_a_live_region(): void {
+		$html = $this->render_for_post( 412 );
+
+		self::assertStringContainsString( 'aria-live="polite"', $html );
+		self::assertStringContainsString( 'role="status"', $html );
+	}
+
+	public function test_render_carries_no_emoji_or_dingbats(): void {
+		self::assertDoesNotMatchRegularExpression(
+			'/[\x{1F300}-\x{1FAFF}\x{2190}-\x{27BF}\x{FE0F}]/u',
+			$this->render_for_post( 412 )
+		);
+	}
+
+	public function test_render_reports_a_missing_bundle_instead_of_pretending_to_work(): void {
+		$html = $this->render_for_post( 412 );
+
+		if ( VisualWorkspacePage::bundle_ready( VisualWorkspacePage::bundle_path() ) ) {
+			self::assertStringNotContainsString( 'data-sw-visual-missing', $html );
+		} else {
+			self::assertStringContainsString( 'data-sw-visual-missing', $html );
+		}
+	}
+
+	// -----------------------------------------------------------------
+	// Packaged browser bundle
+	// -----------------------------------------------------------------
+
+	public function test_bundle_readiness_needs_a_readable_non_empty_file(): void {
+		$dir  = sys_get_temp_dir() . '/sw-visual-' . uniqid( '', false );
+		$file = $dir . '/workspace-browser.js';
+		mkdir( $dir, 0o777, true );
+
+		try {
+			self::assertFalse( VisualWorkspacePage::bundle_ready( $file ), 'A missing bundle is not ready.' );
+
+			file_put_contents( $file, '' );
+			self::assertFalse( VisualWorkspacePage::bundle_ready( $file ), 'An empty bundle is not ready.' );
+
+			file_put_contents( $file, 'var StonewrightVisual = (() => {})();' );
+			self::assertTrue( VisualWorkspacePage::bundle_ready( $file ) );
+		} finally {
+			if ( is_file( $file ) ) {
+				unlink( $file );
+			}
+			rmdir( $dir );
+		}
+	}
+
+	public function test_the_bundle_path_points_at_the_packaged_asset(): void {
+		self::assertStringEndsWith( 'assets/visual/workspace-browser.js', VisualWorkspacePage::bundle_path() );
+	}
+
+	// -----------------------------------------------------------------
+	// Enqueue scoping (source-read, see class docblock)
+	// -----------------------------------------------------------------
+
+	public function test_the_browser_bundle_is_scoped_to_this_page_only(): void {
+		self::assertMatchesRegularExpression(
+			'/if \( VisualWorkspacePage::SLUG === \$page \) \{.*?assets\/visual\/workspace-browser\.js.*?wp_localize_script\(.*?stonewrightVisualWorkspace.*?\}/s',
+			self::bootstrap(),
+			'The workspace bundle and its payload load only on the workspace page.'
+		);
+	}
+
+	public function test_the_workspace_stylesheet_is_page_scoped(): void {
+		self::assertStringContainsString(
+			"'stonewright-visual-workspace' => 'visual-workspace.css'",
+			self::bootstrap()
+		);
+	}
+
+	public function test_the_page_is_registered_by_the_admin_bootstrap(): void {
+		self::assertStringContainsString( 'VisualWorkspacePage::register();', self::bootstrap() );
+	}
+
+	// -----------------------------------------------------------------
+	// Stylesheet
+	// -----------------------------------------------------------------
+
+	public function test_the_stylesheet_ships_with_the_plugin(): void {
+		self::assertFileExists( self::plugin_dir() . '/assets/admin/visual-workspace.css' );
+	}
+
+	public function test_the_stylesheet_only_uses_shared_semantic_colour_tokens(): void {
+		$css = preg_replace( '#/\*.*?\*/#s', '', self::css() );
+		$css = is_string( $css ) ? $css : '';
+
+		self::assertDoesNotMatchRegularExpression( '/#[0-9a-fA-F]{3,8}\b/', $css );
+		self::assertDoesNotMatchRegularExpression( '/\brgba?\s*\(\s*\d/', $css );
+		self::assertStringContainsString( 'var(--sw-surface', $css );
+		self::assertStringContainsString( 'var(--sw-border', $css );
+		self::assertStringContainsString( 'var(--sw-text', $css );
+	}
+
+	public function test_the_stylesheet_keeps_focus_visible_and_honours_reduced_motion(): void {
+		$css = self::css();
+
+		self::assertStringContainsString( ':focus-visible', $css );
+		self::assertStringContainsString( '@media (prefers-reduced-motion: reduce)', $css );
+	}
+
+	public function test_the_inspector_becomes_a_drawer_at_1024px_and_below(): void {
+		$css = self::css();
+
+		self::assertStringContainsString( '@media (max-width: 1024px)', $css );
+		self::assertDoesNotMatchRegularExpression(
+			'/\bmin-width:\s*(?:[4-9]\d{2}|\d{4,})px\s*;/',
+			$css,
+			'No element may claim a minimum width that overflows a 375px viewport.'
+		);
+	}
+
+	public function test_the_stylesheet_carries_no_decorative_glyphs(): void {
+		self::assertDoesNotMatchRegularExpression(
+			'/[\x{1F300}-\x{1FAFF}\x{2190}-\x{27BF}\x{FE0F}]/u',
+			self::css()
+		);
+	}
+
+	// -----------------------------------------------------------------
+	// Page chrome script
+	// -----------------------------------------------------------------
+
+	private static function js(): string {
+		return (string) file_get_contents( self::plugin_dir() . '/assets/admin/visual-workspace.js' );
+	}
+
+	public function test_the_page_script_is_strict_mode_and_dependency_free(): void {
+		$js = self::js();
+
+		self::assertStringContainsString( "'use strict'", $js );
+		self::assertStringNotContainsString( 'jQuery', $js );
+	}
+
+	public function test_the_drawer_keeps_aria_state_and_focus_in_sync(): void {
+		$js = self::js();
+
+		self::assertStringContainsString( 'data-sw-visual-inspector-toggle', $js );
+		self::assertStringContainsString( 'aria-expanded', $js );
+		self::assertStringContainsString( "'Escape'", $js );
+		self::assertStringContainsString( 'focus()', $js );
+	}
+
+	public function test_the_page_script_never_uses_native_dialogs_or_markup_injection(): void {
+		$js = self::js();
+
+		self::assertDoesNotMatchRegularExpression( '/(?<![\w.])confirm\s*\(/', $js );
+		self::assertDoesNotMatchRegularExpression( '/(?<![\w.])alert\s*\(/', $js );
+		self::assertStringNotContainsString( 'innerHTML', $js );
+		self::assertStringNotContainsString( 'document.' . 'write', $js );
+	}
+
+	// -----------------------------------------------------------------
+	// Entry point from the Design Studio
+	// -----------------------------------------------------------------
+
+	public function test_the_design_studio_boot_payload_carries_the_workspace_url(): void {
+		$payload = \Stonewright\WpMcp\Admin\Pages\DesignStudioPage::boot_payload();
+
+		self::assertArrayHasKey( 'visualWorkspaceUrl', $payload );
+		self::assertStringContainsString( 'page=stonewright-visual-workspace', (string) $payload['visualWorkspaceUrl'] );
+	}
+
+	public function test_the_design_studio_offers_a_link_into_the_workspace(): void {
+		$js = (string) file_get_contents( self::plugin_dir() . '/assets/admin/design-studio.js' );
+
+		self::assertStringContainsString( 'visualWorkspaceUrl', $js );
+		self::assertStringContainsString( 'Open Visual Workspace', $js );
+		self::assertStringContainsString( 'post_id=', $js );
+		self::assertStringContainsString( 'editor=', $js );
+	}
+
+	// -----------------------------------------------------------------
+	// Packaging script
+	// -----------------------------------------------------------------
+
+	public function test_package_verification_knows_about_the_staged_bundle(): void {
+		$script = (string) file_get_contents( dirname( self::plugin_dir() ) . '/scripts/package-verify.mjs' );
+
+		self::assertStringContainsString( 'assets/visual/workspace-browser.js', $script );
+		self::assertStringContainsString( '--require-visual-bundle', $script );
+		self::assertStringContainsString( 'node_modules', $script, 'Node-only dependencies must never enter the archive.' );
+	}
+}

--- a/scripts/package-verify.mjs
+++ b/scripts/package-verify.mjs
@@ -11,7 +11,8 @@
  *
  * Usage:
  *   node scripts/package-verify.mjs
- *   node scripts/package-verify.mjs --strict-vendor   # fail if vendor/ missing
+ *   node scripts/package-verify.mjs --strict-vendor          # fail if vendor/ missing
+ *   node scripts/package-verify.mjs --require-visual-bundle  # fail if the Visual bundle is not staged
  */
 
 import fs from 'node:fs';
@@ -21,6 +22,8 @@ import { fileURLToPath } from 'node:url';
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const pluginRoot = path.join(repoRoot, 'plugin');
 const strictVendor = process.argv.includes('--strict-vendor');
+const requireVisualBundle = process.argv.includes('--require-visual-bundle');
+const visualBundle = 'assets/visual/workspace-browser.js';
 const errors = [];
 const warnings = [];
 
@@ -131,6 +134,32 @@ if (fs.existsSync(vendorAutoload)) {
 	}
 }
 
+// The Stonewright Visual browser bundle is built from the `visual` package and
+// staged into the plugin during packaging, so a source checkout does not carry
+// it. Release runs pass --require-visual-bundle to turn that into an error.
+const visualStaged = included.includes(visualBundle);
+if (!visualStaged) {
+	const msg = `Stonewright Visual bundle not staged at plugin/${visualBundle} — run \`cd visual && npm run build\` and copy dist/workspace-browser.js before packaging.`;
+	if (requireVisualBundle) fail(msg);
+	else warn(msg);
+} else if (fs.statSync(path.join(pluginRoot, visualBundle)).size === 0) {
+	fail(`Staged Visual bundle plugin/${visualBundle} is empty.`);
+}
+
+// Only the built bundle ships. Node build inputs must never reach the archive.
+const nodeArtifacts = included.filter(
+	(rel) =>
+		rel.startsWith('assets/visual/') &&
+		(rel.includes('node_modules/') ||
+			rel.endsWith('/package.json') ||
+			rel.endsWith('/package-lock.json') ||
+			rel.endsWith('.ts')),
+);
+
+if (nodeArtifacts.length > 0) {
+	fail(`Simulated package includes Node-only artefacts: ${nodeArtifacts.slice(0, 8).join(', ')}`);
+}
+
 // Dev paths should still exist in the repo (excluded, not deleted).
 for (const rel of ['tests', 'bin', 'phpunit.xml']) {
 	if (!exists(rel)) warn(`Expected development path missing from checkout: plugin/${rel}`);
@@ -141,6 +170,7 @@ const report = {
 	pluginRoot: path.relative(repoRoot, pluginRoot),
 	included_file_count: included.length,
 	vendor_present: fs.existsSync(vendorAutoload),
+	visual_bundle_staged: visualStaged,
 	excludes: mustExclude,
 	warnings,
 	errors,

--- a/visual/README.md
+++ b/visual/README.md
@@ -1,0 +1,67 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+
+# @stonewright/visual
+
+Headless workspace foundation for WordPress editors, plus the browser bundle
+that the Stonewright plugin hosts under **Stonewright → Visual Workspace**.
+
+This package is AGPL-3.0-or-later. It adapts code from Novamira Visual; see
+[NOTICE](NOTICE) and [../docs/upstream-code-reuse.md](../docs/upstream-code-reuse.md)
+for exact source paths and fingerprints.
+
+## What it is
+
+One top-level MCP contract, `stonewright-workspace-request`. Editor-specific
+tools stay nested behind `workspace_call_page_tool`, which keeps Elementor and
+Gutenberg schemas out of the top-level tool list. Nested `batch_call` supports
+aliases such as `$hero`, compact summaries, mandatory mutation readback, and
+rollback through editor transactions or per-tool rollback handlers.
+
+Backend tools come from the Visual-safe discovery contract. Dangerous tools are
+hidden by default, writes and elevated calls enter the confirmation state
+machine before execution, and the dispatcher exposes no JavaScript eval method.
+
+## Layout
+
+| Path | Contents |
+|---|---|
+| `src/index.ts` | Node entry: dispatcher, discovery, confirmations, guidance |
+| `src/workspace-browser.ts` | Browser entry, built as an IIFE for the admin page |
+| `src/workspace-ui/` | Workspace controller, adapter status, confirmation panel, evidence panel |
+| `src/gutenberg/`, `src/elementor-v3/`, `src/elementor-v4/` | Editor adapters |
+| `src/page-tool-registry.ts` | Nested tool registry and argument checks |
+| `src/skills/` | Workspace skill definitions |
+
+## Build
+
+```bash
+cd visual
+npm install
+npm run typecheck
+npm test
+npm run build
+```
+
+`npm run build` emits `dist/index.js` (ESM) and `dist/workspace-browser.js`
+(IIFE, global `StonewrightVisual`).
+
+## Staging the browser bundle
+
+The plugin loads the bundle from `plugin/assets/visual/workspace-browser.js`.
+That directory is generated and is not committed. Build this package, copy
+`dist/workspace-browser.js` into it, and the admin page picks it up; without it
+the page states that the bundle is missing and prints the build command instead
+of rendering an empty frame.
+
+`node scripts/package-verify.mjs` warns about a missing bundle in a source
+checkout and fails under `--require-visual-bundle`, which CI and the release
+workflow pass after staging.
+
+## What the browser side does not claim
+
+The workspace supplies browser-side evidence and the confirmation gate. It does
+not certify that a page looks right. Applying a change with no evidence behind
+it is reported as unverified rather than as a success — the write may have
+landed, but the claim of correctness has not been earned. See
+[../docs/visual.md](../docs/visual.md) for the full ladder and the admin page
+contract.

--- a/visual/package.json
+++ b/visual/package.json
@@ -10,10 +10,12 @@
     "NOTICE"
   ],
   "exports": {
-    ".": "./dist/index.js"
+    ".": "./dist/index.js",
+    "./workspace-browser": "./dist/workspace-browser.js"
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts --clean --outDir dist",
+    "prebuild": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\"",
+    "build": "tsup",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },

--- a/visual/src/index.ts
+++ b/visual/src/index.ts
@@ -25,6 +25,11 @@ export * from "./gutenberg/window-runtime.js";
 export * from "./gutenberg/editor-adapter.js";
 export * from "./skills/skill-registry.js";
 export * from "./skills/use-skill-tool.js";
+export * from "./workspace-ui/state.js";
+export * from "./workspace-ui/adapter-status.js";
+export * from "./workspace-ui/evidence-panel.js";
+export * from "./workspace-ui/confirmation-panel.js";
+export * from "./workspace-ui/workspace.js";
 
 export const STONEWRIGHT_WORKSPACE_TOOL = {
   name: "stonewright-workspace-request",

--- a/visual/src/workspace-browser.ts
+++ b/visual/src/workspace-browser.ts
@@ -46,7 +46,7 @@ export interface WorkspaceBootConfig {
 interface EditorWindow {
   elementor?: { widgetsCache?: Record<string, { atomic?: boolean }>; config?: { elements?: Record<string, { atomic?: boolean }> } };
   $e?: unknown;
-  wp?: { blocks?: unknown; data?: unknown };
+  wp?: { blocks?: unknown; data?: { select?: unknown; dispatch?: unknown } };
   stonewrightVisualWorkspace?: WorkspaceBootConfig;
   /** The mounted controller, so a host script can drive the workspace. */
   stonewrightVisual?: WorkspaceController;
@@ -68,7 +68,7 @@ export function defaultAdapterCandidates(target: EditorWindow = window as unknow
     },
     {
       kind: "gutenberg",
-      detect: () => Boolean(target.wp?.blocks && target.wp?.data),
+      detect: () => hasBlockEditor(target),
       create: () => new GutenbergEditorAdapter(createWindowGutenbergRuntime(target as never)),
     },
   ];
@@ -244,6 +244,34 @@ if (typeof window !== "undefined" && typeof document !== "undefined") {
 
 function hasElementor(target: EditorWindow): boolean {
   return Boolean(target.elementor && target.$e);
+}
+
+/**
+ * True when a block editor is really attached to this page.
+ *
+ * `wp.blocks` and `wp.data` are enqueued on plenty of admin screens that hold
+ * no editor at all — the workspace host page is one of them. Their presence
+ * proves nothing, so detection asks for the stores the Gutenberg runtime
+ * actually calls. Without this the workspace reports "connected" against a
+ * page that has no blocks to read and no post to save.
+ */
+function hasBlockEditor(target: EditorWindow): boolean {
+  const blocks = target.wp?.blocks as { getBlockTypes?: unknown } | undefined;
+  const select = target.wp?.data?.select;
+
+  if (typeof blocks?.getBlockTypes !== "function" || typeof select !== "function") {
+    return false;
+  }
+
+  try {
+    const store = (select as (name: string) => unknown)("core/block-editor") as { getBlocks?: unknown } | undefined;
+    const editor = (select as (name: string) => unknown)("core/editor") as { getCurrentPostId?: unknown } | undefined;
+
+    return typeof store?.getBlocks === "function" && typeof editor?.getCurrentPostId === "function";
+  } catch {
+    // An unregistered store is a missing editor, not a crash.
+    return false;
+  }
 }
 
 function hasAtomicTypes(target: EditorWindow): boolean {

--- a/visual/src/workspace-browser.ts
+++ b/visual/src/workspace-browser.ts
@@ -35,7 +35,11 @@ export interface WorkspaceBootConfig {
   nonce: string;
   postId: number;
   editorKind?: AdapterKind | "auto";
-  direction?: DirectionSummary | null;
+  /**
+   * The WordPress direction row, or an already-normalised summary. The row
+   * carries the contract hash and never the contract itself.
+   */
+  direction?: DirectionSummary | Record<string, unknown> | null;
   mountSelector?: string;
 }
 
@@ -44,6 +48,8 @@ interface EditorWindow {
   $e?: unknown;
   wp?: { blocks?: unknown; data?: unknown };
   stonewrightVisualWorkspace?: WorkspaceBootConfig;
+  /** The mounted controller, so a host script can drive the workspace. */
+  stonewrightVisual?: WorkspaceController;
 }
 
 const MOUNT_SELECTOR = "[data-sw-visual-workspace]";
@@ -122,6 +128,45 @@ export function evidenceFromReport(payload: unknown): EvidenceEntry[] {
   return entries;
 }
 
+/**
+ * Normalises the WordPress direction row into the summary the workspace shows.
+ *
+ * The row is `DirectionSummary::row()` from the plugin: identity, revision, and
+ * `contract_hash`. There is no contract in it, and none is reconstructed here —
+ * the workspace states which direction is in force, it does not re-derive its
+ * rules in the browser.
+ */
+export function directionFromPayload(value: unknown): DirectionSummary | null {
+  const row = asRecord(value);
+  const id = typeof row.id === "number" || typeof row.id === "string" ? String(row.id) : "";
+  if (id === "" || id === "0") {
+    return null;
+  }
+
+  return {
+    id,
+    title: text(row.name ?? row.title ?? row.slug, `Direction ${id}`),
+    revision: typeof row.revision === "number" ? row.revision : Number(row.revision ?? 0) || 0,
+    hash: text(row.contract_hash ?? row.hash, ""),
+  };
+}
+
+/**
+ * Region slots a host page may provide. All three must be present, otherwise
+ * the workspace builds its own regions inside the mount root.
+ */
+function hostRegions(root: HTMLElement): { header: HTMLElement; canvas: HTMLElement; inspector: HTMLElement } | undefined {
+  const header = root.querySelector<HTMLElement>("[data-sw-visual-adapter]");
+  const canvas = root.querySelector<HTMLElement>("[data-sw-visual-workspace-canvas]");
+  const inspector = root.querySelector<HTMLElement>("[data-sw-visual-workspace-inspector]");
+
+  if (header === null || canvas === null || inspector === null) {
+    return undefined;
+  }
+
+  return { header, canvas, inspector };
+}
+
 export function mountFromConfig(
   config: WorkspaceBootConfig,
   target: EditorWindow = window as unknown as EditorWindow,
@@ -132,15 +177,52 @@ export function mountFromConfig(
     return null;
   }
 
-  return mountStonewrightWorkspace(root, {
+  const options: WorkspaceOptions = {
     restBase: config.restBase,
     nonce: config.nonce,
     postId: config.postId,
     editorKind: config.editorKind ?? "auto",
-    direction: config.direction ?? null,
+    direction: directionFromPayload(config.direction),
     adapters: defaultAdapterCandidates(target),
     verify: createQualityVerifier(config),
-  });
+  };
+
+  const regions = hostRegions(root);
+  if (regions !== undefined) {
+    options.regions = regions;
+  }
+
+  return mountStonewrightWorkspace(root, options);
+}
+
+/**
+ * Mounts, connects, and shows what is already known about the post.
+ *
+ * Connecting can legitimately fail: the workspace host page is not an editor,
+ * so there is often no editor runtime to attach to. That is reported in the
+ * status line rather than hidden. Either way the stored quality report is read
+ * and shown, so the page still says what the last verification observed.
+ */
+async function start(config: WorkspaceBootConfig, target: EditorWindow): Promise<void> {
+  const controller = mountFromConfig(config, target);
+  if (controller === null) {
+    return;
+  }
+
+  target.stonewrightVisual = controller;
+  await controller.connect();
+
+  try {
+    const stored = await createQualityVerifier(config)({
+      postId: config.postId,
+      operations: [],
+      direction: directionFromPayload(config.direction),
+    });
+    controller.recordEvidence(stored);
+  } catch {
+    // No readable report is not an error state of its own: the evidence panel
+    // stays empty, which is exactly what "nothing was verified" looks like.
+  }
 }
 
 function boot(): void {
@@ -149,7 +231,7 @@ function boot(): void {
   if (!config) {
     return;
   }
-  mountFromConfig(config, target);
+  void start(config, target);
 }
 
 if (typeof window !== "undefined" && typeof document !== "undefined") {

--- a/visual/src/workspace-browser.ts
+++ b/visual/src/workspace-browser.ts
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * Browser entry for the Stonewright Visual workspace.
+ *
+ * This file is the only place that touches `window`, `document`, and `fetch`.
+ * It builds the adapter candidates from the live editor runtimes, wires
+ * verification to the read-only quality route, and mounts the workspace. It
+ * imports nothing from Node, so the bundle stays loadable in wp-admin.
+ */
+
+import { ElementorV3EditorAdapter } from "./elementor-v3/editor-adapter.js";
+import { createWindowElementorV3Runtime } from "./elementor-v3/window-runtime.js";
+import { ElementorV4EditorAdapter } from "./elementor-v4/editor-adapter.js";
+import { createWindowElementorV4Runtime } from "./elementor-v4/window-runtime.js";
+import { GutenbergEditorAdapter } from "./gutenberg/editor-adapter.js";
+import { createWindowGutenbergRuntime } from "./gutenberg/window-runtime.js";
+import type { AdapterCandidate, AdapterKind } from "./workspace-ui/adapter-status.js";
+import type { EvidenceEntry, EvidenceStatus } from "./workspace-ui/evidence-panel.js";
+import {
+  mountStonewrightWorkspace,
+  type DirectionSummary,
+  type WorkspaceController,
+  type WorkspaceOptions,
+} from "./workspace-ui/workspace.js";
+
+export * from "./workspace-ui/adapter-status.js";
+export * from "./workspace-ui/confirmation-panel.js";
+export * from "./workspace-ui/evidence-panel.js";
+export * from "./workspace-ui/state.js";
+export * from "./workspace-ui/workspace.js";
+
+export interface WorkspaceBootConfig {
+  restBase: string;
+  nonce: string;
+  postId: number;
+  editorKind?: AdapterKind | "auto";
+  direction?: DirectionSummary | null;
+  mountSelector?: string;
+}
+
+interface EditorWindow {
+  elementor?: { widgetsCache?: Record<string, { atomic?: boolean }>; config?: { elements?: Record<string, { atomic?: boolean }> } };
+  $e?: unknown;
+  wp?: { blocks?: unknown; data?: unknown };
+  stonewrightVisualWorkspace?: WorkspaceBootConfig;
+}
+
+const MOUNT_SELECTOR = "[data-sw-visual-workspace]";
+
+export function defaultAdapterCandidates(target: EditorWindow = window as unknown as EditorWindow): AdapterCandidate[] {
+  return [
+    {
+      kind: "elementor-v4",
+      detect: () => hasElementor(target) && hasAtomicTypes(target),
+      create: () => new ElementorV4EditorAdapter(createWindowElementorV4Runtime(target as never)),
+    },
+    {
+      kind: "elementor-v3",
+      detect: () => hasElementor(target),
+      create: () => new ElementorV3EditorAdapter(createWindowElementorV3Runtime(target as never)),
+    },
+    {
+      kind: "gutenberg",
+      detect: () => Boolean(target.wp?.blocks && target.wp?.data),
+      create: () => new GutenbergEditorAdapter(createWindowGutenbergRuntime(target as never)),
+    },
+  ];
+}
+
+/**
+ * Reads the most recent stored quality report for this post and turns it into
+ * evidence rows. No report means no evidence: the controller then reports the
+ * change as unverified instead of inventing a pass.
+ */
+export function createQualityVerifier(config: WorkspaceBootConfig): NonNullable<WorkspaceOptions["verify"]> {
+  return async () => {
+    const url = `${config.restBase.replace(/\/$/, "")}/design-studio/quality?post_id=${config.postId}&limit=1`;
+    const response = await fetch(url, {
+      credentials: "same-origin",
+      headers: { "X-WP-Nonce": config.nonce },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Quality reports could not be read (HTTP ${response.status}).`);
+    }
+
+    const payload: unknown = await response.json();
+    return evidenceFromReport(payload);
+  };
+}
+
+export function evidenceFromReport(payload: unknown): EvidenceEntry[] {
+  const report = firstReport(payload);
+  if (report === null) {
+    return [];
+  }
+
+  const entries: EvidenceEntry[] = [];
+
+  for (const finding of asArray(report.findings)) {
+    const row = asRecord(finding);
+    entries.push({
+      label: text(row.rule_id, "rule"),
+      rule: text(row.rule_id, "rule"),
+      status: severityToStatus(text(row.severity, "warn")),
+      viewport: optionalText(row.viewport),
+      measured: optionalText(row.element_ref),
+      source: "design-quality-check",
+    });
+  }
+
+  for (const rule of asArray(asRecord(report.coverage).not_checked_rules)) {
+    entries.push({
+      label: text(rule, "rule"),
+      rule: text(rule, "rule"),
+      status: "not_checked",
+      source: "design-quality-check",
+    });
+  }
+
+  return entries;
+}
+
+export function mountFromConfig(
+  config: WorkspaceBootConfig,
+  target: EditorWindow = window as unknown as EditorWindow,
+): WorkspaceController | null {
+  const selector = config.mountSelector ?? MOUNT_SELECTOR;
+  const root = document.querySelector<HTMLElement>(selector);
+  if (root === null) {
+    return null;
+  }
+
+  return mountStonewrightWorkspace(root, {
+    restBase: config.restBase,
+    nonce: config.nonce,
+    postId: config.postId,
+    editorKind: config.editorKind ?? "auto",
+    direction: config.direction ?? null,
+    adapters: defaultAdapterCandidates(target),
+    verify: createQualityVerifier(config),
+  });
+}
+
+function boot(): void {
+  const target = window as unknown as EditorWindow;
+  const config = target.stonewrightVisualWorkspace;
+  if (!config) {
+    return;
+  }
+  mountFromConfig(config, target);
+}
+
+if (typeof window !== "undefined" && typeof document !== "undefined") {
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", boot, { once: true });
+  } else {
+    boot();
+  }
+}
+
+function hasElementor(target: EditorWindow): boolean {
+  return Boolean(target.elementor && target.$e);
+}
+
+function hasAtomicTypes(target: EditorWindow): boolean {
+  const cache = target.elementor?.widgetsCache ?? {};
+  const elements = target.elementor?.config?.elements ?? {};
+  return [...Object.values(cache), ...Object.values(elements)].some((entry) => entry?.atomic === true);
+}
+
+function severityToStatus(severity: string): EvidenceStatus {
+  switch (severity) {
+    case "error":
+    case "fail":
+      return "fail";
+    case "not_checked":
+      return "not_checked";
+    case "pass":
+      return "pass";
+    default:
+      return "warn";
+  }
+}
+
+function firstReport(payload: unknown): Record<string, unknown> | null {
+  const reports = asArray(asRecord(payload).reports);
+  return reports.length === 0 ? null : asRecord(reports[0]);
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function text(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.trim() !== "" ? value : fallback;
+}
+
+function optionalText(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() !== "" ? value : undefined;
+}

--- a/visual/src/workspace-ui/adapter-status.ts
+++ b/visual/src/workspace-ui/adapter-status.ts
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { WorkspaceState } from "./state.js";
+
+/**
+ * Editor detection, and the header chip that reports it.
+ *
+ * Detection walks the candidates in order. An editor that is simply not on the
+ * page is skipped. An editor that is on the page but cannot be driven stops the
+ * walk: falling through to the next adapter would let a broken Elementor page be
+ * edited as if it were Gutenberg, which is exactly the failure this refuses to
+ * produce.
+ */
+
+export type AdapterKind = "elementor-v3" | "elementor-v4" | "gutenberg";
+
+export interface EditorRegistryLike {
+  definitions: () => Array<Record<string, unknown>>;
+  call: (tool: string, args?: Record<string, unknown>) => Promise<unknown>;
+}
+
+export interface EditorAdapterLike {
+  registry: () => EditorRegistryLike;
+}
+
+export interface AdapterCandidate {
+  kind: AdapterKind;
+  detect: () => boolean | Promise<boolean>;
+  create: () => EditorAdapterLike | Promise<EditorAdapterLike>;
+}
+
+export interface AdapterResolution {
+  kind: AdapterKind | null;
+  adapter: EditorAdapterLike | null;
+  error: string | null;
+  attempted: AdapterKind[];
+}
+
+const ADAPTER_LABELS: Record<AdapterKind, string> = {
+  "elementor-v3": "Elementor V3",
+  "elementor-v4": "Elementor V4 Atomic",
+  gutenberg: "Gutenberg",
+};
+
+export function adapterLabel(kind: AdapterKind | null): string {
+  return kind === null ? "No editor" : ADAPTER_LABELS[kind];
+}
+
+export async function resolveEditorAdapter(candidates: readonly AdapterCandidate[]): Promise<AdapterResolution> {
+  const attempted: AdapterKind[] = [];
+
+  for (const candidate of candidates) {
+    attempted.push(candidate.kind);
+
+    let present: boolean;
+    try {
+      present = await candidate.detect();
+    } catch (cause) {
+      return { kind: null, adapter: null, error: describeError(candidate.kind, cause), attempted };
+    }
+
+    if (!present) {
+      continue;
+    }
+
+    try {
+      const adapter = await candidate.create();
+      return { kind: candidate.kind, adapter, error: null, attempted };
+    } catch (cause) {
+      return { kind: null, adapter: null, error: describeError(candidate.kind, cause), attempted };
+    }
+  }
+
+  return {
+    kind: null,
+    adapter: null,
+    error: "No supported editor was found on this page.",
+    attempted,
+  };
+}
+
+export interface AdapterStatusModel {
+  kind: AdapterKind | null;
+  label: string;
+  detail: string;
+  tone: "ok" | "error" | "idle";
+}
+
+export function describeAdapterStatus(resolution: AdapterResolution, state: WorkspaceState): AdapterStatusModel {
+  if (resolution.error !== null) {
+    return { kind: null, label: adapterLabel(null), detail: resolution.error, tone: "error" };
+  }
+
+  if (resolution.kind === null) {
+    return { kind: null, label: adapterLabel(null), detail: "Not connected yet.", tone: "idle" };
+  }
+
+  return {
+    kind: resolution.kind,
+    label: adapterLabel(resolution.kind),
+    detail: `Connected — ${state.replace(/_/g, " ")}`,
+    tone: "ok",
+  };
+}
+
+export function renderAdapterStatus(doc: Document, model: AdapterStatusModel): HTMLElement {
+  const wrapper = doc.createElement("div");
+  wrapper.className = `sw-visual-adapter sw-visual-adapter--${model.tone}`;
+  wrapper.setAttribute("data-sw-adapter", model.kind ?? "none");
+
+  const label = doc.createElement("span");
+  label.className = "sw-visual-adapter__label";
+  label.textContent = model.label;
+
+  const detail = doc.createElement("span");
+  detail.className = "sw-visual-adapter__detail";
+  detail.textContent = model.detail;
+
+  wrapper.append(label, detail);
+  return wrapper;
+}
+
+function describeError(kind: AdapterKind, cause: unknown): string {
+  const message = cause instanceof Error ? cause.message : String(cause);
+  return `${ADAPTER_LABELS[kind]} is present but could not be driven: ${message}`;
+}

--- a/visual/src/workspace-ui/confirmation-panel.ts
+++ b/visual/src/workspace-ui/confirmation-panel.ts
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * The confirmation panel view model.
+ *
+ * Nothing is applied from this panel. It states what would change, names what
+ * cannot be changed at all, and refuses to offer a confirm control when either
+ * list makes the answer obvious.
+ */
+
+export interface ProposedOperation {
+  tool: string;
+  target: string;
+  summary: string;
+  before?: string;
+  after?: string;
+  breakpoint?: string;
+}
+
+export interface ConfirmationRow extends ProposedOperation {
+  before: string;
+  after: string;
+  breakpoint: string;
+}
+
+export interface ConfirmationModel {
+  title: string;
+  directionLabel: string;
+  operations: ConfirmationRow[];
+  blocked: string[];
+  canConfirm: boolean;
+  warning: string | null;
+}
+
+export interface ConfirmationInput {
+  operations: readonly ProposedOperation[];
+  directionLabel: string;
+  blocked?: readonly string[];
+}
+
+export function describeConfirmation(input: ConfirmationInput): ConfirmationModel {
+  const blocked = [...(input.blocked ?? [])];
+  const operations: ConfirmationRow[] = input.operations.map((operation) => ({
+    ...operation,
+    before: operation.before ?? "—",
+    after: operation.after ?? "—",
+    breakpoint: operation.breakpoint ?? "all",
+  }));
+
+  const canConfirm = operations.length > 0 && blocked.length === 0;
+
+  return {
+    title: `Apply ${operations.length} change(s) to this page?`,
+    directionLabel: input.directionLabel,
+    operations,
+    blocked,
+    canConfirm,
+    warning: warningFor(operations.length, blocked.length),
+  };
+}
+
+export interface ConfirmationHandlers {
+  onAllow: () => void;
+  onDeny: () => void;
+}
+
+export function renderConfirmationPanel(
+  doc: Document,
+  model: ConfirmationModel,
+  handlers: ConfirmationHandlers,
+): HTMLElement {
+  const panel = doc.createElement("section");
+  panel.className = "sw-visual-confirm";
+  panel.setAttribute("role", "group");
+  panel.setAttribute("aria-label", model.title);
+
+  const heading = doc.createElement("h3");
+  heading.className = "sw-visual-confirm__heading";
+  heading.textContent = model.title;
+
+  const direction = doc.createElement("p");
+  direction.className = "sw-visual-confirm__direction";
+  direction.textContent = `Direction: ${model.directionLabel}`;
+
+  panel.append(heading, direction);
+
+  if (model.warning !== null) {
+    const warning = doc.createElement("p");
+    warning.className = "sw-visual-confirm__warning";
+    warning.textContent = model.warning;
+    panel.append(warning);
+  }
+
+  const list = doc.createElement("ul");
+  list.className = "sw-visual-confirm__list";
+  for (const operation of model.operations) {
+    const item = doc.createElement("li");
+    item.className = "sw-visual-confirm__row";
+
+    const target = doc.createElement("span");
+    target.className = "sw-visual-confirm__target";
+    target.textContent = `${operation.target} · ${operation.breakpoint}`;
+
+    const change = doc.createElement("span");
+    change.className = "sw-visual-confirm__change";
+    change.textContent = `${operation.before} → ${operation.after}`;
+
+    const summary = doc.createElement("span");
+    summary.className = "sw-visual-confirm__summary";
+    summary.textContent = operation.summary;
+
+    item.append(target, change, summary);
+    list.append(item);
+  }
+  panel.append(list);
+
+  if (model.blocked.length > 0) {
+    const blockedList = doc.createElement("ul");
+    blockedList.className = "sw-visual-confirm__blocked";
+    for (const reason of model.blocked) {
+      const item = doc.createElement("li");
+      item.textContent = reason;
+      blockedList.append(item);
+    }
+    panel.append(blockedList);
+  }
+
+  const actions = doc.createElement("div");
+  actions.className = "sw-visual-confirm__actions";
+
+  const allow = doc.createElement("button");
+  allow.type = "button";
+  allow.className = "sw-button sw-button--primary";
+  allow.textContent = "Apply changes";
+  allow.disabled = !model.canConfirm;
+  allow.addEventListener("click", handlers.onAllow);
+
+  const deny = doc.createElement("button");
+  deny.type = "button";
+  deny.className = "sw-button";
+  deny.textContent = "Cancel";
+  deny.addEventListener("click", handlers.onDeny);
+
+  actions.append(allow, deny);
+  panel.append(actions);
+
+  return panel;
+}
+
+function warningFor(operationCount: number, blockedCount: number): string | null {
+  if (operationCount === 0) {
+    return "There is nothing to apply.";
+  }
+  if (blockedCount > 0) {
+    return `${blockedCount} operation(s) cannot be written by the live editor and must be resolved first.`;
+  }
+  return null;
+}

--- a/visual/src/workspace-ui/confirmation-panel.ts
+++ b/visual/src/workspace-ui/confirmation-panel.ts
@@ -15,6 +15,13 @@ export interface ProposedOperation {
   before?: string;
   after?: string;
   breakpoint?: string;
+  /**
+   * Exact arguments for the editor tool. The other fields describe the change
+   * to a person; these are what the adapter is actually called with, so a tool
+   * that needs a client id or an idempotency key can be driven from here
+   * without the panel inventing a schema of its own.
+   */
+  args?: Record<string, unknown>;
 }
 
 export interface ConfirmationRow extends ProposedOperation {

--- a/visual/src/workspace-ui/evidence-panel.ts
+++ b/visual/src/workspace-ui/evidence-panel.ts
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * The evidence panel view model.
+ *
+ * A rule with no evidence behind it is not a pass. It is reported as unchecked
+ * and it keeps the run from claiming verification, which is the same contract
+ * `stonewright/design-quality-check` uses on the server.
+ */
+
+export type EvidenceStatus = "pass" | "fail" | "warn" | "not_checked";
+
+export interface EvidenceEntry {
+  label: string;
+  status: EvidenceStatus;
+  rule?: string;
+  viewport?: string;
+  measured?: string;
+  source?: string;
+}
+
+export interface EvidenceSummary {
+  total: number;
+  pass: number;
+  fail: number;
+  warn: number;
+  notChecked: number;
+  verified: boolean;
+}
+
+export interface EvidenceRow extends EvidenceEntry {
+  measured: string;
+  viewport: string;
+}
+
+export interface EvidencePanelModel {
+  summary: EvidenceSummary;
+  rows: EvidenceRow[];
+  notice: string | null;
+}
+
+export function summarizeEvidence(entries: readonly EvidenceEntry[]): EvidenceSummary {
+  const count = (status: EvidenceStatus): number => entries.filter((entry) => entry.status === status).length;
+
+  const summary: EvidenceSummary = {
+    total: entries.length,
+    pass: count("pass"),
+    fail: count("fail"),
+    warn: count("warn"),
+    notChecked: count("not_checked"),
+    verified: false,
+  };
+
+  summary.verified = summary.total > 0 && summary.fail === 0 && summary.notChecked === 0;
+  return summary;
+}
+
+export function describeEvidencePanel(entries: readonly EvidenceEntry[]): EvidencePanelModel {
+  const summary = summarizeEvidence(entries);
+
+  return {
+    summary,
+    rows: entries.map((entry) => ({
+      ...entry,
+      measured: entry.measured ?? "—",
+      viewport: entry.viewport ?? "—",
+    })),
+    notice: noticeFor(summary),
+  };
+}
+
+export function renderEvidencePanel(doc: Document, model: EvidencePanelModel): HTMLElement {
+  const section = doc.createElement("section");
+  section.className = "sw-visual-evidence";
+  section.setAttribute("data-sw-evidence", model.summary.verified ? "verified" : "unverified");
+
+  const heading = doc.createElement("h3");
+  heading.className = "sw-visual-evidence__heading";
+  heading.textContent = `Evidence — ${model.summary.pass}/${model.summary.total} passed`;
+  section.append(heading);
+
+  if (model.notice !== null) {
+    const notice = doc.createElement("p");
+    notice.className = "sw-visual-evidence__notice";
+    notice.textContent = model.notice;
+    section.append(notice);
+  }
+
+  const list = doc.createElement("ul");
+  list.className = "sw-visual-evidence__list";
+  for (const row of model.rows) {
+    const item = doc.createElement("li");
+    item.className = `sw-visual-evidence__row sw-visual-evidence__row--${row.status}`;
+    item.setAttribute("data-sw-evidence-status", row.status);
+
+    const label = doc.createElement("span");
+    label.className = "sw-visual-evidence__label";
+    label.textContent = row.label;
+
+    const measured = doc.createElement("span");
+    measured.className = "sw-visual-evidence__measured";
+    measured.textContent = `${row.viewport} · ${row.measured}`;
+
+    item.append(label, measured);
+    list.append(item);
+  }
+  section.append(list);
+
+  return section;
+}
+
+function noticeFor(summary: EvidenceSummary): string | null {
+  if (summary.total === 0) {
+    return "Nothing was checked, so nothing passed.";
+  }
+  if (summary.notChecked > 0) {
+    return `${summary.notChecked} rule(s) had no evidence to run against and stay unverified.`;
+  }
+  if (summary.fail > 0) {
+    return `${summary.fail} rule(s) failed against the captured render.`;
+  }
+  return null;
+}

--- a/visual/src/workspace-ui/state.ts
+++ b/visual/src/workspace-ui/state.ts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * The workspace state machine.
+ *
+ * A visual edit walks one path: boot, connect to an editor, read the page,
+ * preview what would change, ask, apply, verify. Every state can fail, and
+ * exactly one state is allowed to dispatch a write. Keeping that rule in a
+ * declared transition table rather than in scattered `if` statements is what
+ * makes "no write before confirmation" checkable instead of hopeful.
+ */
+
+export type WorkspaceState =
+  | "booting"
+  | "connected"
+  | "reading"
+  | "previewing"
+  | "awaiting_confirmation"
+  | "applying"
+  | "verifying"
+  | "complete"
+  | "failed";
+
+/** The only state in which the controller may call a mutating editor tool. */
+const WRITE_STATE: WorkspaceState = "applying";
+
+export const WORKSPACE_TRANSITIONS: Record<WorkspaceState, readonly WorkspaceState[]> = {
+  booting: ["connected", "failed"],
+  connected: ["reading", "failed"],
+  reading: ["previewing", "connected", "failed"],
+  previewing: ["awaiting_confirmation", "connected", "failed"],
+  awaiting_confirmation: ["applying", "connected", "failed"],
+  applying: ["verifying", "failed"],
+  verifying: ["complete", "failed"],
+  complete: ["connected"],
+  failed: ["booting", "connected"],
+};
+
+export function isWriteState(state: WorkspaceState): boolean {
+  return state === WRITE_STATE;
+}
+
+export class WorkspaceStateMachine {
+  private current: WorkspaceState;
+  private readonly seen: WorkspaceState[];
+
+  constructor(initial: WorkspaceState = "booting") {
+    this.current = initial;
+    this.seen = [initial];
+  }
+
+  get state(): WorkspaceState {
+    return this.current;
+  }
+
+  get history(): readonly WorkspaceState[] {
+    return this.seen.slice();
+  }
+
+  can(next: WorkspaceState): boolean {
+    return WORKSPACE_TRANSITIONS[this.current].includes(next);
+  }
+
+  to(next: WorkspaceState): void {
+    if (!this.can(next)) {
+      throw new Error(`Workspace cannot move from ${this.current} to ${next}.`);
+    }
+    this.current = next;
+    this.seen.push(next);
+  }
+
+  reset(): void {
+    this.current = "booting";
+    this.seen.length = 0;
+    this.seen.push("booting");
+  }
+}

--- a/visual/src/workspace-ui/workspace.ts
+++ b/visual/src/workspace-ui/workspace.ts
@@ -1,0 +1,434 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import {
+  describeAdapterStatus,
+  renderAdapterStatus,
+  resolveEditorAdapter,
+  type AdapterCandidate,
+  type AdapterKind,
+  type AdapterResolution,
+  type AdapterStatusModel,
+  type EditorRegistryLike,
+} from "./adapter-status.js";
+import {
+  describeConfirmation,
+  renderConfirmationPanel,
+  type ConfirmationModel,
+  type ProposedOperation,
+} from "./confirmation-panel.js";
+import {
+  describeEvidencePanel,
+  renderEvidencePanel,
+  summarizeEvidence,
+  type EvidenceEntry,
+  type EvidenceSummary,
+} from "./evidence-panel.js";
+import { WorkspaceStateMachine, isWriteState, type WorkspaceState } from "./state.js";
+
+/**
+ * The workspace controller.
+ *
+ * It owns the state machine, the resolved adapter, the evidence it has
+ * collected, and the pending confirmation. It does not own markup: the panels
+ * turn its snapshot into DOM. Every editor write goes through one private
+ * method that refuses to run outside the single write state.
+ */
+
+export interface DirectionSummary {
+  id: string;
+  title: string;
+  revision: number;
+  hash: string;
+}
+
+export interface WorkspaceOptions {
+  restBase: string;
+  nonce: string;
+  postId: number;
+  direction?: DirectionSummary | null;
+  editorKind?: AdapterKind | "auto";
+  adapters: readonly AdapterCandidate[];
+  /** Tool the read step calls on the resolved adapter. */
+  readTool?: string;
+  /** Collects evidence after a write. Injected so the controller stays network-free. */
+  verify?: (context: VerifyContext) => Promise<EvidenceEntry[]>;
+  /** Network access, injected. Nothing in this module calls fetch directly. */
+  request?: (path: string, init?: RequestInit) => Promise<unknown>;
+  viewports?: readonly WorkspaceViewport[];
+}
+
+export interface VerifyContext {
+  postId: number;
+  operations: readonly ProposedOperation[];
+  direction: DirectionSummary | null;
+}
+
+export interface WorkspaceViewport {
+  id: string;
+  label: string;
+  width: number;
+}
+
+export const DEFAULT_VIEWPORTS: readonly WorkspaceViewport[] = [
+  { id: "mobile", label: "Mobile", width: 375 },
+  { id: "tablet", label: "Tablet", width: 768 },
+  { id: "desktop", label: "Desktop", width: 1440 },
+];
+
+export interface WorkspaceSnapshot {
+  state: WorkspaceState;
+  adapter: AdapterStatusModel;
+  evidence: EvidenceSummary;
+  confirmation: ConfirmationModel | null;
+  direction: DirectionSummary | null;
+  viewport: WorkspaceViewport;
+  error: string | null;
+}
+
+export interface WorkspaceController {
+  getState: () => WorkspaceState;
+  snapshot: () => WorkspaceSnapshot;
+  subscribe: (listener: (snapshot: WorkspaceSnapshot) => void) => () => void;
+  connect: () => Promise<void>;
+  read: () => Promise<void>;
+  preview: (operations: readonly ProposedOperation[], blocked?: readonly string[]) => void;
+  requestConfirmation: () => void;
+  decide: (decision: "allow" | "deny") => Promise<void>;
+  recordEvidence: (entries: readonly EvidenceEntry[]) => void;
+  setViewport: (id: string) => void;
+  canDispatchWrite: () => boolean;
+  destroy: () => void;
+}
+
+const EMPTY_RESOLUTION: AdapterResolution = { kind: null, adapter: null, error: null, attempted: [] };
+
+export function createWorkspaceController(options: WorkspaceOptions): WorkspaceController {
+  const machine = new WorkspaceStateMachine();
+  const listeners = new Set<(snapshot: WorkspaceSnapshot) => void>();
+  const viewports = options.viewports ?? DEFAULT_VIEWPORTS;
+
+  let resolution: AdapterResolution = EMPTY_RESOLUTION;
+  let evidence: EvidenceEntry[] = [];
+  let confirmation: ConfirmationModel | null = null;
+  let operations: ProposedOperation[] = [];
+  let viewport: WorkspaceViewport = viewports[viewports.length - 1];
+  let error: string | null = null;
+  let destroyed = false;
+
+  const snapshot = (): WorkspaceSnapshot => ({
+    state: machine.state,
+    adapter: describeAdapterStatus(resolution, machine.state),
+    evidence: summarizeEvidence(evidence),
+    confirmation,
+    direction: options.direction ?? null,
+    viewport,
+    error,
+  });
+
+  const move = (next: WorkspaceState): void => {
+    machine.to(next);
+    for (const listener of listeners) {
+      listener(snapshot());
+    }
+  };
+
+  const fail = (reason: string): void => {
+    error = reason;
+    if (machine.can("failed")) {
+      move("failed");
+    }
+  };
+
+  const registry = (): EditorRegistryLike => {
+    if (resolution.adapter === null) {
+      throw new Error("No editor adapter is connected.");
+    }
+    return resolution.adapter.registry();
+  };
+
+  /** The single place a mutating editor tool may be called. */
+  const dispatchWrite = async (operation: ProposedOperation): Promise<void> => {
+    if (!isWriteState(machine.state)) {
+      throw new Error(`Refusing to write while the workspace is ${machine.state}.`);
+    }
+    await registry().call(operation.tool, { target: operation.target, ...operationArgs(operation) });
+  };
+
+  return {
+    getState: () => machine.state,
+    snapshot,
+
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+
+    async connect() {
+      if (destroyed) {
+        throw new Error("This workspace has been destroyed.");
+      }
+      resolution = await resolveEditorAdapter(candidatesFor(options));
+      if (resolution.error !== null || resolution.adapter === null) {
+        fail(resolution.error ?? "No supported editor was found on this page.");
+        return;
+      }
+      error = null;
+      move("connected");
+    },
+
+    async read() {
+      if (machine.state !== "connected") {
+        throw new Error(`The workspace must be connected before it can read; it is ${machine.state}.`);
+      }
+      move("reading");
+      try {
+        await registry().call(options.readTool ?? "get_page_structure", {});
+      } catch (cause) {
+        fail(messageOf(cause));
+      }
+    },
+
+    preview(next, blocked = []) {
+      if (machine.state !== "reading") {
+        throw new Error(`The workspace must read the page before it can preview; it is ${machine.state}.`);
+      }
+      operations = [...next];
+      confirmation = describeConfirmation({
+        operations,
+        directionLabel: directionLabel(options.direction ?? null),
+        blocked,
+      });
+      move("previewing");
+    },
+
+    requestConfirmation() {
+      if (machine.state !== "previewing") {
+        throw new Error(`There is nothing to confirm while the workspace is ${machine.state}.`);
+      }
+      if (confirmation === null || !confirmation.canConfirm) {
+        throw new Error(confirmation?.warning ?? "This change cannot be confirmed.");
+      }
+      move("awaiting_confirmation");
+    },
+
+    async decide(decision) {
+      if (machine.state !== "awaiting_confirmation") {
+        throw new Error(`No confirmation is pending; the workspace is ${machine.state}.`);
+      }
+
+      if (decision === "deny") {
+        confirmation = null;
+        operations = [];
+        move("connected");
+        return;
+      }
+
+      move("applying");
+      try {
+        for (const operation of operations) {
+          await dispatchWrite(operation);
+        }
+      } catch (cause) {
+        fail(messageOf(cause));
+        return;
+      }
+
+      move("verifying");
+      let collected: EvidenceEntry[] = [];
+      try {
+        collected = options.verify
+          ? await options.verify({ postId: options.postId, operations, direction: options.direction ?? null })
+          : [];
+      } catch (cause) {
+        fail(messageOf(cause));
+        return;
+      }
+
+      evidence = [...evidence, ...collected];
+      const summary = summarizeEvidence(evidence);
+      if (!summary.verified) {
+        fail(
+          summary.total === 0
+            ? "Verification produced no evidence, so the change is unverified."
+            : `Verification failed: ${summary.fail} failing and ${summary.notChecked} unchecked rule(s).`,
+        );
+        return;
+      }
+
+      confirmation = null;
+      move("complete");
+    },
+
+    recordEvidence(entries) {
+      evidence = [...evidence, ...entries];
+    },
+
+    setViewport(id) {
+      const match = viewports.find((candidate) => candidate.id === id);
+      if (match) {
+        viewport = match;
+      }
+    },
+
+    canDispatchWrite: () => isWriteState(machine.state),
+
+    destroy() {
+      destroyed = true;
+      listeners.clear();
+    },
+  };
+}
+
+/**
+ * Build the admin regions and keep them in step with the controller.
+ *
+ * Three regions: a header that states page, editor, and adapter status; an
+ * evidence canvas with the viewport controls; and an inspector holding the
+ * direction, the proposed diff, and the verification result.
+ */
+export function mountStonewrightWorkspace(root: HTMLElement, options: WorkspaceOptions): WorkspaceController {
+  const doc = root.ownerDocument;
+  const controller = createWorkspaceController(options);
+  const viewports = options.viewports ?? DEFAULT_VIEWPORTS;
+
+  root.textContent = "";
+  root.classList.add("sw-visual");
+
+  const header = doc.createElement("header");
+  header.className = "sw-visual__header";
+
+  const title = doc.createElement("h2");
+  title.className = "sw-visual__title";
+  title.textContent = `Post ${options.postId}`;
+
+  const adapterSlot = doc.createElement("div");
+  adapterSlot.className = "sw-visual__adapter-slot";
+
+  header.append(title, adapterSlot);
+
+  const canvas = doc.createElement("section");
+  canvas.className = "sw-visual__canvas";
+  canvas.setAttribute("aria-label", "Evidence canvas");
+
+  const viewportControls = doc.createElement("div");
+  viewportControls.className = "sw-visual__viewports";
+  viewportControls.setAttribute("role", "group");
+  viewportControls.setAttribute("aria-label", "Viewport");
+
+  for (const candidate of viewports) {
+    const button = doc.createElement("button");
+    button.type = "button";
+    button.className = "sw-visual__viewport";
+    button.textContent = candidate.label;
+    button.setAttribute("data-sw-viewport", candidate.id);
+    button.addEventListener("click", () => {
+      controller.setViewport(candidate.id);
+      paint();
+    });
+    viewportControls.append(button);
+  }
+
+  const evidenceSlot = doc.createElement("div");
+  evidenceSlot.className = "sw-visual__evidence-slot";
+  canvas.append(viewportControls, evidenceSlot);
+
+  const inspector = doc.createElement("aside");
+  inspector.className = "sw-visual__inspector";
+  inspector.setAttribute("aria-label", "Inspector");
+
+  const directionLine = doc.createElement("p");
+  directionLine.className = "sw-visual__direction";
+
+  const confirmSlot = doc.createElement("div");
+  confirmSlot.className = "sw-visual__confirm-slot";
+
+  const status = doc.createElement("p");
+  status.className = "sw-visual__status";
+  status.setAttribute("role", "status");
+  status.setAttribute("aria-live", "polite");
+
+  inspector.append(directionLine, confirmSlot, status);
+  root.append(header, canvas, inspector);
+
+  function paint(): void {
+    const current = controller.snapshot();
+
+    root.setAttribute("data-sw-state", current.state);
+    root.setAttribute("data-sw-viewport", current.viewport.id);
+
+    adapterSlot.textContent = "";
+    adapterSlot.append(renderAdapterStatus(doc, current.adapter));
+
+    for (const button of Array.from(viewportControls.querySelectorAll("button"))) {
+      const active = button.getAttribute("data-sw-viewport") === current.viewport.id;
+      button.setAttribute("aria-pressed", active ? "true" : "false");
+    }
+
+    evidenceSlot.textContent = "";
+    evidenceSlot.append(renderEvidencePanel(doc, describeEvidencePanel(evidenceRows(current))));
+
+    directionLine.textContent = `Direction: ${directionLabel(current.direction)}`;
+
+    confirmSlot.textContent = "";
+    if (current.confirmation !== null) {
+      confirmSlot.append(
+        renderConfirmationPanel(doc, current.confirmation, {
+          onAllow: () => void controller.decide("allow"),
+          onDeny: () => void controller.decide("deny"),
+        }),
+      );
+    }
+
+    status.textContent = current.error ?? current.state.replace(/_/g, " ");
+  }
+
+  controller.subscribe(paint);
+  paint();
+
+  return controller;
+}
+
+function evidenceRows(snapshot: WorkspaceSnapshot): EvidenceEntry[] {
+  // The snapshot carries counts, not rows; the panel needs something to list.
+  const rows: EvidenceEntry[] = [];
+  for (let index = 0; index < snapshot.evidence.pass; index += 1) {
+    rows.push({ label: "Passed rule", status: "pass" });
+  }
+  for (let index = 0; index < snapshot.evidence.fail; index += 1) {
+    rows.push({ label: "Failed rule", status: "fail" });
+  }
+  for (let index = 0; index < snapshot.evidence.warn; index += 1) {
+    rows.push({ label: "Warning", status: "warn" });
+  }
+  for (let index = 0; index < snapshot.evidence.notChecked; index += 1) {
+    rows.push({ label: "Unchecked rule", status: "not_checked" });
+  }
+  return rows;
+}
+
+function candidatesFor(options: WorkspaceOptions): readonly AdapterCandidate[] {
+  const requested = options.editorKind ?? "auto";
+  if (requested === "auto") {
+    return options.adapters;
+  }
+  return options.adapters.filter((candidate) => candidate.kind === requested);
+}
+
+function directionLabel(direction: DirectionSummary | null): string {
+  return direction === null ? "none active" : `${direction.title} rev ${direction.revision}`;
+}
+
+function operationArgs(operation: ProposedOperation): Record<string, unknown> {
+  const args: Record<string, unknown> = {};
+  if (operation.breakpoint !== undefined) {
+    args.breakpoint = operation.breakpoint;
+  }
+  if (operation.after !== undefined) {
+    args.value = operation.after;
+  }
+  return args;
+}
+
+function messageOf(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
+}

--- a/visual/src/workspace-ui/workspace.ts
+++ b/visual/src/workspace-ui/workspace.ts
@@ -55,6 +55,21 @@ export interface WorkspaceOptions {
   /** Network access, injected. Nothing in this module calls fetch directly. */
   request?: (path: string, init?: RequestInit) => Promise<unknown>;
   viewports?: readonly WorkspaceViewport[];
+  /**
+   * Slots supplied by a host page. When present the workspace fills them
+   * instead of building its own regions, so the host keeps its heading,
+   * breadcrumbs, and drawer chrome. Absent, the workspace owns the whole root.
+   */
+  regions?: WorkspaceRegions;
+}
+
+export interface WorkspaceRegions {
+  /** Receives the adapter status line. */
+  header: HTMLElement;
+  /** Receives the viewport controls and the evidence panel. */
+  canvas: HTMLElement;
+  /** Receives the direction line, the confirmation panel, and the status. */
+  inspector: HTMLElement;
 }
 
 export interface VerifyContext {
@@ -261,6 +276,11 @@ export function createWorkspaceController(options: WorkspaceOptions): WorkspaceC
 
     recordEvidence(entries) {
       evidence = [...evidence, ...entries];
+      // Recorded evidence changes the snapshot, so subscribers have to see it;
+      // the state itself does not move, which is why this does not use `move`.
+      for (const listener of listeners) {
+        listener(snapshot());
+      }
     },
 
     setViewport(id) {
@@ -291,24 +311,37 @@ export function mountStonewrightWorkspace(root: HTMLElement, options: WorkspaceO
   const controller = createWorkspaceController(options);
   const viewports = options.viewports ?? DEFAULT_VIEWPORTS;
 
-  root.textContent = "";
+  const hosted = options.regions !== undefined;
+
+  if (!hosted) {
+    root.textContent = "";
+  }
   root.classList.add("sw-visual");
 
-  const header = doc.createElement("header");
-  header.className = "sw-visual__header";
+  const header = options.regions?.header ?? doc.createElement("header");
+  if (hosted) {
+    header.textContent = "";
+  } else {
+    header.className = "sw-visual__header";
 
-  const title = doc.createElement("h2");
-  title.className = "sw-visual__title";
-  title.textContent = `Post ${options.postId}`;
+    const title = doc.createElement("h2");
+    title.className = "sw-visual__title";
+    title.textContent = `Post ${options.postId}`;
+    header.append(title);
+  }
 
   const adapterSlot = doc.createElement("div");
   adapterSlot.className = "sw-visual__adapter-slot";
 
-  header.append(title, adapterSlot);
+  header.append(adapterSlot);
 
-  const canvas = doc.createElement("section");
-  canvas.className = "sw-visual__canvas";
-  canvas.setAttribute("aria-label", "Evidence canvas");
+  const canvas = options.regions?.canvas ?? doc.createElement("section");
+  if (hosted) {
+    canvas.textContent = "";
+  } else {
+    canvas.className = "sw-visual__canvas";
+    canvas.setAttribute("aria-label", "Evidence canvas");
+  }
 
   const viewportControls = doc.createElement("div");
   viewportControls.className = "sw-visual__viewports";
@@ -332,9 +365,13 @@ export function mountStonewrightWorkspace(root: HTMLElement, options: WorkspaceO
   evidenceSlot.className = "sw-visual__evidence-slot";
   canvas.append(viewportControls, evidenceSlot);
 
-  const inspector = doc.createElement("aside");
-  inspector.className = "sw-visual__inspector";
-  inspector.setAttribute("aria-label", "Inspector");
+  const inspector = options.regions?.inspector ?? doc.createElement("aside");
+  if (hosted) {
+    inspector.textContent = "";
+  } else {
+    inspector.className = "sw-visual__inspector";
+    inspector.setAttribute("aria-label", "Inspector");
+  }
 
   const directionLine = doc.createElement("p");
   directionLine.className = "sw-visual__direction";
@@ -348,7 +385,9 @@ export function mountStonewrightWorkspace(root: HTMLElement, options: WorkspaceO
   status.setAttribute("aria-live", "polite");
 
   inspector.append(directionLine, confirmSlot, status);
-  root.append(header, canvas, inspector);
+  if (!hosted) {
+    root.append(header, canvas, inspector);
+  }
 
   function paint(): void {
     const current = controller.snapshot();
@@ -419,7 +458,7 @@ function directionLabel(direction: DirectionSummary | null): string {
 }
 
 function operationArgs(operation: ProposedOperation): Record<string, unknown> {
-  const args: Record<string, unknown> = {};
+  const args: Record<string, unknown> = { ...(operation.args ?? {}) };
   if (operation.breakpoint !== undefined) {
     args.breakpoint = operation.breakpoint;
   }

--- a/visual/tests/workspace-browser.test.ts
+++ b/visual/tests/workspace-browser.test.ts
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import {
+  defaultAdapterCandidates,
+  directionFromPayload,
+  evidenceFromReport,
+} from "../src/workspace-browser.js";
+
+/**
+ * The browser entry, tested without a browser.
+ *
+ * Importing this module is safe in Node: the boot block is guarded on `window`
+ * and `document`, so only the pure translation helpers run here. Detection is
+ * exercised against fabricated editor globals, which is the same shape the
+ * adapters see in wp-admin.
+ */
+
+type EditorGlobals = Parameters<typeof defaultAdapterCandidates>[0];
+
+function detectionsFor(target: EditorGlobals): Record<string, boolean> {
+  const out: Record<string, boolean> = {};
+  for (const candidate of defaultAdapterCandidates(target)) {
+    out[candidate.kind] = candidate.detect() === true;
+  }
+  return out;
+}
+
+describe("direction payload", () => {
+  it("maps the WordPress direction row onto the workspace summary", () => {
+    const summary = directionFromPayload({
+      id: 11,
+      slug: "quarry",
+      name: "Quarry",
+      revision: 4,
+      contract_hash: "sha256:9f2c",
+      active: true,
+    });
+
+    expect(summary).toEqual({
+      id: "11",
+      title: "Quarry",
+      revision: 4,
+      hash: "sha256:9f2c",
+    });
+  });
+
+  it("keeps the hash and never invents a contract", () => {
+    const summary = directionFromPayload({
+      id: 11,
+      name: "Quarry",
+      revision: 4,
+      contract_hash: "sha256:9f2c",
+    });
+
+    expect(Object.keys(summary ?? {}).sort()).toEqual(["hash", "id", "revision", "title"]);
+  });
+
+  it("reports no direction when the row is absent, empty, or unsaved", () => {
+    expect(directionFromPayload(null)).toBeNull();
+    expect(directionFromPayload(undefined)).toBeNull();
+    expect(directionFromPayload({})).toBeNull();
+    expect(directionFromPayload({ id: 0, name: "Draft" })).toBeNull();
+  });
+
+  it("accepts an already normalised summary", () => {
+    const summary = directionFromPayload({ id: "7", title: "Basalt", revision: 2, hash: "sha256:aa" });
+
+    expect(summary).toEqual({ id: "7", title: "Basalt", revision: 2, hash: "sha256:aa" });
+  });
+
+  it("falls back to the identifier when the row carries no name", () => {
+    expect(directionFromPayload({ id: 9 })?.title).toBe("Direction 9");
+  });
+
+  it("coerces a string revision and tolerates a missing hash", () => {
+    const summary = directionFromPayload({ id: 3, name: "Slate", revision: "6" });
+
+    expect(summary?.revision).toBe(6);
+    expect(summary?.hash).toBe("");
+  });
+});
+
+describe("adapter detection", () => {
+  it("finds nothing on a page with no editor runtime", () => {
+    expect(detectionsFor({})).toEqual({
+      "elementor-v4": false,
+      "elementor-v3": false,
+      gutenberg: false,
+    });
+  });
+
+  it("reads a classic Elementor page as V3 and not V4", () => {
+    const detections = detectionsFor({ elementor: { widgetsCache: { heading: {} } }, $e: {} });
+
+    expect(detections["elementor-v3"]).toBe(true);
+    expect(detections["elementor-v4"]).toBe(false);
+  });
+
+  it("reads an atomic Elementor page as V4", () => {
+    const detections = detectionsFor({
+      elementor: { widgetsCache: { "e-paragraph": { atomic: true } } },
+      $e: {},
+    });
+
+    expect(detections["elementor-v4"]).toBe(true);
+    // V3 still matches; resolution order decides, and V4 is attempted first.
+    expect(detections["elementor-v3"]).toBe(true);
+  });
+
+  it("requires both halves of the block editor before claiming Gutenberg", () => {
+    expect(detectionsFor({ wp: { blocks: {} } }).gutenberg).toBe(false);
+    expect(detectionsFor({ wp: { blocks: {}, data: {} } }).gutenberg).toBe(true);
+  });
+});
+
+describe("quality report translation", () => {
+  it("turns findings and unchecked rules into evidence rows", () => {
+    const entries = evidenceFromReport({
+      reports: [
+        {
+          findings: [
+            { rule_id: "contrast.text", severity: "error", viewport: "mobile", element_ref: "hero > h1" },
+            { rule_id: "token.spacing", severity: "warning", viewport: "desktop" },
+          ],
+          coverage: { not_checked_rules: ["state.focus"] },
+        },
+      ],
+    });
+
+    expect(entries).toHaveLength(3);
+    expect(entries[0]).toMatchObject({ rule: "contrast.text", status: "fail", viewport: "mobile" });
+    expect(entries[1]).toMatchObject({ rule: "token.spacing", status: "warn" });
+    expect(entries[2]).toMatchObject({ rule: "state.focus", status: "not_checked" });
+  });
+
+  it("produces no evidence when no report was stored", () => {
+    expect(evidenceFromReport({ reports: [] })).toEqual([]);
+    expect(evidenceFromReport(null)).toEqual([]);
+  });
+});

--- a/visual/tests/workspace-browser.test.ts
+++ b/visual/tests/workspace-browser.test.ts
@@ -109,8 +109,38 @@ describe("adapter detection", () => {
   });
 
   it("requires both halves of the block editor before claiming Gutenberg", () => {
+    const editorStores = (name: string) =>
+      name === "core/block-editor"
+        ? { getBlocks: () => [] }
+        : { getCurrentPostId: () => 1 };
+
     expect(detectionsFor({ wp: { blocks: {} } }).gutenberg).toBe(false);
-    expect(detectionsFor({ wp: { blocks: {}, data: {} } }).gutenberg).toBe(true);
+    expect(
+      detectionsFor({ wp: { blocks: { getBlockTypes: () => [] }, data: { select: editorStores } } })
+        .gutenberg,
+    ).toBe(true);
+  });
+
+  it("does not read a plain admin screen that merely loaded wp.data as an editor", () => {
+    // The workspace host page enqueues the block libraries without ever
+    // registering an editor store. Claiming Gutenberg here would report a
+    // connected editor with nothing behind it.
+    expect(detectionsFor({ wp: { blocks: {}, data: {} } }).gutenberg).toBe(false);
+    expect(
+      detectionsFor({
+        wp: { blocks: { getBlockTypes: () => [] }, data: { select: () => undefined } },
+      }).gutenberg,
+    ).toBe(false);
+    expect(
+      detectionsFor({
+        wp: {
+          blocks: { getBlockTypes: () => [] },
+          data: {
+            select: (name: string) => (name === "core/block-editor" ? { getBlocks: () => [] } : undefined),
+          },
+        },
+      }).gutenberg,
+    ).toBe(false);
   });
 });
 

--- a/visual/tests/workspace-ui.test.ts
+++ b/visual/tests/workspace-ui.test.ts
@@ -361,6 +361,50 @@ describe("workspace controller", () => {
     expect(controller.snapshot().adapter.kind).toBe("elementor-v3");
   });
 
+  it("passes the exact tool arguments the operation carries", async () => {
+    const calls: RegistryCall[] = [];
+    const controller = controllerWith(calls, {
+      verify: async () => [{ label: "Body contrast", status: "pass" as const }],
+    });
+
+    await controller.connect();
+    await controller.read();
+    controller.preview([
+      {
+        tool: "update_settings",
+        target: "hero-title",
+        summary: "Set desktop font size to 48px",
+        after: "48px",
+        breakpoint: "desktop",
+        args: { element_id: "abc123", idempotency_key: "key-1" },
+      },
+    ]);
+    controller.requestConfirmation();
+    await controller.decide("allow");
+
+    const write = calls.find((call) => call.tool === "update_settings");
+    expect(write?.args).toEqual({
+      target: "hero-title",
+      element_id: "abc123",
+      idempotency_key: "key-1",
+      breakpoint: "desktop",
+      value: "48px",
+    });
+  });
+
+  it("tells subscribers when evidence is recorded outside a transition", async () => {
+    const controller = controllerWith([]);
+    const seen: number[] = [];
+    const stop = controller.subscribe((snapshot) => seen.push(snapshot.evidence.total));
+
+    await controller.connect();
+    controller.recordEvidence([{ label: "Stored finding", status: "fail" }]);
+    stop();
+
+    expect(seen).toEqual([0, 1]);
+    expect(controller.getState()).toBe("connected");
+  });
+
   it("fails to connect when no editor answers, and says so", async () => {
     const controller = controllerWith([], {
       adapters: [candidate("elementor-v3", { detect: () => false })],

--- a/visual/tests/workspace-ui.test.ts
+++ b/visual/tests/workspace-ui.test.ts
@@ -1,0 +1,394 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import {
+  WORKSPACE_TRANSITIONS,
+  WorkspaceStateMachine,
+  isWriteState,
+  type WorkspaceState,
+} from "../src/workspace-ui/state.js";
+import { describeAdapterStatus, resolveEditorAdapter, type AdapterCandidate } from "../src/workspace-ui/adapter-status.js";
+import { describeEvidencePanel, summarizeEvidence } from "../src/workspace-ui/evidence-panel.js";
+import { describeConfirmation } from "../src/workspace-ui/confirmation-panel.js";
+import { createWorkspaceController } from "../src/workspace-ui/workspace.js";
+
+/**
+ * The workspace controller owns state; the panels own view models. Nothing in
+ * this file touches a document, so the state machine stays testable in Node and
+ * the DOM assembly is left to the admin browser tests.
+ */
+
+interface RegistryCall {
+  tool: string;
+  args: Record<string, unknown>;
+}
+
+function fakeAdapter(calls: RegistryCall[], failOn: string | null = null) {
+  return {
+    registry() {
+      return {
+        definitions: () => [
+          { name: "get_page_structure", mutates: false },
+          { name: "update_settings", mutates: true },
+        ],
+        async call(tool: string, args: Record<string, unknown> = {}) {
+          calls.push({ tool, args });
+          if (tool === failOn) throw new Error(`${tool} exploded`);
+          return { content: [{ type: "text", text: `${tool} ok` }], details: { tool } };
+        },
+      };
+    },
+  };
+}
+
+function candidate(kind: AdapterCandidate["kind"], over: Partial<AdapterCandidate> = {}): AdapterCandidate {
+  return {
+    kind,
+    detect: () => true,
+    create: () => fakeAdapter([]),
+    ...over,
+  };
+}
+
+function controllerWith(calls: RegistryCall[], over: Record<string, unknown> = {}) {
+  return createWorkspaceController({
+    restBase: "https://example.test/wp-json/stonewright/v1",
+    nonce: "nonce-1",
+    postId: 41,
+    direction: { id: "quarry", title: "Quarry", revision: 3, hash: "abc123" },
+    adapters: [candidate("elementor-v3", { create: () => fakeAdapter(calls) })],
+    ...over,
+  });
+}
+
+const OPERATIONS = [
+  { tool: "update_settings", target: "hero-title", summary: "Set desktop font size to 48px", before: "32px", after: "48px", breakpoint: "desktop" },
+];
+
+async function walkToConfirmation(controller: ReturnType<typeof controllerWith>) {
+  await controller.connect();
+  await controller.read();
+  controller.preview(OPERATIONS);
+  controller.requestConfirmation();
+}
+
+/* -------------------------------------------------------------------------- */
+
+describe("workspace state machine", () => {
+  it("starts booting and walks the full happy path", () => {
+    const machine = new WorkspaceStateMachine();
+    expect(machine.state).toBe("booting");
+
+    const path: WorkspaceState[] = [
+      "connected",
+      "reading",
+      "previewing",
+      "awaiting_confirmation",
+      "applying",
+      "verifying",
+      "complete",
+    ];
+    for (const next of path) {
+      machine.to(next);
+    }
+
+    expect(machine.state).toBe("complete");
+    expect(machine.history).toEqual(["booting", ...path]);
+  });
+
+  it("refuses a transition that is not declared and keeps the current state", () => {
+    const machine = new WorkspaceStateMachine();
+    expect(machine.can("applying")).toBe(false);
+    expect(() => machine.to("applying")).toThrow(/booting/);
+    expect(machine.state).toBe("booting");
+  });
+
+  it("lets every state fail and never lets a failed state jump straight into a write", () => {
+    for (const state of Object.keys(WORKSPACE_TRANSITIONS) as WorkspaceState[]) {
+      if (state === "failed" || state === "complete") {
+        continue;
+      }
+      expect(WORKSPACE_TRANSITIONS[state]).toContain("failed");
+    }
+
+    expect(WORKSPACE_TRANSITIONS.failed).not.toContain("applying");
+    expect(WORKSPACE_TRANSITIONS.complete).not.toContain("applying");
+  });
+
+  it("names exactly one write state", () => {
+    const writeStates = (Object.keys(WORKSPACE_TRANSITIONS) as WorkspaceState[]).filter(isWriteState);
+    expect(writeStates).toEqual(["applying"]);
+  });
+});
+
+describe("adapter resolution", () => {
+  it("skips an editor that is not present and reports the one that is", async () => {
+    const resolution = await resolveEditorAdapter([
+      candidate("elementor-v4", { detect: () => false }),
+      candidate("elementor-v3"),
+    ]);
+
+    expect(resolution.kind).toBe("elementor-v3");
+    expect(resolution.adapter).not.toBeNull();
+    expect(resolution.error).toBeNull();
+    expect(resolution.attempted).toEqual(["elementor-v4", "elementor-v3"]);
+  });
+
+  it("stops at an adapter that is present but broken instead of falling through", async () => {
+    const later: string[] = [];
+    const resolution = await resolveEditorAdapter([
+      candidate("elementor-v3", {
+        create: () => {
+          throw new Error("Elementor runtime is half loaded");
+        },
+      }),
+      candidate("gutenberg", {
+        detect: () => {
+          later.push("gutenberg");
+          return true;
+        },
+      }),
+    ]);
+
+    expect(resolution.kind).toBeNull();
+    expect(resolution.adapter).toBeNull();
+    expect(resolution.error).toContain("half loaded");
+    expect(resolution.attempted).toEqual(["elementor-v3"]);
+    expect(later).toEqual([]);
+  });
+
+  it("treats a detection that throws as a failure of that editor, not as absence", async () => {
+    const resolution = await resolveEditorAdapter([
+      candidate("gutenberg", {
+        detect: () => {
+          throw new Error("editor store is missing");
+        },
+      }),
+      candidate("elementor-v3"),
+    ]);
+
+    expect(resolution.kind).toBeNull();
+    expect(resolution.error).toContain("editor store is missing");
+    expect(resolution.attempted).toEqual(["gutenberg"]);
+  });
+
+  it("reports no editor at all rather than inventing one", async () => {
+    const resolution = await resolveEditorAdapter([candidate("elementor-v3", { detect: () => false })]);
+
+    expect(resolution.kind).toBeNull();
+    expect(resolution.error).toContain("No supported editor");
+    expect(describeAdapterStatus(resolution, "failed").tone).toBe("error");
+  });
+
+  it("describes a healthy adapter without claiming more than it knows", async () => {
+    const resolution = await resolveEditorAdapter([candidate("gutenberg")]);
+    const model = describeAdapterStatus(resolution, "connected");
+
+    expect(model.tone).toBe("ok");
+    expect(model.kind).toBe("gutenberg");
+    expect(model.label.toLowerCase()).toContain("gutenberg");
+  });
+});
+
+describe("evidence panel", () => {
+  it("counts unchecked rules separately and refuses to call them a pass", () => {
+    const summary = summarizeEvidence([
+      { label: "Body contrast", status: "pass", viewport: "1440" },
+      { label: "Heading scale", status: "not_checked", viewport: "390" },
+    ]);
+
+    expect(summary.total).toBe(2);
+    expect(summary.pass).toBe(1);
+    expect(summary.notChecked).toBe(1);
+    expect(summary.verified).toBe(false);
+  });
+
+  it("never reports verified when nothing was checked", () => {
+    const model = describeEvidencePanel([]);
+
+    expect(model.summary.verified).toBe(false);
+    expect(model.notice).toMatch(/nothing/i);
+  });
+
+  it("reports verified only when every row passed", () => {
+    const model = describeEvidencePanel([
+      { label: "Body contrast", status: "pass" },
+      { label: "Rhythm", status: "pass" },
+    ]);
+
+    expect(model.summary.verified).toBe(true);
+    expect(model.notice).toBeNull();
+    expect(model.rows).toHaveLength(2);
+  });
+
+  it("keeps a failure visible even when later rows pass", () => {
+    const model = describeEvidencePanel([
+      { label: "Body contrast", status: "fail", measured: "2.9:1", viewport: "390" },
+      { label: "Rhythm", status: "pass" },
+    ]);
+
+    expect(model.summary.verified).toBe(false);
+    expect(model.rows[0].status).toBe("fail");
+    expect(model.rows[0].measured).toBe("2.9:1");
+  });
+});
+
+describe("confirmation panel", () => {
+  it("lists what would change before anything runs", () => {
+    const model = describeConfirmation({ operations: OPERATIONS, directionLabel: "Quarry rev 3" });
+
+    expect(model.canConfirm).toBe(true);
+    expect(model.operations).toHaveLength(1);
+    expect(model.operations[0].summary).toContain("48px");
+    expect(model.title.toLowerCase()).toContain("apply");
+  });
+
+  it("cannot be confirmed with nothing to apply", () => {
+    const model = describeConfirmation({ operations: [], directionLabel: "Quarry rev 3" });
+
+    expect(model.canConfirm).toBe(false);
+    expect(model.warning).toMatch(/nothing/i);
+  });
+
+  it("cannot be confirmed while an operation is blocked", () => {
+    const model = describeConfirmation({
+      operations: OPERATIONS,
+      directionLabel: "Quarry rev 3",
+      blocked: ["hero-title: the live schema has no font_size control"],
+    });
+
+    expect(model.canConfirm).toBe(false);
+    expect(model.blocked).toHaveLength(1);
+  });
+});
+
+describe("workspace controller", () => {
+  it("connects, reads, and exposes the resolved adapter", async () => {
+    const calls: RegistryCall[] = [];
+    const controller = controllerWith(calls);
+
+    expect(controller.getState()).toBe("booting");
+    await controller.connect();
+    expect(controller.getState()).toBe("connected");
+
+    await controller.read();
+    expect(controller.getState()).toBe("reading");
+    expect(calls.map((call) => call.tool)).toEqual(["get_page_structure"]);
+    expect(controller.snapshot().adapter.kind).toBe("elementor-v3");
+  });
+
+  it("dispatches no write before a preview and an explicit confirmation", async () => {
+    const calls: RegistryCall[] = [];
+    const controller = controllerWith(calls);
+
+    await controller.connect();
+    await controller.read();
+
+    expect(controller.canDispatchWrite()).toBe(false);
+    await expect(controller.decide("allow")).rejects.toThrow(/confirmation/i);
+
+    controller.preview(OPERATIONS);
+    expect(controller.canDispatchWrite()).toBe(false);
+    await expect(controller.decide("allow")).rejects.toThrow(/confirmation/i);
+
+    expect(calls.filter((call) => call.tool === "update_settings")).toHaveLength(0);
+  });
+
+  it("cannot preview before it has read the page", async () => {
+    const controller = controllerWith([]);
+    await controller.connect();
+
+    expect(() => controller.preview(OPERATIONS)).toThrow(/read/i);
+  });
+
+  it("applies only after the user allows it, then verifies", async () => {
+    const calls: RegistryCall[] = [];
+    const controller = controllerWith(calls, {
+      verify: async () => [{ label: "Body contrast", status: "pass" as const }],
+    });
+
+    await walkToConfirmation(controller);
+    expect(controller.getState()).toBe("awaiting_confirmation");
+    expect(calls.filter((call) => call.tool === "update_settings")).toHaveLength(0);
+
+    await controller.decide("allow");
+
+    expect(calls.filter((call) => call.tool === "update_settings")).toHaveLength(1);
+    expect(controller.getState()).toBe("complete");
+    expect(controller.snapshot().evidence.verified).toBe(true);
+  });
+
+  it("does not report complete when verification found nothing to check", async () => {
+    const controller = controllerWith([], { verify: async () => [] });
+
+    await walkToConfirmation(controller);
+    await controller.decide("allow");
+
+    expect(controller.getState()).toBe("failed");
+    expect(controller.snapshot().error).toMatch(/verif/i);
+  });
+
+  it("denying returns to connected and writes nothing", async () => {
+    const calls: RegistryCall[] = [];
+    const controller = controllerWith(calls);
+
+    await walkToConfirmation(controller);
+    await controller.decide("deny");
+
+    expect(controller.getState()).toBe("connected");
+    expect(calls.filter((call) => call.tool === "update_settings")).toHaveLength(0);
+    expect(controller.snapshot().confirmation).toBeNull();
+  });
+
+  it("keeps the evidence it already has when an adapter call fails", async () => {
+    const calls: RegistryCall[] = [];
+    const controller = createWorkspaceController({
+      restBase: "https://example.test/wp-json/stonewright/v1",
+      nonce: "nonce-1",
+      postId: 41,
+      direction: null,
+      adapters: [candidate("elementor-v3", { create: () => fakeAdapter(calls, "update_settings") })],
+      verify: async () => [{ label: "Body contrast", status: "pass" as const }],
+    });
+
+    await walkToConfirmation(controller);
+    controller.recordEvidence([{ label: "Baseline capture", status: "pass" }]);
+    await controller.decide("allow");
+
+    expect(controller.getState()).toBe("failed");
+    expect(controller.snapshot().error).toContain("exploded");
+    expect(controller.snapshot().evidence.total).toBe(1);
+    expect(controller.snapshot().adapter.kind).toBe("elementor-v3");
+  });
+
+  it("fails to connect when no editor answers, and says so", async () => {
+    const controller = controllerWith([], {
+      adapters: [candidate("elementor-v3", { detect: () => false })],
+    });
+
+    await controller.connect();
+
+    expect(controller.getState()).toBe("failed");
+    expect(controller.snapshot().error).toContain("No supported editor");
+  });
+
+  it("tells subscribers about every state change once", async () => {
+    const seen: WorkspaceState[] = [];
+    const controller = controllerWith([], { verify: async () => [{ label: "Rhythm", status: "pass" as const }] });
+    const stop = controller.subscribe((snapshot) => seen.push(snapshot.state));
+
+    await walkToConfirmation(controller);
+    await controller.decide("allow");
+    stop();
+
+    expect(seen).toEqual([
+      "connected",
+      "reading",
+      "previewing",
+      "awaiting_confirmation",
+      "applying",
+      "verifying",
+      "complete",
+    ]);
+  });
+});

--- a/visual/tsup.config.ts
+++ b/visual/tsup.config.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { defineConfig } from "tsup";
+
+/**
+ * Two entries, deliberately built differently.
+ *
+ * `src/index.ts` is the package API: ESM plus declarations, consumed by the
+ * companion. `src/workspace-browser.ts` is loaded by wp-admin as a plain
+ * script, so it is bundled into one self-contained IIFE with no chunk imports
+ * and no declarations.
+ *
+ * Neither config cleans: tsup runs them in parallel, so a clean owned by one
+ * config can delete the other's output. The `prebuild` script removes `dist`
+ * once, before either build starts.
+ */
+export default defineConfig([
+  {
+    entry: ["src/index.ts"],
+    format: ["esm"],
+    dts: true,
+    clean: false,
+    outDir: "dist",
+  },
+  {
+    entry: { "workspace-browser": "src/workspace-browser.ts" },
+    format: ["iife"],
+    globalName: "StonewrightVisual",
+    splitting: false,
+    dts: false,
+    clean: false,
+    platform: "browser",
+    outDir: "dist",
+    outExtension: () => ({ js: ".js" }),
+  },
+]);


### PR DESCRIPTION
Stonewright Visual could be driven by an MCP client and by nothing else. This PR gives it a visible surface in wp-admin, so a person can open a post in the same workspace an agent uses and watch the read → preview → confirm → apply → verify ladder run.

Sixth and final PR of the design direction / visual quality / Design Studio plan. Stacked on `pr5-skill-lifecycle` (#25), which is stacked on `pr4-design-studio` (#24).

## What is in it

**Browser workspace (`visual/`).** A workspace controller, adapter status view, confirmation panel, and evidence panel, plus a `workspace-browser` IIFE entry built alongside the existing ESM entry. Adapter detection walks Elementor V4 atomic → Elementor V3 → Gutenberg and stops on an editor that is present but cannot be driven, rather than falling through — editing an Elementor page as if it were Gutenberg is precisely the outcome that ordering exists to prevent.

**Admin page `stonewright-visual-workspace`.** PHP owns the chrome — heading, target post, expected editor, canvas, inspector — and hands the bundle three slots to fill: the adapter chip, the canvas body, and the inspector body. The page reads correctly while the bundle is connecting and still reads correctly if the bundle never loads; a missing bundle is stated on the page with the command that builds it, not left as an empty frame.

**Thin boot payload.** REST base, a `wp_rest` nonce, the post id, the requested editor, and the active direction *row* — identity, revision, contract hash. The contract itself stays on the server: the workspace states which direction is in force, it does not re-derive its rules in JavaScript. Gated on `edit_posts`, and on `Permissions::can_edit_post()` for the targeted post.

**One write path.** Every editor write goes through a single private dispatch that refuses to run outside the applying state. Reading is required before previewing, previewing before confirming, confirming before applying. A proposed operation carries both a human-readable diff and the exact arguments the adapter will be called with, so the confirmation panel shows what a person needs while the adapter still gets what its own schema requires — no second, looser schema in the middle.

**Honest verification.** Applying with no evidence behind it does not report success; it reports the change as unverified. The write may well have landed — that is asserted in the e2e suite — and what failed is the claim of correctness. Same contract `stonewright/design-quality-check` uses on the server. Failed and unchecked rules stay visible as unverified instead of being rounded up to a pass.

**Packaging.** `plugin/assets/visual/` is generated and gitignored. `scripts/package-verify.mjs` warns on a missing bundle in a source checkout and fails under `--require-visual-bundle`; CI and the release workflow pass that flag after staging, and the release job asserts the built zip contains the bundle.

## Admin requirements

- Existing stone-and-precision shell, token-only theming, light and dark.
- Responsive 375–1440 px; below 1025 px the inspector becomes a drawer with an `aria-expanded` toggle, `aria-modal` content, Escape to close, and focus returned to the toggle.
- No `window.confirm()` anywhere — confirmation is the panel, which states target, breakpoint, and before → after per change with the active direction named beside it.
- No emoji, no decorative effects. `prefers-reduced-motion` honoured.
- Keyboard-operable viewport toolbar with `aria-pressed` state.

## Abilities

None added, changed, or removed. This PR adds an admin page and a browser bundle; every write still goes through the existing typed abilities.

## Gates

No backup, confirmation-token, permission, validation, or audit gate changed. The page adds two permission checks of its own (`edit_posts` for the screen, `Permissions::can_edit_post()` for the target post) and adds no new REST write route.

## Tests

- `visual/`: 79 unit tests across 8 files, plus `tsc --noEmit`.
- `plugin/tests/Unit/Admin/VisualWorkspacePageTest.php`: 46 tests, 102 assertions covering slug and capability, submenu registration, post id and editor parsing, URL building, the boot payload shape (including that the contract body is absent), editor context, bundle detection, and the picker path.
- `e2e/tests/visual-workspace.spec.ts`: 160 Playwright tests over the 10-project viewport × colour-scheme matrix. Editor doubles are installed before the bundle boots, so the write actually runs through the genuine Gutenberg adapter — schema validation, `confirm_write`, idempotency, and store readback all execute — rather than through a stub. Covers adapter resolution for all four cases, out-of-order ladder refusals, apply and cancel, the no-evidence path, evidence rows, the drawer including a reduced-motion variant, and the entry points.

## Docs

`docs/architecture.md` gains a Visual Workspace section with a table naming what Design Direction, DesignEvidence, NativePlanner, `design-quality-check`, the Visual Workspace, and the typed Elementor abilities each supply — and what they do not. No part of this subsystem certifies that a page looks right. `docs/visual.md` documents the page, adapter order, the ladder, evidence semantics, accessibility, and bundle staging. New `visual/README.md`. `README.md` and `plugin/README.md` list the page and describe the Design Studio and Visual Workspace workflows end to end. Both changelogs updated.

Two files the plan named do not exist in this repository: `docs/roadmap.md` (skipped — nothing to modify) and `visual/README.md` (created instead of modified). `docs/install-prompts.md` needed no change because no install, transport, or companion behaviour moved. Install URLs keep the `VERSION` placeholder and capability counts are unchanged.

## Verification

`composer test` 5907 tests / 30517 assertions; `phpstan` no errors; `phpcs` clean; `security:audit` 6/6 checks pass; `dependencies:audit` exit 0. `companion` typecheck + 335 tests + build. `visual` typecheck + 79 tests + build. `node scripts/package-verify.mjs` ok. `node scripts/check-docs-freshness.mjs` passes for 167 files. `git diff --check` clean.

The Playwright suite cannot run on the development machine — no container runtime is available locally — so the `e2e-admin-ui` CI job is the runtime verification for it.
