### PR TITLE
Fix OAuth consent completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Unreleased); older history lives in git tags and GitHub releases.
 
 ## [Unreleased]
 
+### Fixed
+
+- ChatGPT and other OAuth clients can now complete administrator consent instead
+  of stopping on a generic authorization error.
+
 ## [1.0.0-alpha.88] - 2026-07-25
 
 ### Added

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- OAuth consent now autoloads its user entity through the normal PSR-4 path, so
+  approved authorization-code requests reach the client callback.
+
 ## [1.0.0-alpha.88] - 2026-07-25
 
 ### Added

--- a/plugin/includes/OAuth/Repositories/UserEntity.php
+++ b/plugin/includes/OAuth/Repositories/UserEntity.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * SPDX-FileCopyrightText: 2026 Stonewright contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * OAuth user entity.
+ *
+ * @package Stonewright\WpMcp
+ */
+
+declare( strict_types=1 );
+
+namespace Stonewright\WpMcp\OAuth\Repositories;
+
+use League\OAuth2\Server\Entities\Traits\EntityTrait;
+use League\OAuth2\Server\Entities\UserEntityInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * User identity attached to an approved authorization request.
+ */
+final class UserEntity implements UserEntityInterface {
+	use EntityTrait;
+}

--- a/plugin/includes/OAuth/Repositories/UserRepository.php
+++ b/plugin/includes/OAuth/Repositories/UserRepository.php
@@ -16,15 +16,10 @@ namespace Stonewright\WpMcp\OAuth\Repositories;
 // phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound, WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 use League\OAuth2\Server\Entities\ClientEntityInterface;
-use League\OAuth2\Server\Entities\Traits\EntityTrait;
 use League\OAuth2\Server\Entities\UserEntityInterface;
 use League\OAuth2\Server\Repositories\UserRepositoryInterface;
 
 defined( 'ABSPATH' ) || exit;
-
-final class UserEntity implements UserEntityInterface {
-	use EntityTrait;
-}
 
 final class UserRepository implements UserRepositoryInterface {
 

--- a/plugin/tests/Integration/OAuth/ConsentCompletionTest.php
+++ b/plugin/tests/Integration/OAuth/ConsentCompletionTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * OAuth consent completion integration tests.
+ *
+ * @package Stonewright\WpMcp
+ */
+
+declare( strict_types=1 );
+
+namespace Stonewright\WpMcp\Tests\Integration\OAuth;
+
+use League\OAuth2\Server\Entities\ScopeEntityInterface;
+use Nyholm\Psr7\Response;
+use Nyholm\Psr7\ServerRequest;
+use PHPUnit\Framework\TestCase;
+use Stonewright\WpMcp\OAuth\Repositories\UserEntity;
+use Stonewright\WpMcp\OAuth\ServerFactory;
+
+final class ConsentCompletionTest extends TestCase {
+
+	private mixed $original_wpdb;
+
+	protected function setUp(): void {
+		$this->original_wpdb                    = $GLOBALS['wpdb'] ?? null;
+		$GLOBALS['stonewright_test_options']    = [];
+		$GLOBALS['stonewright_test_wpdb_inserts'] = [];
+		$GLOBALS['wpdb']                        = new class() {
+			public string $prefix = 'wp_';
+
+			public function prepare( string $query, mixed ...$args ): string {
+				foreach ( $args as $arg ) {
+					$replacement = "'" . str_replace( "'", "''", (string) $arg ) . "'";
+					$query       = preg_replace( '/%s/', $replacement, $query, 1 ) ?? $query;
+				}
+				return $query;
+			}
+
+			/**
+			 * @return array<string, mixed>|null
+			 */
+			public function get_row( string $query, string $output = 'OBJECT' ): ?array {
+				unset( $output );
+				if ( ! str_contains( $query, 'stonewright_oauth_clients' ) ) {
+					return null;
+				}
+
+				return [
+					'client_id'       => 'chatgpt-client',
+					'client_name'     => 'ChatGPT',
+					'redirect_uris'   => wp_json_encode( [ 'https://chatgpt.com/connector/oauth/callback' ] ),
+					'is_confidential' => 0,
+				];
+			}
+
+			/**
+			 * @param array<string, mixed> $data
+			 * @param array<int, string>   $format
+			 */
+			public function insert( string $table, array $data, array $format = [] ): int {
+				unset( $format );
+				$GLOBALS['stonewright_test_wpdb_inserts'][] = [
+					'table' => $table,
+					'data'  => $data,
+				];
+				return 1;
+			}
+		};
+	}
+
+	protected function tearDown(): void {
+		$GLOBALS['wpdb'] = $this->original_wpdb;
+	}
+
+	public function test_approved_chatgpt_request_completes_with_code_and_state(): void {
+		$server  = ServerFactory::authorization_server();
+		$request = ( new ServerRequest( 'GET', 'https://example.test/wp-admin/' ) )->withQueryParams(
+			[
+				'response_type'         => 'code',
+				'client_id'             => 'chatgpt-client',
+				'redirect_uri'          => 'https://chatgpt.com/connector/oauth/callback',
+				'code_challenge'        => str_repeat( 'A', 43 ),
+				'code_challenge_method' => 'S256',
+				'scope'                 => 'mcp',
+				'state'                 => 'expected-state',
+			]
+		);
+
+		$authorization = $server->validateAuthorizationRequest( $request );
+		$user          = new UserEntity();
+		$user->setIdentifier( '1' );
+		$authorization->setUser( $user );
+		$authorization->setAuthorizationApproved( true );
+
+		$response = $server->completeAuthorizationRequest( $authorization, new Response() );
+		$location = $response->getHeaderLine( 'Location' );
+
+		self::assertStringStartsWith( 'https://chatgpt.com/connector/oauth/callback?', $location );
+		self::assertStringContainsString( 'code=', $location );
+		self::assertStringContainsString( 'state=expected-state', $location );
+		self::assertCount( 1, $GLOBALS['stonewright_test_wpdb_inserts'] );
+
+		$insert = $GLOBALS['stonewright_test_wpdb_inserts'][0];
+		self::assertSame( 'wp_stonewright_oauth_auth_codes', $insert['table'] );
+		self::assertSame( 'chatgpt-client', $insert['data']['client_id'] );
+		self::assertSame( '1', (string) $insert['data']['user_id'] );
+		self::assertSame(
+			[ 'mcp' ],
+			array_map(
+				static fn( ScopeEntityInterface $scope ): string => $scope->getIdentifier(),
+				$authorization->getScopes()
+			)
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- move the OAuth user entity into its PSR-4 file so authoritative production autoloading can resolve it
- add an end-to-end authorization-code completion regression test for the ChatGPT callback
- document the OAuth consent fix in the root and plugin changelogs

## Changed abilities
- None. The MCP ability surface is unchanged.

## Security gates
- Backup: unchanged
- Confirmation token: unchanged
- Permission callbacks: unchanged
- Design validation: unchanged
- Audit gates: unchanged
- OAuth redirect URI validation and PKCE remain enforced by the authorization server

## Public docs
- Updated `CHANGELOG.md` and `plugin/CHANGELOG.md`. No setup, architecture, capability, or release-flow documentation changed because the public OAuth workflow is unchanged; this fixes production autoloading of an existing component.

## Validation
- OAuth suite: 67 tests, 261 assertions
- Full plugin suite: 5,909 tests, 30,526 assertions
- PHPCS: 697 files
- PHPStan: 600 files
- `composer security:audit`
- `composer provenance:lint`
- production `--classmap-authoritative` autoload check
- documentation freshness check
- `git diff --check`