### PR TITLE
docs: complete beta.4 OAuth security notes

### DIFF
--- a/docs/permanent-remediation-contracts.md
+++ b/docs/permanent-remediation-contracts.md
@@ -45,6 +45,12 @@ rotated token replaces the old value. `invalid_grant`, `invalid_client`, and
 `unauthorized_client` delete local token state and stop retrying; the caller
 receives a reauthorization-required result.
 
+Authorization, token exchange, refresh, and bearer validation carry or verify
+the exact canonical MCP resource. Protected Resource Metadata advertises only
+the minimal `mcp` resource scope. Refresh tokens share a one-way grant-family
+identifier: reuse of a revoked token revokes the complete family and every
+access token issued from it.
+
 Transient HTTP responses and network failures use bounded exponential backoff,
 `Retry-After` when present, jitter, and a circuit breaker. OAuth responses use
 `Cache-Control: no-store`, a bounded `Retry-After`, and a correlation ID.

--- a/docs/releases/1.0.0-beta.4.md
+++ b/docs/releases/1.0.0-beta.4.md
@@ -29,6 +29,10 @@ transactional, and adds evidence-first design planning without customer data.
 - Every successful refresh must return a new refresh token. Omission or replay
   of the old token now requires reauthorization instead of reusing a rotated
   credential.
+- Authorization, token exchange, refresh, and bearer validation bind to the
+  exact canonical MCP resource. Protected Resource Metadata exposes only the
+  minimal `mcp` scope. Reuse of any revoked refresh token revokes its complete
+  refresh family and all access tokens for that grant.
 - Server-side rate limiting keys client identity with bounded network buckets,
   trusts forwarded addresses only behind configured proxies, emits bounded
   diagnostics, and covers both token and registration entry points.


### PR DESCRIPTION
## Summary

- document canonical OAuth resource and audience binding in beta.4 release notes
- document minimal protected-resource scope and grant-family replay revocation in the permanent contract

## Changed abilities

None. This documents the already-tested OAuth behavior merged in #42. Backup, confirmation-token, permission, validation, and audit gates are unchanged.

## Documentation

Updated `docs/releases/1.0.0-beta.4.md` and `docs/permanent-remediation-contracts.md`.

## Verification

- docs freshness: pass
- public hygiene: pass
- `git diff --check`: pass