### PR TITLE
Ship beta.2 admin and update reliability

### DIFF
--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,130 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-07-30T20:00:00Z",
+  "title": "Design System: Stonewright",
+  "extensions": {
+    "colorMeta": {
+      "workspace": {
+        "role": "neutral",
+        "displayName": "Workbench",
+        "canonical": "#f7f8fb",
+        "tonalRamp": ["#1a1b22", "#30323c", "#505462", "#737988", "#9ba1ae", "#c3c7d0", "#e3e5ea", "#f7f8fb"]
+      },
+      "brand": {
+        "role": "primary",
+        "displayName": "Tool Indigo",
+        "canonical": "#4f46e5",
+        "tonalRamp": ["#171443", "#25206b", "#332d96", "#433ac3", "#5e56e9", "#8b85f0", "#bbb8f7", "#eeefff"]
+      }
+    },
+    "typographyMeta": {
+      "headline": {
+        "displayName": "Headline",
+        "purpose": "Page titles only."
+      },
+      "body": {
+        "displayName": "Body",
+        "purpose": "Instructions and supporting copy."
+      },
+      "data": {
+        "displayName": "Data",
+        "purpose": "Versions, identifiers, hashes, counts, and times."
+      }
+    },
+    "shadows": [
+      {
+        "name": "resting-surface",
+        "value": "0 1px 2px rgba(23, 25, 33, 0.05)",
+        "purpose": "Optional separation for primary panels."
+      },
+      {
+        "name": "raised-control",
+        "value": "0 6px 18px rgba(23, 25, 33, 0.10)",
+        "purpose": "Sticky filters and menus."
+      }
+    ],
+    "motion": [
+      {
+        "name": "state",
+        "value": "150ms cubic-bezier(.25,.46,.45,.94)",
+        "purpose": "Hover, focus, and state transitions."
+      }
+    ],
+    "breakpoints": [
+      {"name": "phone", "value": "375px"},
+      {"name": "admin-collapse", "value": "782px"},
+      {"name": "tablet", "value": "960px"},
+      {"name": "desktop", "value": "1200px"},
+      {"name": "wide", "value": "1440px"}
+    ]
+  },
+  "components": [
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "Main safe action on a screen.",
+      "html": "<button class=\"ds-btn-primary\">Save Changes</button>",
+      "css": ".ds-btn-primary{min-height:36px;padding:9px 14px;border:1px solid #4f46e5;border-radius:6px;background:#4f46e5;color:#fcfcfe;font:600 12px/1.35 system-ui;transition:background 150ms cubic-bezier(.25,.46,.45,.94),border-color 150ms cubic-bezier(.25,.46,.45,.94)}.ds-btn-primary:hover{background:#4338ca;border-color:#4338ca}.ds-btn-primary:focus-visible{outline:2px solid #4f46e5;outline-offset:2px}"
+    },
+    {
+      "name": "Secondary Button",
+      "kind": "button",
+      "refersTo": "button-secondary",
+      "description": "Secondary or reversible action.",
+      "html": "<button class=\"ds-btn-secondary\">Check Status</button>",
+      "css": ".ds-btn-secondary{min-height:36px;padding:9px 14px;border:1px solid #c8ceda;border-radius:6px;background:#fcfcfe;color:#171921;font:600 12px/1.35 system-ui;transition:background 150ms cubic-bezier(.25,.46,.45,.94),border-color 150ms cubic-bezier(.25,.46,.45,.94)}.ds-btn-secondary:hover{background:#f1f3f8;border-color:#4f46e5}.ds-btn-secondary:focus-visible{outline:2px solid #4f46e5;outline-offset:2px}"
+    },
+    {
+      "name": "Text Field",
+      "kind": "input",
+      "refersTo": "field",
+      "description": "Standard settings and filter field.",
+      "html": "<label class=\"ds-field-label\">Site URL<input class=\"ds-field\" value=\"https://example.com\"></label>",
+      "css": ".ds-field-label{display:grid;gap:6px;color:#474c57;font:600 12px/1.35 system-ui}.ds-field{min-height:36px;padding:8px 10px;border:1px solid #dfe2ea;border-radius:6px;background:#fcfcfe;color:#171921;font:400 14px/1.55 system-ui}.ds-field:focus-visible{border-color:#4f46e5;outline:2px solid #4f46e5;outline-offset:1px}"
+    },
+    {
+      "name": "Status Pill",
+      "kind": "chip",
+      "refersTo": "status-pill",
+      "description": "Explicit operational status with semantic contrast.",
+      "html": "<span class=\"ds-status\">Current</span>",
+      "css": ".ds-status{display:inline-flex;align-items:center;min-height:22px;padding:4px 9px;border:1px solid #a8dac0;border-radius:999px;background:#e7f6ee;color:#157347;font:700 12px/1.2 system-ui}"
+    },
+    {
+      "name": "Summary Band",
+      "kind": "custom",
+      "refersTo": "dashboard-summary",
+      "description": "Compact grouped metrics without a wall of cards.",
+      "html": "<section class=\"ds-summary\"><div><strong>346</strong><span>Tools</span></div><div><strong>6 min</strong><span>Last Activity</span></div></section>",
+      "css": ".ds-summary{display:flex;flex-wrap:wrap;border:1px solid #dfe2ea;border-radius:14px;background:#fcfcfe}.ds-summary>div{display:grid;gap:4px;min-width:140px;padding:16px 20px;border-right:1px solid #dfe2ea}.ds-summary>div:last-child{border-right:0}.ds-summary strong{color:#171921;font:650 18px/1.2 system-ui}.ds-summary span{color:#68707d;font:600 12px/1.35 system-ui}"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Operator's Workbench",
+    "overview": "Stonewright is a clean, well-made technical instrument. Premium quality comes from exact spacing, predictable controls, honest status, and polished edge cases.",
+    "keyCharacteristics": [
+      "Restrained light palette with one indigo action color.",
+      "Compact system typography built for technical scanning.",
+      "Flat-by-default surfaces separated by borders and tonal shifts.",
+      "Responsive structure without horizontal overflow.",
+      "Clear operational states with text, shape, and color."
+    ],
+    "rules": [
+      {"name": "One Tool Color", "body": "Indigo means action, focus, or current state. Never use it as decoration.", "section": "colors"},
+      {"name": "Compact Evidence", "body": "Metrics never exceed 20px. Technical values wrap or truncate with a reachable full-value affordance.", "section": "typography"},
+      {"name": "Flat by Default", "body": "No shadow on every card. Elevation must explain layer or interaction.", "section": "elevation"}
+    ],
+    "dos": [
+      "Do keep the default workspace light.",
+      "Do use semantic HTML and visible focus.",
+      "Do test narrow and wide breakpoints."
+    ],
+    "donts": [
+      "Don't build identical oversized metric card walls.",
+      "Don't use low-contrast status pills.",
+      "Don't use colored side stripes.",
+      "Don't ship project-specific state as defaults."
+    ]
+  }
+}

--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -65,7 +65,7 @@
       "refersTo": "button-primary",
       "description": "Main safe action on a screen.",
       "html": "<button class=\"ds-btn-primary\">Save Changes</button>",
-      "css": ".ds-btn-primary{min-height:36px;padding:9px 14px;border:1px solid #4f46e5;border-radius:6px;background:#4f46e5;color:#fcfcfe;font:600 12px/1.35 system-ui;transition:background 150ms cubic-bezier(.25,.46,.45,.94),border-color 150ms cubic-bezier(.25,.46,.45,.94)}.ds-btn-primary:hover{background:#4338ca;border-color:#4338ca}.ds-btn-primary:focus-visible{outline:2px solid #4f46e5;outline-offset:2px}"
+      "css": ".ds-btn-primary{min-height:36px;padding:9px 14px;border:1px solid #4f46e5;border-radius:6px;background:#4f46e5;color:#ffffff;font:600 12px/1.35 system-ui;transition:background 150ms cubic-bezier(.25,.46,.45,.94),border-color 150ms cubic-bezier(.25,.46,.45,.94)}.ds-btn-primary:hover{background:#4338ca;border-color:#4338ca}.ds-btn-primary:focus-visible{outline:2px solid #4f46e5;outline-offset:2px}"
     },
     {
       "name": "Secondary Button",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,33 @@ were never stable releases and are not part of the supported public history.
 
 ## [Unreleased]
 
+## [1.0.0-beta.2] - 2026-07-30
+
+### Added
+
+- A maintained `DESIGN.md` system and page-by-page admin surface checklist for
+  the supported light interface.
+
+### Changed
+
+- The Dashboard uses one compact summary band and balanced evidence panels
+  instead of a wall of oversized metric cards.
+- Setup, Sandbox, Audit, Abilities, Design Studio, Visual Workspace, Blueprints,
+  Memory, and Skills now share tighter typography, spacing, focus, status,
+  border, and contrast contracts.
+
+### Fixed
+
+- Make an explicit **Check latest companion** action bypass the 12-hour release
+  cache and browser caches, while retaining the cache for automatic background
+  checks.
+- Preserve every top-level field required by an ability output schema when
+  `stonewright_fields` projects a smaller response. Compact `task-start`
+  responses can no longer lose required handshake fields.
+- Center the complete Domain Lock control group, keep Sandbox file-type badges
+  readable, remove inline click handling from category actions, and correct
+  low-contrast setup code blocks and focus rings.
+
 ## [1.0.0-beta.1] - 2026-07-30
 
 ### Added

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -13,6 +13,7 @@ colors:
   brand: "#4f46e5"
   brand-strong: "#4338ca"
   brand-soft: "#eeefff"
+  on-brand: "#ffffff"
   success: "#157347"
   success-soft: "#e7f6ee"
   warning: "#8a5a00"
@@ -64,7 +65,7 @@ spacing:
 components:
   button-primary:
     backgroundColor: "{colors.brand}"
-    textColor: "{colors.surface}"
+    textColor: "{colors.on-brand}"
     typography: "{typography.label}"
     rounded: "{rounded.sm}"
     padding: "9px 14px"
@@ -174,7 +175,7 @@ Surfaces are flat by default. Borders and tonal shifts establish structure; shad
 ### Buttons
 
 - **Shape:** compact rounded rectangle, 6px radius, minimum 36px desktop height and 44px touch height on narrow screens.
-- **Primary:** Tool Indigo fill, Paper text, 9px by 14px padding.
+- **Primary:** Tool Indigo fill, pure white text, 9px by 14px padding.
 - **Hover / Focus:** deeper fill on hover; 2px visible Tool Indigo focus ring.
 - **Secondary / Ghost:** Paper or transparent background with Hairline border and Graphite text.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,256 @@
+---
+name: Stonewright
+description: Precise, calm WordPress operations in a restrained light workspace.
+colors:
+  workspace: "#f7f8fb"
+  surface: "#fcfcfe"
+  surface-raised: "#f1f3f8"
+  border: "#dfe2ea"
+  border-strong: "#c8ceda"
+  ink: "#171921"
+  ink-secondary: "#474c57"
+  ink-muted: "#68707d"
+  brand: "#4f46e5"
+  brand-strong: "#4338ca"
+  brand-soft: "#eeefff"
+  success: "#157347"
+  success-soft: "#e7f6ee"
+  warning: "#8a5a00"
+  warning-soft: "#fff3d6"
+  danger: "#b42318"
+  danger-soft: "#fdebe9"
+  info: "#0369a1"
+  info-soft: "#e0f2fe"
+typography:
+  headline:
+    fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, system-ui, sans-serif"
+    fontSize: "24px"
+    fontWeight: 650
+    lineHeight: 1.2
+    letterSpacing: "-0.015em"
+  title:
+    fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, system-ui, sans-serif"
+    fontSize: "16px"
+    fontWeight: 650
+    lineHeight: 1.3
+  body:
+    fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, system-ui, sans-serif"
+    fontSize: "14px"
+    fontWeight: 400
+    lineHeight: 1.55
+  label:
+    fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, system-ui, sans-serif"
+    fontSize: "12px"
+    fontWeight: 600
+    lineHeight: 1.35
+  data:
+    fontFamily: "ui-monospace, SFMono-Regular, Cascadia Code, Consolas, monospace"
+    fontSize: "12px"
+    fontWeight: 500
+    lineHeight: 1.45
+rounded:
+  sm: "6px"
+  md: "10px"
+  lg: "14px"
+  pill: "999px"
+spacing:
+  xs: "4px"
+  sm: "8px"
+  md: "12px"
+  lg: "16px"
+  xl: "24px"
+  xxl: "32px"
+  section: "48px"
+components:
+  button-primary:
+    backgroundColor: "{colors.brand}"
+    textColor: "{colors.surface}"
+    typography: "{typography.label}"
+    rounded: "{rounded.sm}"
+    padding: "9px 14px"
+    height: "36px"
+  button-secondary:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.ink}"
+    typography: "{typography.label}"
+    rounded: "{rounded.sm}"
+    padding: "9px 14px"
+    height: "36px"
+  field:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body}"
+    rounded: "{rounded.sm}"
+    padding: "8px 10px"
+    height: "36px"
+  status-pill:
+    backgroundColor: "{colors.surface-raised}"
+    textColor: "{colors.ink-secondary}"
+    typography: "{typography.label}"
+    rounded: "{rounded.pill}"
+    padding: "4px 9px"
+---
+
+# Design System: Stonewright
+
+## 1. Overview
+
+**Creative North Star: "The Operator's Workbench"**
+
+Stonewright should feel like a clean, well-made instrument used in daylight on a large monitor: technical, composed, and immediately trustworthy. Light surfaces keep WordPress tasks familiar; dense information stays readable through compact type, strong alignment, and selective emphasis.
+
+Premium quality comes from exact spacing, predictable controls, honest status, and polished edge cases. The system rejects generic AI SaaS card walls, giant metrics, decorative effects, and inconsistent page-specific styling.
+
+**Key Characteristics:**
+
+- Restrained light palette with one indigo action color.
+- Compact system typography built for technical scanning.
+- Flat-by-default surfaces separated by borders and small tonal shifts.
+- Responsive structure, never horizontal overflow.
+- Clear operational states with text, shape, and color.
+
+## 2. Colors
+
+Tinted cool neutrals create a quiet workspace; indigo appears only for primary actions, focus, and current location.
+
+### Primary
+
+- **Tool Indigo** (`#4f46e5`): primary actions, current navigation, focus, and direct links.
+- **Deep Tool Indigo** (`#4338ca`): hover and active states.
+- **Indigo Wash** (`#eeefff`): selected or informational backgrounds.
+
+### Neutral
+
+- **Workbench** (`#f7f8fb`): page background.
+- **Paper** (`#fcfcfe`): cards, controls, and tables.
+- **Raised Paper** (`#f1f3f8`): hover rows, grouped metrics, and secondary panels.
+- **Graphite** (`#171921`): primary text.
+- **Slate** (`#474c57`): supporting text.
+- **Steel** (`#68707d`): metadata and labels.
+- **Hairline** (`#dfe2ea`): default border.
+
+### Named Rules
+
+**The One Tool Color Rule.** Indigo means action, focus, or current state. Never use it as decoration.
+
+**The Complete Status Rule.** Success, warning, danger, and info always pair color with explicit text or an icon.
+
+## 3. Typography
+
+**Display Font:** system UI sans
+**Body Font:** system UI sans
+**Label/Mono Font:** native UI monospace
+
+**Character:** Neutral and exact. Interface labels stay familiar; code, versions, hashes, counts, and times use stable tabular or monospaced figures.
+
+### Hierarchy
+
+- **Headline** (650, 24px, 1.2): page title only.
+- **Title** (650, 16px, 1.3): section and panel titles.
+- **Body** (400, 14px, 1.55): instructions and descriptions, capped near 70 characters.
+- **Label** (600, 12px, 1.35): controls, metadata, table headers, and badges.
+- **Data** (500, 12px, 1.45): identifiers and technical values.
+
+### Named Rules
+
+**The Compact Evidence Rule.** Metrics never exceed 20px. Technical values wrap or truncate with a reachable full-value affordance.
+
+## 4. Elevation
+
+Surfaces are flat by default. Borders and tonal shifts establish structure; shadows only separate sticky chrome, menus, focused panels, or an active hover surface.
+
+### Shadow Vocabulary
+
+- **Resting surface** (`0 1px 2px rgba(23, 25, 33, 0.05)`): optional for primary panels only.
+- **Raised control** (`0 6px 18px rgba(23, 25, 33, 0.10)`): dropdowns and sticky filters.
+- **Overlay** (`0 16px 40px rgba(23, 25, 33, 0.16)`): dialogs and floating inspectors.
+
+### Named Rules
+
+**The Flat-by-Default Rule.** No shadow on every card. Elevation must explain layer or interaction.
+
+## 5. Components
+
+### Buttons
+
+- **Shape:** compact rounded rectangle, 6px radius, minimum 36px desktop height and 44px touch height on narrow screens.
+- **Primary:** Tool Indigo fill, Paper text, 9px by 14px padding.
+- **Hover / Focus:** deeper fill on hover; 2px visible Tool Indigo focus ring.
+- **Secondary / Ghost:** Paper or transparent background with Hairline border and Graphite text.
+
+### Chips
+
+- **Style:** 22px minimum height, pill radius, semantic soft background, strong readable text, and optional 1px semantic border.
+- **State:** text remains visible without hover or selection.
+
+### Cards / Containers
+
+- **Corner Style:** 10px to 14px radius.
+- **Background:** Paper on Workbench.
+- **Shadow Strategy:** flat by default.
+- **Border:** 1px Hairline.
+- **Internal Padding:** 16px compact, 24px primary.
+
+### Inputs / Fields
+
+- **Style:** Paper background, Hairline border, 6px radius, 36px minimum desktop height.
+- **Focus:** Tool Indigo border and 2px focus ring.
+- **Error / Disabled:** explicit helper text and semantic state, never color alone.
+
+### Navigation
+
+Dark product header, compact system labels, predictable active fill, visible focus, wrapping at medium widths, and contained horizontal scrolling only when wrapping cannot preserve labels.
+
+### Dashboard Summary
+
+One grouped overview band with aligned metric cells and dividers replaces a wall of identical cards. Values stay compact; long technical values wrap safely.
+
+## 6. Do's and Don'ts
+
+### Do:
+
+- **Do** keep default workspace light using Workbench and Paper.
+- **Do** use 4px and 8px spacing increments with larger section breaks.
+- **Do** keep every control keyboard reachable with visible focus.
+- **Do** test 320px, 375px, 768px, 1024px, and 1440px widths.
+- **Do** use semantic HTML and native WordPress controls where they remain accessible.
+- **Do** expose loading, success, error, disabled, empty, and long-content states.
+
+### Don't:
+
+- **Don't** build generic AI SaaS dashboards from identical oversized metric cards.
+- **Don't** use giant type that reduces useful information density.
+- **Don't** use dark-first, neon, gradient, glassmorphism, or ornamental interfaces.
+- **Don't** ship low-contrast pills, hidden overflow, cramped controls, or unexplained status color.
+- **Don't** use colored side stripes on cards, callouts, notices, or errors.
+- **Don't** use display fonts in labels, controls, tables, or data.
+- **Don't** use `transition: all`, remove focus without replacement, or animate layout properties.
+- **Don't** ship project-specific names, URLs, memory, audit data, or credentials as product defaults.
+
+## 7. Admin Surface Audit
+
+This is the release checklist for every Stonewright-owned wp-admin surface.
+
+| Surface | Primary job | Visual contract | Risk to re-check |
+| --- | --- | --- | --- |
+| Dashboard | Scan current operating state | One compact summary band, two evidence panels, metrics at 20px or below | Long mode, URL, and activity values must wrap without changing cell width |
+| Setup | Connect and update safely | Numbered steps, grouped choices, readable code, explicit verification receipts | Release checks must bypass stale caches; secrets never enter examples |
+| AI Abilities | Search and gate tools | Sticky filters, compact grouped rows, semantic switches and buttons | Category actions must not depend on inline click handlers |
+| Sandbox | Review code before activation | Clear tabs, readable file badges, explicit primary/destructive actions | Status text and payloads must remain legible at narrow widths |
+| Design Studio | Capture and validate direction | Same sans hierarchy and shared tokens as the rest of the product | Rich editing must not introduce a second visual language |
+| Visual Workspace | Inspect and edit visually | Stable canvas/inspector hierarchy, shared controls and focus rings | Drawer, canvas, and technical values must stay usable at 320px |
+| Blueprints | Choose repeatable structures | Compact catalog cards, restrained metadata, progressive detail | Industry, mode, and hash chips must remain at least 12px |
+| Prompts | Find a safe task starter | Search-first catalog, grouped outcomes, copy action | Long prompt/tool text must wrap inside its surface |
+| Code Approval | Issue a scoped grant | Clearly labeled token, copy action, binding receipt | Token content must never be obscured, logged, or persisted accidentally |
+| Audit Log | Diagnose and understand outcomes | Filter panel, responsive rows, full-width readable payload | Payload, cause, and repair copy must never escape or collapse the table |
+| Memory | Manage durable site knowledge | Compact table, explicit lifecycle/status, edit/delete actions | Fresh installs start empty; updates preserve user data |
+| Skills | Manage reusable instructions | Catalog/editor split, clear provenance and lifecycle | Fresh installs include only product defaults; user data survives updates |
+
+### Cross-page release checks
+
+- Load every page with the shared shell and no console errors.
+- Test 320px, 375px, 768px, 1024px, and 1440px widths with zero product-level horizontal overflow.
+- Verify default, hover, focus-visible, disabled, loading, success, warning, error, empty, and long-content states.
+- Keep body copy at 12px or larger and page titles at 24px.
+- Use one light token system; page styles may extend layout, never redefine the palette.
+- Treat plugin version, release version, configured bridge version, and live companion version as different facts.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -6,46 +6,32 @@ product
 
 ## Users
 
-WordPress site owners, developers, agencies, and AI coding agents configuring
-or operating Stonewright. They need a trustworthy path from installation to a
-verified connection, then compact guidance for safe WordPress work.
+WordPress site owners, developers, agencies, and AI-assisted operators managing live sites. They work inside wp-admin, often during setup, diagnosis, implementation, or recovery, and need dense technical information without visual noise.
 
 ## Product Purpose
 
-Stonewright gives AI agents guarded, inspectable WordPress capabilities through
-Plugin mode or the pluginless Direct mode. Success means users can install,
-connect, understand the active capability surface, perform recoverable changes,
-and update both components without exposing credentials or needing to reverse
-engineer the setup.
+Stonewright connects AI clients to WordPress through guarded, inspectable workflows. Success means operators can understand current state, choose the correct action quickly, verify every write, and recover safely without exposing credentials or learning project-specific quirks from scratch.
 
 ## Brand Personality
 
-Precise, capable, and candid. Stonewright should feel like a dependable
-developer tool: calm under pressure, explicit about limits, and economical with
-the user's attention.
+Precise, calm, capable. Premium through restraint and craft, never decoration.
 
 ## Anti-references
 
-- Generic AI-product decoration, gradients, glow, or novelty that obscures the
-  task.
-- Dense walls of setup copy with no visible next action.
-- Custom controls that fight familiar WordPress administration patterns.
-- Security theatre, hidden capability differences, or success states that lack
-  verification.
-- Customer, project, site, credential, audit, or memory data in public product
-  artifacts.
+- Generic AI SaaS dashboards built from identical oversized metric cards.
+- Giant type that reduces useful information density.
+- Dark-first, neon, gradient, glassmorphism, or ornamental interfaces.
+- Low-contrast pills, hidden overflow, cramped controls, and unexplained status color.
+- Inconsistent components or project-specific data shipped as product defaults.
 
 ## Design Principles
 
-1. Make the next safe action obvious.
-2. Keep Plugin and Direct mode differences explicit and current.
-3. Show verification receipts, not optimistic claims.
-4. Keep credentials local, short-lived, and out of agent prompts.
-5. Preserve familiar WordPress interaction patterns and progressive disclosure.
+1. Task first. Every screen makes current state and next safe action obvious.
+2. Evidence over decoration. Status, history, verification, and recovery earn visual emphasis.
+3. White-space with purpose. Use a light workspace, compact typography, and deliberate grouping.
+4. One component language. Navigation, buttons, fields, badges, tables, and feedback behave consistently.
+5. Safety stays visible. Permissions, backups, confirmation, audit, and update boundaries remain clear.
 
 ## Accessibility & Inclusion
 
-Target WCAG 2.2 AA for admin surfaces. Every control must be keyboard operable,
-have a visible focus state, expose state to assistive technology, avoid
-color-only meaning, and remain usable at narrow WordPress admin widths and
-browser zoom.
+Target WCAG 2.2 AA. Full keyboard operation, visible focus, semantic controls, non-color status labels, readable contrast, reduced-motion support, zoom-safe layouts, and responsive operation from 320px through wide desktop.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Stonewright is a WordPress MCP stack for AI coding agents. **Elementor** is a fi
   ·
   <a href="docs/woocommerce.md">WooCommerce</a>
   ·
+  <a href="DESIGN.md">Design system</a>
+  ·
   <a href="CONTRIBUTING.md">Contributing</a>
 </p>
 
@@ -286,9 +288,9 @@ Two optional inputs cut payload without losing precision:
 - **`stonewright_fields`** — available on every ability. Give it dot-separated
   response paths, as a list or a comma-separated string
   (`"meta.title, outline.id"`), and the response carries only those branches.
-  Unknown paths are ignored rather than raising an error, the `ok` envelope is
-  never removed, and errors come back unprojected so you can still see why a call
-  failed.
+  Unknown paths are ignored rather than raising an error, top-level fields
+  required by the ability output schema remain present, and errors come back
+  unprojected so you can still see why a call failed.
 - **`knownHash`** on `stonewright-elementor-v3-get-page-structure` — pass the
   `hash` a previous read returned. If the document has not moved, the answer is
   `{ post_id, active, hash, unchanged: true }` and no outline or tree is built.
@@ -366,7 +368,8 @@ Plugin mode admin pages include Setup, Dashboard (Site Pulse), Abilities,
 Blueprints, Design Studio, Visual Workspace, Skills, Memory, Sandbox, and Audit
 Log. The Audit Log is the single responsive incident view; Sandbox does not
 duplicate it. The admin ships one supported light theme; there is no theme
-toggle.
+toggle. Its maintained tokens, component contracts, responsive rules, and
+page-by-page release checklist live in [DESIGN.md](DESIGN.md).
 
 Design Studio holds design directions: validated site-wide design intent with
 provenance and revisions. Visual Workspace opens the real Elementor or block

--- a/companion/CHANGELOG.md
+++ b/companion/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [1.0.0-beta.2] - 2026-07-30
+
+### Changed
+
+- Align the companion package version with the beta.2 plugin release. Direct
+  mode behavior, private state, rules, and update-preservation guarantees remain
+  unchanged.
+
 ## [1.0.0-beta.1] - 2026-07-30
 
 ### Changed

--- a/companion/package-lock.json
+++ b/companion/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@stonewright/companion",
-	"version": "1.0.0-beta.1",
+	"version": "1.0.0-beta.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@stonewright/companion",
-			"version": "1.0.0-beta.1",
+			"version": "1.0.0-beta.2",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/companion/package.json
+++ b/companion/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@stonewright/companion",
-	"version": "1.0.0-beta.1",
+	"version": "1.0.0-beta.2",
 	"description": "Node companion for the Stonewright WordPress MCP plugin: WP-CLI, health checks, and optional MCP HTTP proxy.",
 	"type": "module",
 	"license": "MIT",

--- a/companion/src/version.ts
+++ b/companion/src/version.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = '1.0.0-beta.1';
+export const APP_VERSION = '1.0.0-beta.2';
 
 export function companionPackageSpec(version: string = APP_VERSION): string {
 	return `https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v${version}/stonewright-companion-${version}.tgz`;

--- a/companion/tests/http-smoke.test.ts
+++ b/companion/tests/http-smoke.test.ts
@@ -30,7 +30,7 @@ beforeAll(async () => {
 		const url = req.url ?? '/';
 		if (url === '/health') {
 			res.writeHead(200, { 'Content-Type': 'application/json' });
-			res.end(JSON.stringify({ status: 'ok', version: '1.0.0-beta.1' }));
+			res.end(JSON.stringify({ status: 'ok', version: '1.0.0-beta.2' }));
 			return;
 		}
 		res.writeHead(404, { 'Content-Type': 'application/json' });

--- a/docs/abilities.md
+++ b/docs/abilities.md
@@ -49,7 +49,8 @@ matrix after changing the registry.
 | SEO | 3 | Multi-plugin SEO status and metadata reads/writes. |
 | Menu | 5 | Menu creation, item management, locations, and deletion. |
 
-All ability responses support optional `stonewright_fields` projection. The
+All ability responses support optional `stonewright_fields` projection while
+retaining top-level fields required by their declared output schema. The
 `stonewright/rules-get` ability serves the native registry with digest/filter
 semantics, `stonewright/memory-generalize` de-identifies memory in bounded
 batches, and `stonewright/elementor-v3-get-page-structure` accepts `knownHash`

--- a/docs/admin/configuration.md
+++ b/docs/admin/configuration.md
@@ -238,6 +238,8 @@ The update card makes the two-component boundary explicit:
 **Check latest companion** reads GitHub's latest public release, accepts
 packages only from this repository's versioned release path, and shows the
 installed plugin, latest release, and optional configured HTTP bridge version.
+An explicit click bypasses the background 12-hour release cache and browser
+caches; automatic update checks stay cached.
 The panel links the exact companion package and SHA-256 manifest and creates a
 credential-free **Copy update prompt** handoff.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -167,12 +167,14 @@ Two mechanisms trim read cost without weakening any gate:
   result. `ResponseProjection` is pure and stateless because registry ability
   instances are reused across requests — a projection remembered on an instance
   would leak one caller's request into the next caller's response. Projection
-  runs *after* the ability has produced and validated its output, so declared
-  output schemas keep describing the full response, and *before* the task-start
-  nudge is attached, so the nudge cannot be projected away. Errors pass through
-  unprojected: trimming a `WP_Error` would hide why the call failed. The parameter
-  is advertised on every strict schema because `additionalProperties: false`
-  would otherwise have the client reject it before it reached the seam.
+  runs *after* the ability has produced its output and always retains top-level
+  fields declared required by that ability's output schema. Declared contracts
+  therefore remain valid even when the caller requests a smaller payload.
+  Projection runs *before* the task-start nudge is attached, so the nudge cannot
+  be projected away. Errors pass through unprojected: trimming a `WP_Error`
+  would hide why the call failed. The parameter is advertised on every strict
+  schema because `additionalProperties: false` would otherwise have the client
+  reject it before it reached the seam.
 - **Read short-circuit.** `stonewright/elementor-v3-get-page-structure` accepts
   the `hash` it previously returned as `knownHash`. On a match it answers before
   flattening the tree or building the outline. The hash is taken from the decoded

--- a/docs/documentation-maintenance.md
+++ b/docs/documentation-maintenance.md
@@ -12,6 +12,7 @@ safety, and release claims must match the code shipped in the same commit.
 | Plugin abilities | generated `docs/ability-truth-matrix.md` |
 | Direct tools | `DIRECT_TOOL_NAMES` in `companion/src/direct/registry.ts` |
 | Current release notes | `docs/releases/<version>.md` |
+| Admin design system | `DESIGN.md` |
 | Public workflow rules | `AGENTS.md` and runtime agent instructions |
 | Installation prompts | `docs/install-prompts.md` and generated wp-admin client snippets |
 
@@ -44,6 +45,8 @@ Review every affected item in the same PR:
 - `docs/install-prompts.md`, `docs/installation.md`, `docs/onboarding.md`;
 - `docs/admin/` and `docs/getting-started/` client instructions;
 - architecture, security, capability counts, examples, and relevant skills;
+- `DESIGN.md` whenever admin tokens, components, layout, accessibility, or
+  responsive behavior changes;
 - active plans when scope, ordering, gates, or known baselines changed.
 
 If a document does not need a change, the PR description must say why its

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@ workflows with operator controls.
 - [Installation for Windows and macOS](installation.md)
 - [AI client install prompts (plugin + Direct)](install-prompts.md)
 - [Updating the plugin and companion](updates.md)
+- [Admin design system and page audit](../DESIGN.md)
 - [Documentation maintenance and release freshness](documentation-maintenance.md)
 - [All abilities by category](abilities.md)
 - [Design Spec reference](design-spec.md)
@@ -43,6 +44,7 @@ workflows with operator controls.
 | `ability-truth-matrix.md` | Generated ability gate matrix for permissions, backups, tokens, validators, and tests |
 | `companion.md` | Node companion, stdio MCP, optional HTTP bridge, and tokenized WP-CLI |
 | `updates.md` | Plugin/companion update matrix, steps, and persistence guarantees |
+| `../DESIGN.md` | Canonical light admin tokens, components, accessibility, responsive rules, and page audit |
 | `security.md` and `security-guarantees.md` | Threat model and hardening guarantees |
 | `upstream-code-reuse.md` | Third-party source, licensing, attribution, and import ledger |
 

--- a/docs/install-prompts.md
+++ b/docs/install-prompts.md
@@ -53,9 +53,9 @@ After reload:
   an unchanged registry costs one short response.
 - Treat hard rules as blocking, strong rules as required practice that the
   runtime cannot check for you, and advisory rules as guidance.
-- To keep reads cheap, pass stonewright_fields with the paths you need, and pass
-  knownHash to stonewright-elementor-v3-get-page-structure to skip an unchanged
-  page tree.
+- To keep reads cheap, pass stonewright_fields with the paths you need. Required
+  response-envelope fields remain present. Pass knownHash to
+  stonewright-elementor-v3-get-page-structure to skip an unchanged page tree.
 - For visual work, verify browser/Playwright tools before the first write.
 - Do not inspect private AI-client config files, hand-roll JSON-RPC, or run wp in a normal shell as an MCP workaround.
 - Use stonewright-php-execute for short runtime PHP; keep WP-CLI tokenized via stonewright-wp-cli-*.

--- a/docs/releases/1.0.0-beta.2.md
+++ b/docs/releases/1.0.0-beta.2.md
@@ -1,0 +1,101 @@
+# Stonewright 1.0.0-beta.2
+
+This release fixes stale companion-version reporting, strengthens response
+projection contracts, and unifies the WordPress admin interface around one
+maintained light design system.
+
+## Companion release checks
+
+- **Check latest companion** now performs a fresh trusted GitHub release read
+  instead of returning a release cached by an earlier background check.
+- The explicit browser request also uses a cache-busting URL and `no-store`.
+- Automatic WordPress update checks keep the 12-hour cache, so normal admin
+  traffic does not create unnecessary GitHub requests.
+- The result continues to distinguish the installed plugin, latest public
+  release, optional configured HTTP bridge, and the local stdio process that
+  WordPress cannot inspect.
+- Download and checksum URLs still have to match the official Stonewright
+  repository and exact release tag.
+
+## Response efficiency
+
+- `stonewright_fields` still projects read responses to requested paths.
+- Every top-level field declared required by the ability output schema now
+  survives that projection.
+- Compact `stonewright-task-start` responses therefore retain the full required
+  handshake envelope, including `ok`, `context_token`, `mode`,
+  `auth_guidance`, and `fast_path`.
+- Integer-keyed maps, list member order, error responses, and the task-start
+  nudge retain their existing guarantees.
+
+## Admin design system
+
+- Add a maintained root `DESIGN.md` with the light palette, type, spacing,
+  radius, elevation, component, responsive, accessibility, and page-specific
+  release contracts.
+- Replace the Dashboard card wall with one compact summary band plus balanced
+  activity and audit panels.
+- Keep metric values at 20px or below and make technical values wrap without
+  widening their cells.
+- Align Setup, Abilities, Sandbox, Audit Log, Design Studio, Visual Workspace,
+  Blueprints, Prompts, Memory, Skills, and Code Approval on the same tokens.
+- Center the complete Domain Lock group, not only its container.
+- Give Sandbox file-type badges explicit readable foreground, background,
+  border, and minimum height.
+- Replace colored side stripes with complete bordered callouts.
+- Correct low-contrast setup code blocks, Visual Workspace focus outlines,
+  undersized metadata, and the inline click handler on ability category actions.
+- Keep the supported interface light-only and responsive without product-level
+  horizontal overflow.
+
+## Direct mode and persistent state
+
+- Direct mode remains first-class and ships at the same beta.2 companion
+  version.
+- Its tools, private state location, native rules, write gates, redaction, and
+  WooCommerce read-only boundary are unchanged.
+- Plugin and companion updates preserve existing memory, user skills, audit
+  history, site configuration, backups, content, and admin settings.
+- A genuinely fresh Plugin or Direct installation still starts without user
+  memory, user-created skills, or audit events.
+
+## Abilities and gates
+
+- Plugin mode exposes **346** abilities.
+- Direct mode exposes **100** tools.
+- Existing permission, backup, validation, confirmation, Elementor integrity,
+  audit, credential, archive-hygiene, and readback gates remain in force.
+
+## Package versions
+
+- WordPress plugin and companion: `1.0.0-beta.2`.
+- `@stonewright/visual`: `0.4.0`.
+
+## Verification
+
+The release is tagged only from a pull request whose complete CI matrix is
+green. Release gates cover:
+
+- plugin tests, PHPStan, PHPCS, security, dependency, provenance, public API,
+  documentation, and token budgets;
+- companion tests, typecheck, lint, contracts, token budgets, and production
+  build;
+- Visual tests, typecheck, and production build;
+- clean production Composer installation, Jetpack manifest validation, staged
+  archive inspection, and public-repository hygiene;
+- WordPress and WooCommerce co-activation from the extracted release archive;
+- responsive wp-admin Playwright coverage without console errors or horizontal
+  overflow.
+
+GitHub release assets must contain the versioned plugin ZIP, companion TGZ,
+Visual TGZ, and `SHA256SUMS.txt`.
+
+## Upgrade
+
+For local stdio, update both the WordPress plugin and companion to
+`1.0.0-beta.2`, fully restart the AI client, call `stonewright-task-start`, and
+verify `companion_version`, `expected_companion_package`, and
+`refresh_required_tool_names`. Remote Streamable HTTP updates only the plugin;
+pluginless Direct mode updates only the companion.
+
+See [Updating Stonewright](../updates.md).

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -38,6 +38,9 @@ companion**. The result compares:
 - the latest trusted GitHub release;
 - the optional configured HTTP bridge, when WordPress can reach it.
 
+This explicit check refreshes the official release immediately. Automatic
+background checks remain cached to avoid unnecessary GitHub requests.
+
 Local stdio runs inside the AI client, so WordPress cannot inspect or replace
 that process directly. Use **Copy update prompt** to hand a credential-free
 update request to the agent, or use **Download official companion** and verify

--- a/e2e/tests/admin-remediation-ui.spec.ts
+++ b/e2e/tests/admin-remediation-ui.spec.ts
@@ -113,23 +113,25 @@ test('companion update handoff is explicit and never claims browser-side install
 }, testInfo) => {
 	test.skip(testInfo.project.name !== 'desktop-1440-light', 'Connect handoff runs once.');
 	await login(page);
+	let statusRequestUrl = '';
 	await page.route('**/stonewright/v1/admin/companion-update-status*', async (route) => {
+		statusRequestUrl = route.request().url();
 		await route.fulfill({
 			status: 200,
 			contentType: 'application/json',
 			body: JSON.stringify({
 				ok: true,
-				plugin_version: '1.0.0-beta.1',
-				latest_release_version: '1.0.0-beta.1',
+				plugin_version: '1.0.0-beta.2',
+				latest_release_version: '1.0.0-beta.2',
 				plugin_update_available: false,
 				companion_status: 'unverified',
 				companion_package:
-					'https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.1/stonewright-companion-1.0.0-beta.1.tgz',
+					'https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.2/stonewright-companion-1.0.0-beta.2.tgz',
 				checksums:
-					'https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.1/SHA256SUMS.txt',
+					'https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.2/SHA256SUMS.txt',
 				bridge: { reachable: false, version: '' },
 				update_prompt:
-					'Update the Stonewright companion used by this AI client to 1.0.0-beta.1. Do not print, reveal, move, or commit credentials.',
+					'Update the Stonewright companion used by this AI client to 1.0.0-beta.2. Do not print, reveal, move, or commit credentials.',
 				boundary:
 					'WordPress cannot replace a local stdio companion process. Update it in the AI client.',
 			}),
@@ -145,6 +147,7 @@ test('companion update handoff is explicit and never claims browser-side install
 		'The browser cannot replace an stdio process on your computer.',
 	);
 	await check.click();
+	await expect.poll(() => statusRequestUrl).toContain('force=1');
 	const prompt = page.locator('#stonewright-companion-update-prompt');
 	await expect(prompt).toBeVisible();
 	await expect(prompt).toHaveValue(/Do not print, reveal, move, or commit credentials/);

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## [Unreleased]
 
+## [1.0.0-beta.2] - 2026-07-30
+
+### Added
+
+- A maintained light-mode design system and page-by-page admin release
+  checklist.
+
+### Changed
+
+- Replace oversized Dashboard metric cards with a compact grouped overview.
+- Align all wp-admin surfaces on the same typography, spacing, border, focus,
+  badge, and status language.
+
+### Fixed
+
+- Force explicit companion release checks past stale WordPress and browser
+  caches without disabling background caching.
+- Keep required output-schema fields in projected responses, including the
+  compact task-start handshake.
+- Center Domain Lock controls, restore Sandbox file-type contrast, remove an
+  inline category-action click handler, and correct setup code contrast and
+  Visual Workspace focus outlines.
+
 ## [1.0.0-beta.1] - 2026-07-30
 
 ### Added

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,6 +1,6 @@
 # Stonewright Plugin
 
-Version: 1.0.0-beta.1
+Version: 1.0.0-beta.2
 Requires WordPress: 6.7+
 Requires PHP: 8.1+
 License: AGPL-3.0-or-later
@@ -51,8 +51,8 @@ See [Updating Stonewright](../docs/updates.md) for plugin/companion version
 matching, upgrade steps, and persistence guarantees.
 The Connect update panel can read the latest trusted release, compare an
 optional configured HTTP bridge, and copy a credential-free companion update
-prompt. A local stdio process still has to be replaced and restarted inside its
-AI client.
+prompt. An explicit check bypasses the background release cache. A local stdio
+process still has to be replaced and restarted inside its AI client.
 
 Normal MCP clients launch the versioned companion release tarball with `npx`.
 Use the admin **Local WP-CLI bridge (advanced)** controls only when you
@@ -257,6 +257,8 @@ says so and prints the build command. See
 The admin UI ships a single light theme. There is no dark mode and no theme
 toggle: maintaining two token sets meant every contrast fix had to be made twice,
 and one of the two was always the stale one.
+The canonical tokens, component rules, responsive requirements, and complete
+surface audit are maintained in [`../DESIGN.md`](../DESIGN.md).
 
 ## Code Payload Handling
 

--- a/plugin/assets/admin/admin.css
+++ b/plugin/assets/admin/admin.css
@@ -7,10 +7,12 @@
 /* Status badges                                                        */
 /* ------------------------------------------------------------------ */
 .stonewright-badge {
-	display: inline-block;
-	padding: 1px 8px;
-	border-radius: 3px;
-	font-size: 11px;
+	display: inline-flex;
+	align-items: center;
+	min-height: 22px;
+	padding: 2px 8px;
+	border-radius: var(--sw-radius-pill);
+	font-size: var(--sw-text-xs);
 	font-weight: 600;
 	line-height: 1.6;
 }
@@ -73,11 +75,15 @@
 	align-items: flex-start;
 	justify-content: space-between;
 	gap: 16px;
-	margin: 18px 0;
+	margin: 0 0 var(--sw-space-5);
 }
 
 .stonewright-page-header h1 {
 	margin: 0 0 4px;
+	font-size: var(--sw-text-2xl);
+	font-weight: 650;
+	line-height: 1.2;
+	letter-spacing: -.015em;
 }
 
 .stonewright-page-header p {
@@ -110,7 +116,7 @@
 .stonewright-panel {
 	background: var(--sw-surface);
 	border: 1px solid var(--sw-border);
-	border-radius: 6px;
+	border-radius: var(--sw-radius);
 	margin: 0 0 14px;
 	padding: 16px;
 }
@@ -125,7 +131,7 @@
 .stonewright-guidance-card {
 	background: var(--sw-surface);
 	border: 1px solid var(--sw-border);
-	border-radius: 6px;
+	border-radius: var(--sw-radius);
 	padding: 14px;
 }
 
@@ -331,9 +337,11 @@
 }
 
 .sw-badge {
-	border-radius: 3px;
-	display: inline-block;
-	font-size: 11px;
+	border-radius: var(--sw-radius-pill);
+	display: inline-flex;
+	align-items: center;
+	min-height: 22px;
+	font-size: var(--sw-text-xs);
 	font-weight: 700;
 	line-height: 1.7;
 	padding: 1px 8px;
@@ -357,7 +365,7 @@
 	border-radius: 999px;
 	display: inline-flex;
 	align-items: center;
-	font-size: 11px;
+	font-size: var(--sw-text-xs);
 	font-weight: 600;
 	line-height: 1;
 	height: 22px;
@@ -463,22 +471,22 @@
 }
 
 .stonewright-risk-notice {
-	border-left: 4px solid var(--sw-warn-text);
+	border: 1px solid var(--sw-warn-text);
 	background: var(--sw-warn-soft);
 	color: var(--sw-warn-text);
 	margin: 10px 0 12px;
 	padding: 9px 12px;
-	border-radius: 4px;
+	border-radius: var(--sw-radius-sm);
 }
 
 .stonewright-risk-notice--ok {
-	border-left-color: var(--sw-ok-text);
+	border-color: var(--sw-ok-text);
 	background: var(--sw-ok-soft);
 	color: var(--sw-ok-text);
 }
 
 .stonewright-risk-notice--info {
-	border-left-color: var(--sw-brand);
+	border-color: var(--sw-brand);
 	background: var(--sw-bg);
 	color: var(--sw-text);
 }
@@ -527,7 +535,8 @@
 
 .stonewright-app-password-success {
 	background: var(--sw-ok-soft);
-	border-left: 4px solid var(--sw-ok-text);
+	border: 1px solid var(--sw-ok-text);
+	border-radius: var(--sw-radius-sm);
 	display: grid;
 	gap: 8px;
 	margin: 12px 0;
@@ -555,7 +564,8 @@
 
 .stonewright-share-warning {
 	background: var(--sw-bg);
-	border-left: 4px solid var(--sw-brand);
+	border: 1px solid var(--sw-border-strong);
+	border-radius: var(--sw-radius-sm);
 	margin: 12px 0;
 	padding: 10px 12px;
 }
@@ -773,7 +783,7 @@
 
 .stonewright-provider-name {
 	color: var(--sw-text-muted);
-	font-size: 11px;
+	font-size: var(--sw-text-xs);
 	font-weight: 700;
 	letter-spacing: 0;
 	text-transform: uppercase;
@@ -790,7 +800,7 @@
 .stonewright-ability-table__head {
 	border-bottom: 1px solid var(--sw-border);
 	color: var(--sw-text-muted);
-	font-size: 11px;
+	font-size: var(--sw-text-xs);
 	font-weight: 700;
 	text-transform: uppercase;
 }
@@ -831,9 +841,11 @@
 }
 
 .stonewright-kind-badge {
-	border-radius: 3px;
-	display: inline-block;
-	font-size: 11px;
+	border-radius: var(--sw-radius-pill);
+	display: inline-flex;
+	align-items: center;
+	min-height: 22px;
+	font-size: var(--sw-text-xs);
 	font-weight: 700;
 	line-height: 1.7;
 	padding: 1px 8px;

--- a/plugin/assets/admin/admin.js
+++ b/plugin/assets/admin/admin.js
@@ -483,9 +483,13 @@
 
 				button.disabled = true;
 				setButtonFeedback( button, 'Checking release…' );
-				window.fetch( url, {
+				var refreshUrl = new window.URL( url, window.location.href );
+				refreshUrl.searchParams.set( 'force', '1' );
+				refreshUrl.searchParams.set( '_', String( Date.now() ) );
+				window.fetch( refreshUrl.toString(), {
 					method: 'GET',
 					credentials: 'same-origin',
+					cache: 'no-store',
 					headers: {
 						'X-WP-Nonce': nonce || '',
 						'Accept': 'application/json',
@@ -662,7 +666,8 @@
 		} );
 
 		document.querySelectorAll( '[data-sw-bulk-action]' ).forEach( function ( button ) {
-			button.addEventListener( 'click', function () {
+			button.addEventListener( 'click', function ( event ) {
+				event.stopPropagation();
 				var action = button.getAttribute( 'data-sw-bulk-action' ) || '';
 				var category = button.getAttribute( 'data-sw-bulk-category' ) || '';
 				var actionSelect = document.querySelector( 'select[name="stonewright_bulk_action"]' );

--- a/plugin/assets/admin/audit.css
+++ b/plugin/assets/admin/audit.css
@@ -124,7 +124,8 @@
 .sw-audit-error-cause {
 	margin: 0 0 var(--sw-space-2);
 	padding: var(--sw-space-2) var(--sw-space-3);
-	border-left: 3px solid var(--sw-danger-text);
+	border: 1px solid var(--sw-danger-text);
+	border-radius: var(--sw-radius-sm);
 	background: var(--sw-danger-soft);
 	color: var(--sw-danger-text);
 	font-size: var(--sw-text-sm);
@@ -172,7 +173,7 @@
 	box-sizing: border-box;
 	overflow: auto;
 	font-family: var(--sw-font-mono);
-	font-size: 11px;
+	font-size: var(--sw-text-xs);
 	line-height: 1.45;
 	background: var(--sw-bg);
 	color: var(--sw-text);

--- a/plugin/assets/admin/blueprints.css
+++ b/plugin/assets/admin/blueprints.css
@@ -43,8 +43,9 @@
 .sw-prompt-safety {
 	margin: 0 0 16px;
 	padding: 12px 14px;
-	border-left: 3px solid var(--sw-brand);
-	background: var(--sw-surface);
+	border: 1px solid var(--sw-border-strong);
+	border-radius: var(--sw-radius-sm);
+	background: var(--sw-surface-raised);
 	color: var(--sw-text-secondary);
 	font-size: var(--sw-text-sm);
 	line-height: 1.5;
@@ -114,7 +115,7 @@
 
 .sw-blueprint-card__industry {
 	align-self: flex-start;
-	font-size: 10px;
+	font-size: var(--sw-text-xs);
 	font-weight: 600;
 	letter-spacing: 0.08em;
 	text-transform: uppercase;
@@ -137,7 +138,7 @@
 	border-radius: var(--sw-radius-pill);
 	background: var(--sw-brand-soft);
 	color: var(--sw-brand-strong);
-	font-size: 10px;
+	font-size: var(--sw-text-xs);
 	font-weight: 600;
 }
 
@@ -165,7 +166,7 @@
 	flex-wrap: wrap;
 	margin: 0;
 	color: var(--sw-text-muted);
-	font-size: 11px;
+	font-size: var(--sw-text-xs);
 	font-weight: 400;
 }
 
@@ -177,7 +178,7 @@
 	padding: 2px 6px;
 	color: var(--sw-text-secondary);
 	font-family: var(--sw-font-mono);
-	font-size: 10px;
+	font-size: var(--sw-text-xs);
 	font-weight: 400;
 	line-height: 1.3;
 	max-width: 100%;
@@ -192,7 +193,7 @@
 }
 
 .sw-prompt-details {
-	font-size: 11px;
+	font-size: var(--sw-text-xs);
 	color: var(--sw-text-muted);
 }
 

--- a/plugin/assets/admin/dashboard.css
+++ b/plugin/assets/admin/dashboard.css
@@ -8,36 +8,40 @@
 
 .sw-stat-grid {
 	display: grid;
-	/* minmax floor must stay below ~280px usable width at 320 viewport. */
-	grid-template-columns: repeat(auto-fit, minmax(min(100%, 140px), 1fr));
-	gap: var(--sw-space-4);
+	grid-template-columns: repeat(auto-fit, minmax(min(100%, 150px), 1fr));
+	gap: 1px;
 	margin: 0 0 var(--sw-space-6);
+	overflow: hidden;
+	background: var(--sw-border);
+	border: 1px solid var(--sw-border);
+	border-radius: var(--sw-radius-lg);
 }
 
 .sw-stat-card {
-	display: flex;
-	flex-direction: column;
-	gap: var(--sw-space-2);
-	padding: var(--sw-space-5);
-	background: var(--sw-color-card, var(--sw-surface));
-	border: 1px solid var(--sw-color-border, var(--sw-gray-200));
-	border-radius: var(--sw-radius);
-	box-shadow: var(--sw-shadow-1);
+	display: grid;
+	grid-template-columns: auto minmax(0, 1fr);
+	align-content: start;
+	gap: var(--sw-space-1) var(--sw-space-2);
+	padding: var(--sw-space-4);
+	background: var(--sw-surface);
 	min-width: 0;
 }
 
 .sw-stat-card__icon {
-	font-size: var(--sw-text-xl);
+	grid-row: 1 / span 2;
+	margin-top: 2px;
+	font-size: var(--sw-text-lg);
 	color: var(--sw-brand);
 	line-height: 1;
 }
 
 .sw-stat-card__value {
-	font-size: var(--sw-text-xl);
-	font-weight: 700;
+	grid-column: 2;
+	font-size: 18px;
+	font-weight: 650;
 	color: var(--sw-color-text);
 	line-height: 1.2;
-	word-break: break-word;
+	overflow-wrap: anywhere;
 	font-variant-numeric: tabular-nums;
 }
 
@@ -45,7 +49,7 @@
 	display: flex;
 	align-items: baseline;
 	gap: var(--sw-space-2);
-	font-size: 28px;
+	font-size: 20px;
 	line-height: 1;
 }
 
@@ -81,32 +85,50 @@
 }
 
 .sw-stat-card__value code {
-	font-size: inherit;
-	background: transparent;
+	font-size: var(--sw-text-md);
+	font-weight: 600;
+	background: transparent !important;
+	border: 0 !important;
 	padding: 0;
+	color: inherit !important;
+	white-space: normal;
+	overflow-wrap: anywhere;
 }
 
 .sw-stat-card__label {
-	font-size: var(--sw-text-sm);
+	grid-column: 2;
+	font-size: var(--sw-text-xs);
 	font-weight: 600;
 	color: var(--sw-color-muted);
 }
 
 .sw-stat-card__meta {
+	grid-column: 2;
 	font-size: var(--sw-text-xs);
 	color: var(--sw-color-muted);
 }
 
 .sw-stat-card__link {
-	margin-top: auto;
-	font-size: var(--sw-text-sm);
+	grid-column: 2;
+	margin-top: var(--sw-space-1);
+	width: fit-content;
+	font-size: var(--sw-text-xs);
 	font-weight: 600;
 }
 
 .sw-dashboard-panels {
 	display: grid;
-	grid-template-columns: 1fr 1.2fr;
+	grid-template-columns: minmax(0, .8fr) minmax(0, 1.2fr);
 	gap: var(--sw-space-5);
+	align-items: start;
+}
+
+.sw-dashboard-panel {
+	min-width: 0;
+	padding: var(--sw-space-5);
+	background: var(--sw-surface);
+	border: 1px solid var(--sw-border);
+	border-radius: var(--sw-radius-lg);
 }
 
 .sw-dashboard-panel .sw-card__header,
@@ -123,10 +145,12 @@
 .sw-card h2 {
 	margin: 0;
 	font-size: var(--sw-text-lg);
+	font-weight: 650;
 }
 
 .sw-sparkline {
 	color: var(--sw-brand);
+	padding-top: var(--sw-space-2);
 }
 
 .sw-sparkline svg {
@@ -157,7 +181,7 @@
 	gap: var(--sw-space-2) var(--sw-space-3);
 	padding: var(--sw-space-3);
 	border-radius: var(--sw-radius-sm);
-	background: var(--sw-gray-50);
+	background: var(--sw-surface-raised);
 }
 
 .sw-audit-feed__item time {
@@ -184,6 +208,12 @@
 
 @media screen and (max-width: 960px) {
 	.sw-dashboard-panels {
+		grid-template-columns: 1fr;
+	}
+}
+
+@media screen and (max-width: 480px) {
+	.sw-stat-grid {
 		grid-template-columns: 1fr;
 	}
 }

--- a/plugin/assets/admin/design-studio.css
+++ b/plugin/assets/admin/design-studio.css
@@ -12,8 +12,8 @@
 	--sw-ds-radius-sm: 10px;
 	--sw-ds-radius-lg: 14px;
 	--sw-ds-rule: 1px solid var(--sw-border);
-	--sw-ds-serif: 'Iowan Old Style', 'Palatino Linotype', Palatino, 'Book Antiqua', Georgia, serif;
-	--sw-ds-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+	--sw-ds-serif: var(--sw-font-sans);
+	--sw-ds-sans: var(--sw-font-sans);
 
 	max-width: var(--sw-shell-content-max, 1200px);
 	color: var(--sw-text);

--- a/plugin/assets/admin/sandbox.css
+++ b/plugin/assets/admin/sandbox.css
@@ -121,6 +121,20 @@
 	color: var(--sw-on-brand) !important;
 }
 
+.stonewright-sandbox-page .sw-badge--category {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 22px;
+	padding: 2px var(--sw-space-2);
+	background: var(--sw-info-soft) !important;
+	color: var(--sw-info-text) !important;
+	border: 1px solid var(--sw-border-strong);
+	border-radius: var(--sw-radius-pill);
+	font-size: var(--sw-text-xs);
+	line-height: 1.2;
+}
+
 .stonewright-sandbox-page .button.button-link-delete {
 	color: var(--sw-danger-text) !important;
 }

--- a/plugin/assets/admin/setup.css
+++ b/plugin/assets/admin/setup.css
@@ -414,7 +414,7 @@
 	max-width: 100%;
 	max-height: 280px;
 	background: var(--sw-ink);
-	color: var(--sw-text-muted);
+	color: var(--sw-on-brand);
 	border-radius: var(--sw-radius-sm);
 	font-family: var(--sw-font-mono);
 	font-size: var(--sw-text-xs);
@@ -514,7 +514,8 @@
 .sw-update-security {
 	margin: var(--sw-space-4) 0 0;
 	padding: var(--sw-space-3);
-	border-left: 3px solid var(--sw-warning);
+	border: 1px solid var(--sw-warning);
+	border-radius: var(--sw-radius-sm);
 	background: var(--sw-warning-bg);
 	color: var(--sw-text);
 }
@@ -529,13 +530,16 @@
 
 .sw-companion-update-result__summary {
 	margin: 0 0 var(--sw-space-3);
-	padding-left: var(--sw-space-3);
-	border-left: 3px solid var(--sw-info-text);
+	padding: var(--sw-space-3);
+	border: 1px solid var(--sw-info-text);
+	border-radius: var(--sw-radius-sm);
+	background: var(--sw-info-soft);
 	color: var(--sw-text-secondary);
 }
 
 .sw-companion-update-result__summary--warn {
-	border-left-color: var(--sw-warn-text);
+	border-color: var(--sw-warn-text);
+	background: var(--sw-warn-soft);
 	color: var(--sw-warn-text);
 }
 
@@ -620,7 +624,7 @@
 .sw-oauth-tab.is-active {
 	background: var(--sw-brand);
 	border-color: var(--sw-brand);
-	color: var(--sw-brand-contrast);
+	color: var(--sw-on-brand);
 }
 
 .sw-oauth-client-panel {
@@ -638,7 +642,7 @@
 	white-space: pre-wrap;
 	overflow-wrap: anywhere;
 	background: var(--sw-ink);
-	color: var(--sw-text-muted);
+	color: var(--sw-on-brand);
 	border-radius: var(--sw-radius-sm);
 	font: var(--sw-text-xs)/1.5 var(--sw-font-mono);
 }

--- a/plugin/assets/admin/shell.css
+++ b/plugin/assets/admin/shell.css
@@ -26,7 +26,7 @@
 	--sw-brand-fill: #4f46e5;
 	--sw-brand-fill-hover: #4338ca;
 	--sw-brand-soft: #eeefff;
-	--sw-on-brand: #fcfcfe;
+	--sw-on-brand: #ffffff;
 
 	/* status */
 	--sw-ok-text: #157347;

--- a/plugin/assets/admin/shell.css
+++ b/plugin/assets/admin/shell.css
@@ -8,16 +8,16 @@
 /* ============ Semantic tokens — LIGHT (default) ============ */
 :root {
 	/* surfaces */
-	--sw-bg: #f6f7f9;
-	--sw-surface: #ffffff;
-	--sw-surface-raised: #ffffff;
-	--sw-border: #e4e6eb;
-	--sw-border-strong: #cfd3da;
+	--sw-bg: #f7f8fb;
+	--sw-surface: #fcfcfe;
+	--sw-surface-raised: #f1f3f8;
+	--sw-border: #dfe2ea;
+	--sw-border-strong: #c8ceda;
 
 	/* text hierarchy: primary / secondary / muted on surface */
-	--sw-text: #16181d;
-	--sw-text-secondary: #4b5058;
-	--sw-text-muted: #6b7076;
+	--sw-text: #171921;
+	--sw-text-secondary: #474c57;
+	--sw-text-muted: #68707d;
 	--sw-text-invert: #ffffff;
 
 	/* brand indigo family */
@@ -25,14 +25,14 @@
 	--sw-brand-strong: #4338ca;
 	--sw-brand-fill: #4f46e5;
 	--sw-brand-fill-hover: #4338ca;
-	--sw-brand-soft: #eef0fe;
-	--sw-on-brand: #ffffff;
+	--sw-brand-soft: #eeefff;
+	--sw-on-brand: #fcfcfe;
 
 	/* status */
 	--sw-ok-text: #157347;
 	--sw-ok-soft: #e7f6ee;
-	--sw-warn-text: #9a6700;
-	--sw-warn-soft: #fdf3d9;
+	--sw-warn-text: #8a5a00;
+	--sw-warn-soft: #fff3d6;
 	--sw-danger-text: #b42318;
 	--sw-danger-soft: #fdebe9;
 	--sw-info-text: #0369a1;
@@ -41,9 +41,9 @@
 	--sw-focus-ring: #4f46e5;
 
 	/* shadows (light) */
-	--sw-shadow-1: 0 1px 2px rgba(22, 24, 29, .06), 0 1px 3px rgba(22, 24, 29, .08);
-	--sw-shadow-2: 0 4px 12px rgba(22, 24, 29, .10);
-	--sw-shadow-3: 0 12px 32px rgba(22, 24, 29, .16);
+	--sw-shadow-1: 0 1px 2px rgba(23, 25, 33, .05);
+	--sw-shadow-2: 0 6px 18px rgba(23, 25, 33, .10);
+	--sw-shadow-3: 0 16px 40px rgba(23, 25, 33, .16);
 
 	/* header (always dark chrome) */
 	--sw-shell-header-bg: #16181d;
@@ -70,12 +70,14 @@
 	--sw-text-md: 14px;
 	--sw-text-lg: 16px;
 	--sw-text-xl: 20px;
-	--sw-text-2xl: 28px;
+	--sw-text-2xl: 24px;
+	--sw-font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
 	--sw-font-mono: ui-monospace, 'SF Mono', 'Cascadia Code', Consolas, monospace;
 
 	/* Elevation + motion */
-	--sw-radius: 12px;
-	--sw-radius-sm: 8px;
+	--sw-radius: 10px;
+	--sw-radius-sm: 6px;
+	--sw-radius-lg: 14px;
 	--sw-radius-pill: 999px;
 	--sw-ease: cubic-bezier(.25, .46, .45, .94);
 	--sw-dur: 150ms;
@@ -93,6 +95,7 @@
 	--sw-color-muted: var(--sw-text-muted);
 	--sw-color-bg: var(--sw-bg);
 	--sw-color-pre: var(--sw-bg);
+	--sw-surface-subtle: var(--sw-surface-raised);
 	--sw-ink: var(--sw-text);
 	--sw-ink-soft: var(--sw-text-secondary);
 	--sw-gray-50: var(--sw-bg);
@@ -145,6 +148,9 @@
 	min-height: calc(100vh - 32px);
 	box-sizing: border-box;
 	color: var(--sw-text);
+	font-family: var(--sw-font-sans);
+	font-size: var(--sw-text-md);
+	line-height: 1.55;
 	overflow-x: hidden;
 }
 
@@ -213,7 +219,7 @@
 
 .sw-shell__nav-group-label {
 	display: none;
-	font-size: 10px;
+	font-size: var(--sw-text-xs);
 	font-weight: 600;
 	letter-spacing: 0.06em;
 	text-transform: uppercase;
@@ -393,7 +399,7 @@
 	background: var(--sw-surface-raised) !important;
 	color: var(--sw-text-muted) !important;
 	border-bottom: 1px solid var(--sw-border) !important;
-	font-size: 11px;
+	font-size: var(--sw-text-xs);
 	font-weight: 600;
 	letter-spacing: 0.04em;
 	text-transform: uppercase;
@@ -436,7 +442,7 @@
 	border: 1px solid var(--sw-border);
 	border-radius: 4px;
 	padding: 1px 6px;
-	font-size: 11px;
+	font-size: var(--sw-text-xs);
 }
 
 .sw-shell .subsubsub {
@@ -605,7 +611,7 @@ html.sw-has-shell {
 .sw-shell .sw-notice.notice {
 	margin: 0 0 var(--sw-space-4);
 	border-radius: var(--sw-radius-sm);
-	border-left-width: 4px;
+	border-left-width: 1px;
 	background: var(--sw-surface);
 	color: var(--sw-text);
 }
@@ -620,7 +626,7 @@ html.sw-has-shell {
 	height: 36px;
 	padding: 0 var(--sw-space-4);
 	border-radius: var(--sw-radius-sm);
-	font-size: var(--sw-text-md);
+	font-size: var(--sw-text-xs);
 	font-weight: 600;
 	line-height: 1;
 	cursor: pointer;
@@ -693,9 +699,9 @@ html.sw-has-shell {
 }
 
 .sw-btn--sm {
-	height: 28px;
+	height: 32px;
 	padding: 0 var(--sw-space-3);
-	font-size: var(--sw-text-sm);
+	font-size: var(--sw-text-xs);
 }
 
 .sw-btn[disabled] {
@@ -860,7 +866,12 @@ html.sw-has-shell {
 /* ------------------------------------------------------------------ */
 .sw-shell .stonewright-domain-lock-status {
 	margin: var(--sw-space-6) auto 0;
-	max-width: 560px;
+	width: min(100%, 560px);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-wrap: wrap;
+	gap: var(--sw-space-2);
 	text-align: center;
 	padding: var(--sw-space-4);
 	background: var(--sw-surface-raised);
@@ -868,6 +879,12 @@ html.sw-has-shell {
 	border-radius: var(--sw-radius-sm);
 	color: var(--sw-text-secondary);
 	font-size: var(--sw-text-sm);
+}
+
+.sw-shell .stonewright-domain-lock-status .stonewright-inline-form {
+	display: inline-flex;
+	align-items: center;
+	margin: 0;
 }
 
 /* ------------------------------------------------------------------ */

--- a/plugin/assets/admin/skills-memory.css
+++ b/plugin/assets/admin/skills-memory.css
@@ -276,7 +276,7 @@
 	height: 22px;
 	padding: 0 10px;
 	border-radius: 999px;
-	font-size: 11px;
+	font-size: var(--sw-text-xs);
 	font-weight: 600;
 	letter-spacing: 0.02em;
 	text-transform: lowercase;

--- a/plugin/assets/admin/visual-workspace.css
+++ b/plugin/assets/admin/visual-workspace.css
@@ -13,8 +13,8 @@
 	--sw-vw-radius: 12px;
 	--sw-vw-radius-sm: 10px;
 	--sw-vw-rule: 1px solid var(--sw-border);
-	--sw-vw-serif: 'Iowan Old Style', 'Palatino Linotype', Palatino, 'Book Antiqua', Georgia, serif;
-	--sw-vw-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+	--sw-vw-serif: var(--sw-font-sans);
+	--sw-vw-sans: var(--sw-font-sans);
 
 	max-width: var(--sw-shell-content-max, 1200px);
 	color: var(--sw-text);
@@ -34,7 +34,7 @@
 }
 
 .sw-visual-page :focus-visible {
-	outline: var(--sw-focus-ring);
+	outline: 2px solid var(--sw-focus-ring);
 	outline-offset: 2px;
 }
 

--- a/plugin/includes/Admin/AbilitiesPage.php
+++ b/plugin/includes/Admin/AbilitiesPage.php
@@ -164,7 +164,7 @@ final class AbilitiesPage {
 								);
 								?>
 							</span>
-							<span class="sw-ability-category__actions sw-actions" onclick="event.preventDefault();">
+							<span class="sw-ability-category__actions sw-actions">
 								<button
 									type="submit"
 									form="stonewright-bulk-form"

--- a/plugin/includes/Admin/CompanionUpdateStatus.php
+++ b/plugin/includes/Admin/CompanionUpdateStatus.php
@@ -16,11 +16,12 @@ final class CompanionUpdateStatus {
 
 	/**
 	 * @param callable|null $bridge_transport Test seam matching wp_safe_remote_get.
+	 * @param bool          $force_refresh    Ignore the cached release for an explicit user check.
 	 * @return array<string, mixed>
 	 */
-	public static function report( ?callable $bridge_transport = null ): array {
+	public static function report( ?callable $bridge_transport = null, bool $force_refresh = false ): array {
 		$plugin_version = defined( 'STONEWRIGHT_VERSION' ) ? (string) constant( 'STONEWRIGHT_VERSION' ) : '0.0.0';
-		$release        = GitHubUpdater::fetch_latest_release();
+		$release        = GitHubUpdater::fetch_latest_release( $force_refresh );
 		$latest_version = is_array( $release ) ? (string) ( $release['version'] ?? '' ) : '';
 		$target_version = '' !== $latest_version ? $latest_version : $plugin_version;
 		$bridge         = self::bridge_health( $bridge_transport );

--- a/plugin/includes/Admin/Pages/StatusPage.php
+++ b/plugin/includes/Admin/Pages/StatusPage.php
@@ -77,7 +77,7 @@ final class StatusPage {
 			<div class="sw-stat-grid stonewright-status-grid">
 				<?php if ( null !== $pulse_score ) : ?>
 					<article class="sw-stat-card sw-stat-card--pulse">
-						<span class="sw-stat-card__icon" aria-hidden="true">◎</span>
+						<span class="sw-stat-card__icon dashicons dashicons-chart-area" aria-hidden="true"></span>
 						<div class="sw-stat-card__value">
 							<span class="sw-pulse-score"><?php echo esc_html( (string) $pulse_score ); ?></span>
 							<?php if ( '' !== $pulse_grade ) : ?>
@@ -96,7 +96,7 @@ final class StatusPage {
 				<?php endif; ?>
 
 				<article class="sw-stat-card">
-					<span class="sw-stat-card__icon" aria-hidden="true">⬡</span>
+					<span class="sw-stat-card__icon dashicons dashicons-shield" aria-hidden="true"></span>
 					<div class="sw-stat-card__value"><code><?php echo esc_html( $mode ); ?></code></div>
 					<div class="sw-stat-card__label"><?php esc_html_e( 'Mode', 'stonewright' ); ?></div>
 					<a class="sw-stat-card__link" href="<?php echo esc_url( admin_url( 'admin.php?page=stonewright' ) ); ?>">
@@ -105,7 +105,7 @@ final class StatusPage {
 				</article>
 
 				<article class="sw-stat-card">
-					<span class="sw-stat-card__icon" aria-hidden="true">▣</span>
+					<span class="sw-stat-card__icon dashicons dashicons-admin-plugins" aria-hidden="true"></span>
 					<div class="sw-stat-card__value">
 						<?php if ( '' !== $elementor_ver ) : ?>
 							<code><?php echo esc_html( $elementor_ver ); ?></code>
@@ -130,7 +130,7 @@ final class StatusPage {
 				</article>
 
 				<article class="sw-stat-card">
-					<span class="sw-stat-card__icon" aria-hidden="true">⟷</span>
+					<span class="sw-stat-card__icon dashicons dashicons-admin-links" aria-hidden="true"></span>
 					<div class="sw-stat-card__value"><code><?php echo esc_html( $companion_url ); ?></code></div>
 					<div class="sw-stat-card__label"><?php esc_html_e( 'Companion', 'stonewright' ); ?></div>
 					<a class="sw-stat-card__link" href="<?php echo esc_url( admin_url( 'admin.php?page=stonewright' ) ); ?>">
@@ -139,7 +139,7 @@ final class StatusPage {
 				</article>
 
 				<article class="sw-stat-card">
-					<span class="sw-stat-card__icon" aria-hidden="true">⚙</span>
+					<span class="sw-stat-card__icon dashicons dashicons-admin-generic" aria-hidden="true"></span>
 					<div class="sw-stat-card__value"><?php echo esc_html( (string) $tool_count ); ?></div>
 					<div class="sw-stat-card__label"><?php esc_html_e( 'Tool surface', 'stonewright' ); ?></div>
 					<a class="sw-stat-card__link" href="<?php echo esc_url( admin_url( 'admin.php?page=stonewright-abilities' ) ); ?>">
@@ -148,7 +148,7 @@ final class StatusPage {
 				</article>
 
 				<article class="sw-stat-card">
-					<span class="sw-stat-card__icon" aria-hidden="true">◷</span>
+					<span class="sw-stat-card__icon dashicons dashicons-clock" aria-hidden="true"></span>
 					<div class="sw-stat-card__value">
 						<?php
 						echo '' !== $last_activity
@@ -163,7 +163,7 @@ final class StatusPage {
 				</article>
 
 				<article class="sw-stat-card">
-					<span class="sw-stat-card__icon" aria-hidden="true">☰</span>
+					<span class="sw-stat-card__icon dashicons dashicons-database" aria-hidden="true"></span>
 					<div class="sw-stat-card__value">
 						<?php
 						printf(

--- a/plugin/includes/Admin/RestApi.php
+++ b/plugin/includes/Admin/RestApi.php
@@ -85,7 +85,7 @@ final class RestApi {
 	public static function handle_companion_update_status( \WP_REST_Request $request ): \WP_REST_Response {
 		unset( $request );
 
-		return rest_ensure_response( CompanionUpdateStatus::report() );
+		return rest_ensure_response( CompanionUpdateStatus::report( null, true ) );
 	}
 
 	/**

--- a/plugin/includes/Core/AbilityRegistry.php
+++ b/plugin/includes/Core/AbilityRegistry.php
@@ -787,7 +787,7 @@ final class AbilityRegistry {
 		if ( ! self::requires_context_token( $ability ) ) {
 			unset( $input['stonewright_context_token'] );
 			$result = self::finalize_ability_result( $name, $ability->execute( $input ) );
-			$result = self::maybe_project( $result, $fields );
+			$result = self::maybe_project( $ability, $result, $fields );
 			return self::maybe_attach_task_start_hint( $ability, $result );
 		}
 
@@ -810,7 +810,7 @@ final class AbilityRegistry {
 		ExecutionContext::set_task_hash( $task_hash );
 		try {
 			$result = self::finalize_ability_result( $name, $ability->execute( $input ) );
-			$result = self::maybe_project( $result, $fields );
+			$result = self::maybe_project( $ability, $result, $fields );
 			return self::maybe_attach_task_start_hint( $ability, $result );
 		} finally {
 			ExecutionContext::clear();
@@ -826,16 +826,22 @@ final class AbilityRegistry {
 	 * caller-requested subset of it, so the projection runs after the ability has
 	 * produced (and validated) its own output, never before.
 	 *
-	 * @param mixed $result Ability result.
-	 * @param mixed $fields Raw projection parameter from the current call.
+	 * @param Ability $ability Current ability, including its declared output contract.
+	 * @param mixed   $result Ability result.
+	 * @param mixed   $fields Raw projection parameter from the current call.
 	 * @return mixed
 	 */
-	private static function maybe_project( mixed $result, mixed $fields ): mixed {
+	private static function maybe_project( Ability $ability, mixed $result, mixed $fields ): mixed {
 		if ( null === $fields || ! is_array( $result ) ) {
 			return $result;
 		}
 
-		return ResponseProjection::apply( $result, $fields );
+		$output_schema = $ability->output_schema();
+		$required      = is_array( $output_schema['required'] ?? null )
+			? array_values( array_filter( $output_schema['required'], 'is_string' ) )
+			: [];
+
+		return ResponseProjection::apply( $result, $fields, $required );
 	}
 
 	/**

--- a/plugin/includes/Core/GitHubUpdater.php
+++ b/plugin/includes/Core/GitHubUpdater.php
@@ -119,20 +119,23 @@ final class GitHubUpdater {
 	}
 
 	/**
+	 * @param bool $force_refresh Ignore the cached release for an explicit user check.
 	 * @return array{version: string, package: string, companion_package: string, checksums: string, url: string, body?: string, tested?: string, requires?: string, requires_php?: string}|null
 	 */
-	public static function fetch_latest_release(): ?array {
+	public static function fetch_latest_release( bool $force_refresh = false ): ?array {
 		if ( (bool) apply_filters( 'stonewright_disable_update_check', false ) ) {
 			return null;
 		}
 
-		$cached = get_transient( self::CACHE_KEY );
-		if ( is_array( $cached ) && isset( $cached['version'], $cached['package'], $cached['url'] ) ) {
-			/** @var array{version: string, package: string, companion_package: string, checksums: string, url: string, body?: string, tested?: string, requires?: string, requires_php?: string} $cached */
-			return $cached;
-		}
-		if ( 'error' === $cached ) {
-			return null;
+		if ( ! $force_refresh ) {
+			$cached = get_transient( self::CACHE_KEY );
+			if ( is_array( $cached ) && isset( $cached['version'], $cached['package'], $cached['url'] ) ) {
+				/** @var array{version: string, package: string, companion_package: string, checksums: string, url: string, body?: string, tested?: string, requires?: string, requires_php?: string} $cached */
+				return $cached;
+			}
+			if ( 'error' === $cached ) {
+				return null;
+			}
 		}
 
 		$response = wp_remote_get(

--- a/plugin/includes/Support/ResponseProjection.php
+++ b/plugin/includes/Support/ResponseProjection.php
@@ -68,16 +68,17 @@ final class ResponseProjection {
 	 *
 	 * @param array<string, mixed> $result Ability response.
 	 * @param mixed                $fields Raw parameter value as it came off the wire.
+	 * @param list<string>         $required_keys Top-level keys required by the declared output schema.
 	 * @return array<string, mixed>
 	 */
-	public static function apply( array $result, mixed $fields ): array {
+	public static function apply( array $result, mixed $fields, array $required_keys = [] ): array {
 		$paths = self::normalize( $fields );
 		if ( [] === $paths ) {
 			return $result;
 		}
 
 		$projected = [];
-		foreach ( self::ALWAYS_KEPT as $key ) {
+		foreach ( array_values( array_unique( [ ...self::ALWAYS_KEPT, ...$required_keys ] ) ) as $key ) {
 			if ( array_key_exists( $key, $result ) ) {
 				$projected[ $key ] = $result[ $key ];
 			}

--- a/plugin/stonewright.php
+++ b/plugin/stonewright.php
@@ -3,7 +3,7 @@
  * Plugin Name: Stonewright
  * Plugin URI: https://github.com/cosmincraciun97/stonewright-wp-mcp
  * Description: Guarded WordPress MCP tools for Elementor, Gutenberg/FSE, WooCommerce catalogs, content models, PHP runtime execution, and tokenized WP-CLI.
- * Version: 1.0.0-beta.1
+ * Version: 1.0.0-beta.2
  * Requires at least: 6.7
  * Requires PHP: 8.1
  * Author: Stonewright
@@ -33,7 +33,7 @@ if ( defined( 'STONEWRIGHT_FILE' ) ) {
 define( 'STONEWRIGHT_FILE', __FILE__ );
 define( 'STONEWRIGHT_DIR', plugin_dir_path( __FILE__ ) );
 define( 'STONEWRIGHT_URL', plugin_dir_url( __FILE__ ) );
-define( 'STONEWRIGHT_VERSION', '1.0.0-beta.1' );
+define( 'STONEWRIGHT_VERSION', '1.0.0-beta.2' );
 define( 'STONEWRIGHT_MIN_PHP', '8.1' );
 define( 'STONEWRIGHT_MIN_WP', '6.7' );
 

--- a/plugin/tests/Unit/Admin/AbilitiesPageTest.php
+++ b/plugin/tests/Unit/Admin/AbilitiesPageTest.php
@@ -55,6 +55,7 @@ final class AbilitiesPageTest extends TestCase {
 		self::assertStringContainsString( '<details', $html );
 		self::assertStringContainsString( 'stonewright-schema-table-wrap', $html );
 		self::assertStringContainsString( 'stonewright/ping', $html );
+		self::assertStringNotContainsString( 'onclick=', $html );
 	}
 
 	public function test_render_includes_sticky_filters_stats_and_switches(): void {

--- a/plugin/tests/Unit/Admin/AdminJavascriptTest.php
+++ b/plugin/tests/Unit/Admin/AdminJavascriptTest.php
@@ -63,6 +63,24 @@ final class AdminJavascriptTest extends TestCase {
 		self::assertStringContainsString( 'normalizeChecklistStatus', $script );
 	}
 
+	public function test_explicit_companion_check_bypasses_browser_caches(): void {
+		$script = (string) file_get_contents( dirname( __DIR__, 3 ) . '/assets/admin/admin.js' );
+		$start  = strpos( $script, 'function initCompanionUpdateStatus()' );
+		$end    = strpos( $script, 'function escapeRegExp', false === $start ? 0 : $start );
+
+		self::assertNotFalse( $start );
+		self::assertNotFalse( $end );
+		$companion_update_script = substr( $script, (int) $start, (int) $end - (int) $start );
+
+		self::assertStringContainsString( "refreshUrl.searchParams.set( 'force', '1' )", $companion_update_script );
+		self::assertStringContainsString( "cache: 'no-store'", $companion_update_script );
+
+		$connection_test_end = strpos( $script, 'function initCompanionUpdateStatus()' );
+		self::assertNotFalse( $connection_test_end );
+		$connection_test_script = substr( $script, 0, (int) $connection_test_end );
+		self::assertStringNotContainsString( "refreshUrl.searchParams.set( 'force', '1' )", $connection_test_script );
+	}
+
 	public function test_setup_client_and_method_pickers_are_wired(): void {
 		$script = (string) file_get_contents( dirname( __DIR__, 3 ) . '/assets/admin/admin.js' );
 

--- a/plugin/tests/Unit/Admin/AdminPagesPolishTest.php
+++ b/plugin/tests/Unit/Admin/AdminPagesPolishTest.php
@@ -225,6 +225,7 @@ final class AdminPagesPolishTest extends TestCase {
 		self::assertStringContainsString( 'sw-dashboard-page', $html );
 		self::assertStringContainsString( 'sw-stat-grid', $html );
 		self::assertStringContainsString( 'sw-stat-card', $html );
+		self::assertStringContainsString( 'dashicons-chart-area', $html );
 		self::assertStringContainsString( 'sw-audit-feed', $html );
 		self::assertStringContainsString( 'sw-sparkline', $html );
 		self::assertStringContainsString( 'Dashboard', $html );

--- a/plugin/tests/Unit/Admin/CompanionUpdateStatusTest.php
+++ b/plugin/tests/Unit/Admin/CompanionUpdateStatusTest.php
@@ -37,7 +37,7 @@ final class CompanionUpdateStatusTest extends TestCase {
 				[
 					'status'           => 'ok',
 					'contract_version' => '1.0.0',
-					'version'          => '1.0.0-beta.1',
+					'version'          => '1.0.0-beta.2',
 				]
 			),
 		];
@@ -47,7 +47,7 @@ final class CompanionUpdateStatusTest extends TestCase {
 		self::assertTrue( $report['ok'] );
 		self::assertTrue( $report['plugin_update_available'] );
 		self::assertSame( 'outdated', $report['companion_status'] );
-		self::assertSame( '1.0.0-beta.1', $report['bridge']['version'] );
+		self::assertSame( '1.0.0-beta.2', $report['bridge']['version'] );
 		self::assertStringContainsString( 'stonewright-companion-1.0.0-beta.99.tgz', $report['companion_package'] );
 		self::assertStringContainsString( 'refresh_required_tool_names', $report['update_prompt'] );
 		self::assertStringNotContainsString( 'Application Password:', $report['update_prompt'] );

--- a/plugin/tests/Unit/Assets/AdminAssetContractTest.php
+++ b/plugin/tests/Unit/Assets/AdminAssetContractTest.php
@@ -80,6 +80,32 @@ final class AdminAssetContractTest extends TestCase {
 		self::assertStringContainsString( 'color: var(--sw-on-brand)', $body );
 	}
 
+	public function test_sandbox_category_badge_has_explicit_readable_colors(): void {
+		$body = self::rule_body( 'sandbox.css', '.stonewright-sandbox-page .sw-badge--category' );
+
+		self::assertStringContainsString( 'background: var(--sw-info-soft)', $body );
+		self::assertStringContainsString( 'color: var(--sw-info-text)', $body );
+		self::assertStringContainsString( 'min-height: 22px', $body );
+	}
+
+	public function test_dashboard_metrics_are_grouped_in_one_summary_band(): void {
+		$grid = self::rule_body( 'dashboard.css', '.sw-stat-grid' );
+		$cell = self::rule_body( 'dashboard.css', '.sw-stat-card' );
+
+		self::assertStringContainsString( 'gap: 1px', $grid );
+		self::assertStringContainsString( 'border-radius: var(--sw-radius-lg)', $grid );
+		self::assertStringNotContainsString( 'box-shadow', $cell );
+		self::assertStringNotContainsString( 'border:', $cell );
+	}
+
+	public function test_domain_lock_status_centers_its_complete_control_group(): void {
+		$body = self::rule_body( 'shell.css', '.sw-shell .stonewright-domain-lock-status' );
+
+		self::assertStringContainsString( 'display: flex', $body );
+		self::assertStringContainsString( 'justify-content: center', $body );
+		self::assertStringContainsString( 'flex-wrap: wrap', $body );
+	}
+
 	public function test_audit_payload_becomes_full_width_in_responsive_rows(): void {
 		$css = self::asset( 'audit.css' );
 

--- a/plugin/tests/Unit/Core/GitHubUpdaterTest.php
+++ b/plugin/tests/Unit/Core/GitHubUpdaterTest.php
@@ -96,6 +96,30 @@ final class GitHubUpdaterTest extends TestCase {
 		self::assertSame( $calls_before, $calls_after );
 	}
 
+	public function test_force_refresh_replaces_a_stale_cached_release(): void {
+		$cached = [
+			'version' => '1.0.0-beta.1',
+			'package' => 'https://example.test/stonewright-1.0.0-beta.1.zip',
+			'url'     => 'https://example.test/release',
+		];
+		set_transient( GitHubUpdater::CACHE_KEY, $cached, 12 * HOUR_IN_SECONDS );
+
+		$raw = $this->fixture_json();
+		$GLOBALS['stonewright_test_wp_remote_get'] = static function ( string $url ) use ( $raw ): array {
+			return [
+				'response' => [ 'code' => 200 ],
+				'body'     => (string) wp_json_encode( $raw ),
+			];
+		};
+
+		$parsed = GitHubUpdater::fetch_latest_release( true );
+
+		self::assertIsArray( $parsed );
+		self::assertSame( '1.0.0-beta.99', $parsed['version'] );
+		self::assertSame( $parsed, get_transient( GitHubUpdater::CACHE_KEY ) );
+		self::assertCount( 1, $GLOBALS['stonewright_test_wp_remote_get_calls'] );
+	}
+
 	public function test_inject_update_adds_response_when_remote_is_newer(): void {
 		set_transient(
 			GitHubUpdater::CACHE_KEY,

--- a/plugin/tests/Unit/Core/ResponseProjectionRegistryTest.php
+++ b/plugin/tests/Unit/Core/ResponseProjectionRegistryTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Stonewright\WpMcp\Abilities\Ability;
 use Stonewright\WpMcp\Abilities\ContentModel\CptAcfLoopGridFlow;
 use Stonewright\WpMcp\Abilities\Site\Info;
+use Stonewright\WpMcp\Abilities\System\WorkflowPreflight;
 use Stonewright\WpMcp\Core\AbilityRegistry;
 use Stonewright\WpMcp\Support\ResponseProjection;
 
@@ -79,7 +80,7 @@ final class ResponseProjectionRegistryTest extends TestCase {
 		);
 
 		self::assertIsArray( $result );
-		self::assertSame( [ 'name', 'url' ], array_keys( $result ) );
+		self::assertSame( [ 'name', 'url', 'wp_version' ], array_keys( $result ) );
 	}
 
 	public function test_the_projection_parameter_never_reaches_execute(): void {
@@ -159,6 +160,22 @@ final class ResponseProjectionRegistryTest extends TestCase {
 			],
 			$full
 		);
+	}
+
+	public function test_task_start_projection_keeps_its_required_output_envelope(): void {
+		$result = AbilityRegistry::execute_with_context_guard(
+			new WorkflowPreflight(),
+			[
+				'task'                    => 'Inspect the current site.',
+				'responseMode'            => 'compact',
+				ResponseProjection::PARAM => [ 'context_token' ],
+			]
+		);
+
+		self::assertIsArray( $result );
+		foreach ( [ 'ok', 'context_token', 'mode', 'auth_guidance', 'fast_path' ] as $required ) {
+			self::assertArrayHasKey( $required, $result );
+		}
 	}
 
 	public function test_error_responses_are_not_projected(): void {

--- a/plugin/tests/Unit/Support/ReleaseRetentionTest.php
+++ b/plugin/tests/Unit/Support/ReleaseRetentionTest.php
@@ -19,7 +19,7 @@ final class ReleaseRetentionTest extends TestCase {
 				$versioned[] = $name;
 			}
 		}
-		self::assertSame( [ '1.0.0-beta.1.md' ], $versioned );
+		self::assertSame( [ '1.0.0-beta.1.md', '1.0.0-beta.2.md' ], $versioned );
 	}
 
 	public function test_root_changelog_has_at_most_five_versions_plus_unreleased(): void {
@@ -34,7 +34,7 @@ final class ReleaseRetentionTest extends TestCase {
 			)
 		);
 		self::assertContains( 'Unreleased', $headers );
-		self::assertSame( [ '1.0.0-beta.1' ], $versions );
+		self::assertSame( [ '1.0.0-beta.2', '1.0.0-beta.1' ], $versions );
 		self::assertStringContainsString( 'public changelog starts with the first beta', $raw );
 	}
 }

--- a/plugin/tests/Unit/Support/ResponseProjectionTest.php
+++ b/plugin/tests/Unit/Support/ResponseProjectionTest.php
@@ -67,6 +67,17 @@ final class ResponseProjectionTest extends TestCase {
 		);
 	}
 
+	public function test_declared_required_keys_survive_projection(): void {
+		self::assertSame(
+			[
+				'ok'      => true,
+				'post_id' => 41,
+				'hash'    => 'abc123',
+			],
+			ResponseProjection::apply( self::payload(), [ 'hash' ], [ 'post_id' ] )
+		);
+	}
+
 	public function test_nested_projection_prunes_siblings(): void {
 		self::assertSame(
 			[

--- a/plugin/tests/phpstan-bootstrap.php
+++ b/plugin/tests/phpstan-bootstrap.php
@@ -51,7 +51,7 @@ if ( ! defined( 'STONEWRIGHT_URL' ) ) {
 }
 
 if ( ! defined( 'STONEWRIGHT_VERSION' ) ) {
-	define( 'STONEWRIGHT_VERSION', '1.0.0-beta.1' );
+	define( 'STONEWRIGHT_VERSION', '1.0.0-beta.2' );
 }
 
 if ( ! defined( 'STONEWRIGHT_MIN_PHP' ) ) {
@@ -70,4 +70,3 @@ $phpstan_autoload = dirname( __DIR__ ) . '/vendor/autoload.php';
 if ( file_exists( $phpstan_autoload ) ) {
 	require_once $phpstan_autoload;
 }
-


### PR DESCRIPTION
## Summary

- make explicit companion release checks bypass stale WordPress and browser caches while background checks remain cached
- preserve all top-level output-schema requirements when `stonewright_fields` projects a response
- unify every Stonewright wp-admin surface around the restrained light design system in `DESIGN.md`
- ship plugin and companion metadata/documentation as `1.0.0-beta.2` while keeping Direct mode and persistent state behavior intact

## Ability and safety contract

Changed abilities: none.

The shared response projection seam now retains fields declared required by each ability output schema. No permission, backup, confirmation-token, validator, destructive-operation, Elementor-integrity, audit, or readback gate changed.

## Public documentation

Updated the root, plugin, and companion changelogs; root and plugin READMEs; architecture, abilities, installation prompts, update/configuration guidance, documentation index/maintenance rules; added `DESIGN.md` and versioned beta.2 release notes. Generated ability documentation remains current at 346 Plugin abilities and 100 Direct tools.

## Verification

- PHPUnit: 6,404 tests / 33,474 assertions
- PHPStan, PHPCS, security audit, dependency audit, contract compatibility, provenance, manifests, docs freshness, public hygiene, token budgets, and `git diff --check`: pass
- clean production Composer install: Jetpack manifests valid with 1,136 paths and no development-only DeepCopy dependency
- companion: typecheck, lint, 356 tests, contracts, token budgets, production build, and archive-state hygiene: pass
- Visual: typecheck, 80 tests, production build: pass
- Playwright: 340 tests enumerate successfully across 5 light viewports; CI runs the exact extracted plugin ZIP with WooCommerce and archives screenshots because Docker is unavailable on the local host

Fresh installs remain empty of user memory, user skills, and audit events. Updates continue to preserve persistent user state.