### PR TITLE
feat(companion): permanent gateways and truthful connection status

### DIFF
--- a/companion/README.md
+++ b/companion/README.md
@@ -108,7 +108,7 @@ Fast path for MCP clients:
         "STONEWRIGHT_WP_URL": "http://mcp-test.local",
         "STONEWRIGHT_WP_ROOT": "/absolute/path/to/wordpress",
         "STONEWRIGHT_WP_APP_PASSWORD_AUTO": "local-only",
-        "STONEWRIGHT_MCP_TOOL_PROFILE": "bootstrap"
+        "STONEWRIGHT_MCP_TOOL_PROFILE": "essential-static"
       }
     }
   }
@@ -152,9 +152,11 @@ Documented in `src/direct/capability-tiers.ts`:
 | `plugin` | Full Stonewright plugin MCP surface |
 | `plugin-browser-qa` | Plugin + Playwright visual/admin gates |
 
-Direct `STONEWRIGHT_MCP_TOOL_PROFILE=bootstrap` starts with a compact surface.
-`stonewright-task-start` selects and enables a compact Direct task
-profile for the current session; Full is explicit only.
+Default `STONEWRIGHT_MCP_TOOL_PROFILE=essential-static` starts with a bounded
+useful surface plus permanent recovery gateways (`task-start`, `connect-doctor`,
+`reconnect`, `mode-capabilities`, and friends). `stonewright-task-start` can still
+expand the session profile when the client honors `tools/list_changed`. Full is
+never selected implicitly.
 
 After the MCP server starts, call `stonewright-setup-profile` once. It returns
 the same config shape plus platform checks, credential status, and notes for
@@ -226,7 +228,7 @@ cp .env.example .env
 | `STONEWRIGHT_WP_URL` | recommended for stdio | WordPress site URL; the companion derives `/wp-json/mcp/stonewright` |
 | `STONEWRIGHT_WP_USERNAME` | with `STONEWRIGHT_WP_URL` | WordPress username for Application Password auth |
 | `STONEWRIGHT_WP_APP_PASSWORD` | with `STONEWRIGHT_WP_URL` | WordPress Application Password |
-| `STONEWRIGHT_MCP_TOOL_PROFILE` | optional | Initial/fallback client-visible surface. In plugin mode, normal bootstrap/essential/full clients follow the surface saved in WordPress Setup; `low-tools` and specialist profiles remain explicit overrides. |
+| `STONEWRIGHT_MCP_TOOL_PROFILE` | optional | Initial/fallback client-visible surface. Default is `essential-static` (not bootstrap, not full). In plugin mode, normal essential-static/bootstrap/essential clients may follow the surface saved in WordPress Setup; `low-tools` and specialist profiles remain explicit overrides. `full` is never selected implicitly. |
 | `STONEWRIGHT_MCP_TOOL_PROFILE_LOCK` | optional | Set to `1` to force the environment profile instead of the WordPress Setup preference. |
 | `STONEWRIGHT_MCP_MAX_TOOLS` | optional | Maximum proxied tools registered for the client. Use `50` for capped clients so Stonewright trims deterministically after write-critical ordering. |
 | `STONEWRIGHT_MCP_URL` | optional | Explicit WordPress MCP endpoint override |

--- a/companion/src/cli/doctor.ts
+++ b/companion/src/cli/doctor.ts
@@ -413,11 +413,11 @@ export async function runDoctor(argv: string[] = []): Promise<number> {
 		writeOut('  2. Re-list tools (honor tools/list_changed or re_list_instruction)');
 		writeOut('  3. If still missing: restart MCP client');
 		writeOut('  4. Never call /wp-json/stonewright/v1/abilities/run as a workaround');
-		const envProfile = (process.env.STONEWRIGHT_MCP_TOOL_PROFILE ?? process.env.STONEWRIGHT_MCP_PROXY_PROFILE ?? 'bootstrap').trim();
+		const envProfile = (process.env.STONEWRIGHT_MCP_TOOL_PROFILE ?? process.env.STONEWRIGHT_MCP_PROXY_PROFILE ?? 'essential-static').trim();
 		const lock = (process.env.STONEWRIGHT_MCP_TOOL_PROFILE_LOCK ?? '').trim();
 		const siteAlias = (process.env.STONEWRIGHT_SITE_ALIAS ?? '').trim();
 		const url = (process.env.STONEWRIGHT_WP_URL ?? process.env.STONEWRIGHT_MCP_URL ?? '').trim();
-		writeOut(`env STONEWRIGHT_MCP_TOOL_PROFILE=${envProfile || '(unset → bootstrap)'}`);
+		writeOut(`env STONEWRIGHT_MCP_TOOL_PROFILE=${envProfile || '(unset → essential-static)'}`);
 		writeOut(`env STONEWRIGHT_MCP_TOOL_PROFILE_LOCK=${lock || '(unset)'}`);
 		writeOut(`env STONEWRIGHT_SITE_ALIAS=${siteAlias || '(unset)'}`);
 		writeOut(`env write target URL=${url || '(unset)'}`);

--- a/companion/src/cli/init.ts
+++ b/companion/src/cli/init.ts
@@ -86,7 +86,7 @@ export async function runInit(): Promise<number> {
 					args: ['-y', '--package', pkg, 'stonewright-mcp'],
 					env: {
 						STONEWRIGHT_MODE: 'direct',
-						STONEWRIGHT_MCP_TOOL_PROFILE: 'bootstrap',
+						STONEWRIGHT_MCP_TOOL_PROFILE: 'essential-static',
 					},
 				},
 			},

--- a/companion/src/connection/client-defaults.ts
+++ b/companion/src/connection/client-defaults.ts
@@ -1,0 +1,53 @@
+/**
+ * Client-aware profile defaults.
+ *
+ * - Unknown clients and unset env default to essential-static (NOT bootstrap, NOT full).
+ * - full is never selected implicitly.
+ * - Known reliable dynamic clients may still start on bootstrap then activate essential.
+ */
+
+export type ClientReliability = 'unknown' | 'static' | 'dynamic-reliable';
+
+/** Clients known to honor tools/list_changed without restart. */
+const DYNAMIC_RELIABLE_CLIENT_HINTS = [
+	'claude-code',
+	'claude_code',
+	'codex',
+	'cursor',
+] as const;
+
+export function classifyClientReliability(clientHint: string | null | undefined): ClientReliability {
+	const normalized = (clientHint ?? '').trim().toLowerCase().replace(/[\s_]+/g, '-');
+	if (!normalized || normalized === 'unknown' || normalized === 'auto') {
+		return 'unknown';
+	}
+	if (DYNAMIC_RELIABLE_CLIENT_HINTS.some((hint) => normalized.includes(hint))) {
+		return 'dynamic-reliable';
+	}
+	if (normalized.includes('static') || normalized.includes('antigravity') || normalized.includes('gemini')) {
+		return 'static';
+	}
+	return 'unknown';
+}
+
+/**
+ * Default MCP tool profile when env is unset.
+ * Unknown / static clients → essential-static.
+ * Dynamic-reliable may still prefer bootstrap for progressive expansion.
+ */
+export function defaultProxyProfileForClient(
+	clientHint: string | null | undefined,
+	options: { allowBootstrapForDynamic?: boolean } = {},
+): 'essential-static' | 'bootstrap' {
+	const reliability = classifyClientReliability(clientHint);
+	if (options.allowBootstrapForDynamic && reliability === 'dynamic-reliable') {
+		return 'bootstrap';
+	}
+	return 'essential-static';
+}
+
+/** full is never selected implicitly from empty/auto/unknown env. */
+export function isImplicitFullForbidden(raw: string | null | undefined): boolean {
+	const normalized = (raw ?? '').trim().toLowerCase();
+	return normalized === '' || normalized === 'auto' || normalized === 'default' || normalized === 'unknown';
+}

--- a/companion/src/connection/index.ts
+++ b/companion/src/connection/index.ts
@@ -1,0 +1,58 @@
+export {
+	PERMANENT_GATEWAY_TOOL_NAMES,
+	PERMANENT_GATEWAY_TOOL_NAME_SET,
+	isPermanentGatewayTool,
+	permanentGatewayMembership,
+	type PermanentGatewayToolName,
+} from './permanent-gateways.js';
+
+export {
+	computeSurfaceDigest,
+	SurfaceRevisionTracker,
+} from './surface-digest.js';
+
+export {
+	ConnectionStateMachine,
+	type ConnectionStage,
+} from './state-machine.js';
+
+export {
+	classifyClientReliability,
+	defaultProxyProfileForClient,
+	isImplicitFullForbidden,
+	type ClientReliability,
+} from './client-defaults.js';
+
+export {
+	STATUS_SCHEMA_VERSION,
+	clientHasTool,
+	defaultClientVisibility,
+	clientVisibilityFromEvidence,
+	computeRefreshRequiredToolNames,
+	mapConfiguredMode,
+	buildConnectionStatusV2,
+	normalizeToolName,
+	modeCapabilitiesComparison,
+	type ConfiguredMode,
+	type ActiveMode,
+	type ClientVisibility,
+	type ClientVisibilityState,
+	type SurfaceStatus,
+	type PluginStatus,
+	type ConnectionStatusV2,
+	type ClientHasToolContext,
+	type ModeCapabilityRow,
+} from './status-contract.js';
+
+export {
+	RegistryBarrier,
+	type CatalogEntry,
+	type RegistrySnapshot,
+} from './registry-barrier.js';
+
+export {
+	ReconnectController,
+	type ReconnectInput,
+	type ReconnectResult,
+	type ReconnectExecutor,
+} from './reconnect.js';

--- a/companion/src/connection/permanent-gateways.ts
+++ b/companion/src/connection/permanent-gateways.ts
@@ -1,0 +1,32 @@
+/**
+ * Permanent local gateway tools.
+ *
+ * Registered by the companion BEFORE any remote handshake and never removed by
+ * profiles, advisory filters, or reconnect failures. Local gateway owns the
+ * name when the remote plugin exposes the same canonical tool.
+ */
+
+export const PERMANENT_GATEWAY_TOOL_NAMES = [
+	'stonewright-task-start',
+	'stonewright-connect-doctor',
+	'stonewright-wordpress-mcp-status',
+	'stonewright-setup-profile',
+	'stonewright-mode-capabilities',
+	'stonewright-tool-profile',
+	'stonewright-client-surface-check',
+	'stonewright-reconnect',
+	'stonewright-ping',
+] as const;
+
+export type PermanentGatewayToolName = (typeof PERMANENT_GATEWAY_TOOL_NAMES)[number];
+
+export const PERMANENT_GATEWAY_TOOL_NAME_SET = new Set<string>(PERMANENT_GATEWAY_TOOL_NAMES);
+
+export function isPermanentGatewayTool(name: string): boolean {
+	return PERMANENT_GATEWAY_TOOL_NAME_SET.has(name);
+}
+
+/** Gateway tools that are always client-callable once the companion process is up. */
+export function permanentGatewayMembership(name: string): boolean {
+	return isPermanentGatewayTool(name);
+}

--- a/companion/src/connection/reconnect.ts
+++ b/companion/src/connection/reconnect.ts
@@ -1,0 +1,65 @@
+/**
+ * Singleflight reconnect: concurrent reconnect requests coalesce into one transition.
+ * Failed reconnect leaves prior healthy registry active and reports failure separately.
+ */
+
+export interface ReconnectInput {
+	reason: string;
+	site_alias?: string;
+	force_probe?: boolean;
+}
+
+export interface ReconnectResult {
+	ok: boolean;
+	coalesced: boolean;
+	reason: string;
+	site_alias: string | null;
+	force_probe: boolean;
+	connection_generation: number;
+	surface_revision: number;
+	prior_registry_preserved: boolean;
+	error: string | null;
+	status?: Record<string, unknown>;
+}
+
+export type ReconnectExecutor = (input: ReconnectInput) => Promise<ReconnectResult>;
+
+export class ReconnectController {
+	private inflight: Promise<ReconnectResult> | null = null;
+	private waiters = 0;
+
+	constructor(private readonly execute: ReconnectExecutor) {}
+
+	async reconnect(input: ReconnectInput): Promise<ReconnectResult> {
+		const reason = (input.reason ?? '').trim() || 'unspecified';
+		const normalized: ReconnectInput = {
+			reason,
+			...(input.site_alias !== undefined ? { site_alias: input.site_alias } : {}),
+			...(input.force_probe !== undefined ? { force_probe: input.force_probe } : {}),
+		};
+
+		if (this.inflight) {
+			this.waiters += 1;
+			const result = await this.inflight;
+			return { ...result, coalesced: true };
+		}
+
+		this.waiters = 0;
+		this.inflight = this.execute(normalized)
+			.then((result) => ({ ...result, coalesced: false }))
+			.finally(() => {
+				this.inflight = null;
+				this.waiters = 0;
+			});
+
+		return this.inflight;
+	}
+
+	isInFlight(): boolean {
+		return this.inflight !== null;
+	}
+
+	pendingWaiters(): number {
+		return this.waiters;
+	}
+}

--- a/companion/src/connection/registry-barrier.ts
+++ b/companion/src/connection/registry-barrier.ts
@@ -1,0 +1,136 @@
+/**
+ * Registry readiness barrier.
+ *
+ * Remote registration completes atomically into a staging set, then swaps into
+ * the active catalog. startup_ready stays false until the barrier commits.
+ * Failed reconnect leaves the prior healthy registry active.
+ */
+
+export interface CatalogEntry {
+	name: string;
+	source: 'local-gateway' | 'local' | 'remote' | 'direct';
+}
+
+export interface RegistrySnapshot {
+	entries: CatalogEntry[];
+	names: string[];
+	ready: boolean;
+	generation: number;
+}
+
+export class RegistryBarrier {
+	private active: CatalogEntry[] = [];
+	private staging: CatalogEntry[] | null = null;
+	private ready = false;
+	private readyBeforeStaging = false;
+	private generation = 0;
+	private lastFailure: string | null = null;
+
+	get isReady(): boolean {
+		return this.ready;
+	}
+
+	getGeneration(): number {
+		return this.generation;
+	}
+
+	getLastFailure(): string | null {
+		return this.lastError();
+	}
+
+	private lastError(): string | null {
+		return this.lastFailure;
+	}
+
+	getActiveNames(): string[] {
+		return this.active.map((e) => e.name);
+	}
+
+	getActiveEntries(): CatalogEntry[] {
+		return [...this.active];
+	}
+
+	/** Seed permanent local tools before any remote work (does not mark ready). */
+	seedLocal(entries: CatalogEntry[]): void {
+		const byName = new Map(this.active.map((e) => [e.name, e]));
+		for (const entry of entries) {
+			byName.set(entry.name, entry);
+		}
+		this.active = [...byName.values()].sort((a, b) => a.name.localeCompare(b.name));
+		// Local seed alone is not a ready remote/direct registry.
+		this.ready = false;
+	}
+
+	beginStaging(): void {
+		this.readyBeforeStaging = this.ready;
+		this.staging = [];
+		this.ready = false;
+	}
+
+	stage(entry: CatalogEntry): void {
+		if (!this.staging) {
+			this.beginStaging();
+		}
+		const staging = this.staging!;
+		const idx = staging.findIndex((e) => e.name === entry.name);
+		if (idx >= 0) staging[idx] = entry;
+		else staging.push(entry);
+	}
+
+	stageMany(entries: readonly CatalogEntry[]): void {
+		for (const entry of entries) this.stage(entry);
+	}
+
+	/**
+	 * Atomic commit of staged remote/direct tools merged with permanent local entries.
+	 * Bumps generation. Clears last failure.
+	 */
+	commit(options: { keepLocalSources?: ReadonlySet<string> } = {}): RegistrySnapshot {
+		const keepSources = options.keepLocalSources ?? new Set(['local-gateway', 'local']);
+		const priorLocal = this.active.filter((e) => keepSources.has(e.source));
+		const staged = this.staging ?? [];
+		const byName = new Map<string, CatalogEntry>();
+		for (const entry of priorLocal) byName.set(entry.name, entry);
+		for (const entry of staged) {
+			// Local gateway always wins name ownership.
+			const existing = byName.get(entry.name);
+			if (existing && (existing.source === 'local-gateway' || existing.source === 'local')) {
+				continue;
+			}
+			byName.set(entry.name, entry);
+		}
+		this.active = [...byName.values()].sort((a, b) => a.name.localeCompare(b.name));
+		this.staging = null;
+		this.ready = true;
+		this.generation += 1;
+		this.lastFailure = null;
+		return this.snapshot();
+	}
+
+	/**
+	 * Abort staging; leave prior healthy registry intact and record failure separately.
+	 */
+	abort(error: string): RegistrySnapshot {
+		this.staging = null;
+		// Restore prior ready state so a failed reconnect keeps the healthy catalog.
+		this.ready = this.readyBeforeStaging;
+		this.lastFailure = error;
+		return this.snapshot();
+	}
+
+	/** Mark ready for Direct path without remote staging. */
+	commitDirect(entries: readonly CatalogEntry[]): RegistrySnapshot {
+		this.beginStaging();
+		this.stageMany(entries);
+		return this.commit();
+	}
+
+	snapshot(): RegistrySnapshot {
+		return {
+			entries: [...this.active],
+			names: this.active.map((e) => e.name),
+			ready: this.ready,
+			generation: this.generation,
+		};
+	}
+}

--- a/companion/src/connection/runtime.ts
+++ b/companion/src/connection/runtime.ts
@@ -1,0 +1,939 @@
+/**
+ * Mutable connection runtime shared by permanent gateways and createMcpServer.
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import {
+	AGENT_DO_NOT_USE,
+	agentUseInstead,
+	buildSetupProfile,
+	buildToolInventory,
+	type ToolInventory,
+} from '../setup-profile.js';
+import {
+	STARTUP_REQUIRED_PROXY_TOOL_NAMES,
+	emitToolListChanged,
+	proxyToolNamesForProfile,
+	type ProxyToolProfile,
+	type WordPressProxyLiveState,
+} from '../wordpress-mcp.js';
+import { APP_VERSION, companionPackageSpec } from '../version.js';
+import type { DirectSessionControls, DirectToolProfile } from '../direct/registry.js';
+import * as selfImprove from '../direct/tools/self-improve.js';
+import {
+	ConnectionStateMachine,
+	PERMANENT_GATEWAY_TOOL_NAMES,
+	PERMANENT_GATEWAY_TOOL_NAME_SET,
+	ReconnectController,
+	RegistryBarrier,
+	SurfaceRevisionTracker,
+	buildConnectionStatusV2,
+	clientHasTool,
+	clientVisibilityFromEvidence,
+	computeRefreshRequiredToolNames,
+	defaultClientVisibility,
+	mapConfiguredMode,
+	modeCapabilitiesComparison,
+	normalizeToolName,
+	type ActiveMode,
+	type ConfiguredMode,
+	type ConnectionStatusV2,
+	type ReconnectInput,
+	type ReconnectResult,
+} from './index.js';
+
+export interface WordPressMcpConnectionStatus extends Record<string, unknown> {
+	ok: boolean;
+	configured: boolean;
+	connected: boolean;
+	url: string | null;
+	tool_profile: string | null;
+	surface_revision: number | null;
+	surface_digest: string | null;
+	startup_ready: boolean;
+	startup_required_tool_names: string[];
+	startup_missing_tool_names: string[];
+	local_recovery_tool_names: string[];
+	local_tool_names: string[];
+	profile_expected_tool_count: number;
+	client_visible_expected_tool_count: number;
+	profile_missing_tool_names: string[];
+	remote_tool_count: number;
+	proxied_tool_count: number;
+	profile_filtered_tool_count: number;
+	profile_filtered_tool_names: string[];
+	tool_inventory: ToolInventory;
+	companion_version: string;
+	expected_companion_package: string;
+	refresh_required_tool_names: string[];
+	prompt_skill_count: number;
+	error: { message: string } | null;
+	agent_do_not_use: string[];
+	agent_use_instead: string[];
+	recovery: string[];
+	mode: 'plugin' | 'direct';
+	mode_reason: string | null;
+	configured_mode: ConfiguredMode;
+	connection_stage: string;
+	connection_generation: number;
+	direct_tool_count: number;
+	direct_tool_names: string[];
+	unavailable_plugin_capabilities: Array<{ id: string; label: string; reason: string; upgrade: string }>;
+	live: WordPressProxyLiveState | null;
+	schema_version: number;
+	client_visibility: { state: string; reason: string };
+	error_code: string | null;
+	next_action: string | null;
+}
+
+export interface ConnectionRuntime {
+	env: NodeJS.ProcessEnv;
+	profile: ProxyToolProfile;
+	fetchImpl: typeof fetch;
+	status: WordPressMcpConnectionStatus;
+	stateMachine: ConnectionStateMachine;
+	registry: RegistryBarrier;
+	surface: SurfaceRevisionTracker;
+	reconnect: ReconnectController;
+	invokedToolNames: Set<string>;
+	callRemoteTool: ((name: string, args: Record<string, unknown>) => Promise<unknown>) | null;
+	directSession: DirectSessionControls | null;
+	server: McpServer | null;
+	/** Rebuild / re-probe plugin or Direct registration. */
+	performReconnect: (input: ReconnectInput) => Promise<ReconnectResult>;
+	/** Snapshot registered tool names from the MCP server. */
+	listRegisteredToolNames: () => string[];
+	/** Build schema v2 status for gateways. */
+	buildStatusV2: (overrides?: Partial<ConnectionStatusV2>) => ConnectionStatusV2;
+	/** Merge v2 fields into the mutable legacy status object. */
+	syncLegacyStatus: () => void;
+	/** Mark a tool as invoked this session (for client_has_tool). */
+	markInvoked: (name: string) => void;
+	/** Recompute surface digest/revision from live registrations. */
+	refreshSurfaceFromServer: (options?: { forceBump?: boolean }) => void;
+}
+
+export function createConnectionRuntime(args: {
+	env: NodeJS.ProcessEnv;
+	profile: ProxyToolProfile;
+	fetchImpl?: typeof fetch;
+}): ConnectionRuntime {
+	const env = args.env;
+	const profile = args.profile;
+	const stateMachine = new ConnectionStateMachine();
+	const registry = new RegistryBarrier();
+	const surface = new SurfaceRevisionTracker();
+	const invokedToolNames = new Set<string>();
+
+	const status = createInitialStatus(profile);
+
+	const runtime: ConnectionRuntime = {
+		env,
+		profile,
+		fetchImpl: args.fetchImpl ?? fetch,
+		status,
+		stateMachine,
+		registry,
+		surface,
+		reconnect: null as unknown as ReconnectController,
+		invokedToolNames,
+		callRemoteTool: null,
+		directSession: null,
+		server: null,
+		performReconnect: async () => {
+			throw new Error('Reconnect executor not wired');
+		},
+		listRegisteredToolNames: () => {
+			if (!runtime.server) return [...PERMANENT_GATEWAY_TOOL_NAMES];
+			const tools = (runtime.server as unknown as { _registeredTools?: Record<string, { enabled?: boolean }> })._registeredTools ?? {};
+			return Object.entries(tools)
+				.filter(([, handle]) => handle?.enabled !== false)
+				.map(([name]) => name)
+				.sort();
+		},
+		buildStatusV2: (overrides = {}) => {
+			const stage = runtime.stateMachine.getStage();
+			const activeMode: ActiveMode = runtime.status.mode === 'direct'
+				? 'direct'
+				: runtime.status.connected
+					? 'plugin'
+					: stage === 'local-ready' || stage === 'degraded'
+						? 'local-only'
+						: 'none';
+			const registered = runtime.listRegisteredToolNames();
+			const localCount = registered.filter((n) =>
+				PERMANENT_GATEWAY_TOOL_NAME_SET.has(n) || n.startsWith('stonewright-wp-cli-') || n.startsWith('companion_'),
+			).length;
+			const remoteCount = runtime.status.remote_tool_count;
+			const requested = proxyToolNamesForProfile(runtime.profile);
+			const refresh = computeRefreshRequiredToolNames(requested, registered);
+			const base = buildConnectionStatusV2({
+				siteAlias: (runtime.env['STONEWRIGHT_SITE_ALIAS'] ?? '').trim() || null,
+				configuredMode: runtime.status.configured_mode,
+				activeMode,
+				connectionStage: stage,
+				connectionGeneration: runtime.stateMachine.getGeneration(),
+				mcpUrl: runtime.status.url,
+				authConfigured: runtime.status.configured,
+				authMethod: detectAuthMethod(runtime.env),
+				wpReachable: runtime.status.connected ? true : runtime.status.error ? false : null,
+				siteUrl: siteUrlFromEnv(runtime.env),
+				plugin: {
+					reachable: runtime.status.mode === 'plugin' ? (runtime.status.connected ? true : false) : null,
+					enabled_requested: runtime.status.configured_mode !== 'direct-only',
+					effective_state: stage,
+					registry_ready: runtime.registry.isReady || stage === 'direct-ready',
+				},
+				surface: {
+					profile: String(runtime.status.tool_profile ?? runtime.profile),
+					local_tool_count: localCount,
+					remote_tool_count: remoteCount,
+					registered_tool_count: registered.length,
+					revision: runtime.surface.getRevision(),
+					digest: runtime.surface.getDigest(),
+					relist_required: Boolean(runtime.status.live?.lastRefresh && (runtime.status.live.lastRefresh.added.length > 0 || runtime.status.live.lastRefresh.removed.length > 0)),
+				},
+				clientVisibility: clientVisibilityFromEvidence({ invokedToolNames: runtime.invokedToolNames }),
+				errorCode: runtime.status.error_code ?? (runtime.status.error ? 'connection_error' : null),
+				nextAction: runtime.status.next_action,
+				startupReady: runtime.status.startup_ready,
+				refreshRequiredToolNames: refresh,
+				ok: runtime.status.ok,
+			});
+			return { ...base, ...overrides };
+		},
+		syncLegacyStatus: () => {
+			const v2 = runtime.buildStatusV2();
+			runtime.status.schema_version = v2.schema_version;
+			runtime.status.connected = v2.connected;
+			runtime.status.connection_stage = v2.connection_stage;
+			runtime.status.connection_generation = v2.connection_generation;
+			runtime.status.configured_mode = v2.configured_mode;
+			runtime.status.surface_revision = v2.surface.revision;
+			runtime.status.surface_digest = v2.surface.digest;
+			runtime.status.client_visibility = v2.client_visibility;
+			runtime.status.error_code = v2.error_code;
+			runtime.status.next_action = v2.next_action;
+			runtime.status.startup_ready = v2.startup_ready;
+			runtime.status.refresh_required_tool_names = v2.refresh_required_tool_names;
+		},
+		markInvoked: (name: string) => {
+			runtime.invokedToolNames.add(normalizeToolName(name));
+		},
+		refreshSurfaceFromServer: (options = {}) => {
+			const names = runtime.listRegisteredToolNames();
+			if (options.forceBump) {
+				runtime.surface.bump(names);
+			} else {
+				runtime.surface.commit(names);
+			}
+			runtime.status.surface_revision = runtime.surface.getRevision();
+			runtime.status.surface_digest = runtime.surface.getDigest();
+			runtime.status.local_tool_names = names.filter((n) =>
+				PERMANENT_GATEWAY_TOOL_NAME_SET.has(n) || n.startsWith('stonewright-wp-cli-') || n.startsWith('companion_'),
+			);
+			const requested = proxyToolNamesForProfile(runtime.profile);
+			runtime.status.refresh_required_tool_names = computeRefreshRequiredToolNames(requested, names);
+			runtime.syncLegacyStatus();
+		},
+	};
+
+	runtime.reconnect = new ReconnectController(async (input) => runtime.performReconnect(input));
+
+	registry.seedLocal(PERMANENT_GATEWAY_TOOL_NAMES.map((name) => ({
+		name,
+		source: 'local-gateway' as const,
+	})));
+	surface.commit([...PERMANENT_GATEWAY_TOOL_NAMES]);
+	status.surface_revision = surface.getRevision();
+	status.surface_digest = surface.getDigest();
+	status.configured_mode = mapConfiguredMode(env['STONEWRIGHT_MODE']);
+	status.connection_stage = stateMachine.getStage();
+	status.connection_generation = stateMachine.getGeneration();
+
+	return runtime;
+}
+
+function createInitialStatus(profile: ProxyToolProfile): WordPressMcpConnectionStatus {
+	const profileExpectedToolNames = proxyToolNamesForProfile(profile);
+	const localToolNames = [...PERMANENT_GATEWAY_TOOL_NAMES];
+	return {
+		ok: false,
+		configured: false,
+		connected: false,
+		url: null,
+		tool_profile: profile,
+		surface_revision: 0,
+		surface_digest: null,
+		startup_ready: false,
+		startup_required_tool_names: Array.from(STARTUP_REQUIRED_PROXY_TOOL_NAMES),
+		startup_missing_tool_names: Array.from(STARTUP_REQUIRED_PROXY_TOOL_NAMES),
+		local_recovery_tool_names: localToolNames,
+		local_tool_names: localToolNames,
+		profile_expected_tool_count: profileExpectedToolNames.length,
+		client_visible_expected_tool_count: profileExpectedToolNames.length + localToolNames.length,
+		profile_missing_tool_names: profileExpectedToolNames.filter((n) => !localToolNames.includes(n as never)),
+		remote_tool_count: 0,
+		proxied_tool_count: 0,
+		profile_filtered_tool_count: 0,
+		profile_filtered_tool_names: [],
+		tool_inventory: buildToolInventory(profile, localToolNames),
+		companion_version: APP_VERSION,
+		expected_companion_package: companionPackageSpec(),
+		refresh_required_tool_names: computeRefreshRequiredToolNames(profileExpectedToolNames, localToolNames),
+		prompt_skill_count: 0,
+		error: null,
+		agent_do_not_use: Array.from(AGENT_DO_NOT_USE),
+		agent_use_instead: agentUseInstead({ STONEWRIGHT_MCP_TOOL_PROFILE: profile }),
+		recovery: [
+			'Verify STONEWRIGHT_WP_URL or STONEWRIGHT_MCP_URL points to /wp-json/mcp/stonewright.',
+			'Verify STONEWRIGHT_WP_USERNAME plus STONEWRIGHT_WP_APP_PASSWORD or STONEWRIGHT_MCP_AUTHORIZATION.',
+			'Keep using permanent local gateways (task-start, connect-doctor, reconnect, setup-profile) while fixing the WordPress MCP connection.',
+		],
+		mode: 'plugin',
+		mode_reason: null,
+		configured_mode: 'auto',
+		connection_stage: 'local-ready',
+		connection_generation: 0,
+		direct_tool_count: 0,
+		direct_tool_names: [],
+		unavailable_plugin_capabilities: [],
+		live: null,
+		schema_version: 2,
+		client_visibility: defaultClientVisibility(),
+		error_code: null,
+		next_action: 'Call stonewright-task-start or stonewright-connect-doctor to diagnose connectivity.',
+	};
+}
+
+function detectAuthMethod(env: NodeJS.ProcessEnv): ConnectionStatusV2['authentication']['method'] {
+	if ((env['STONEWRIGHT_OAUTH_CLIENT_ID'] ?? '').trim()) return 'oauth';
+	if ((env['STONEWRIGHT_MCP_AUTHORIZATION'] ?? '').trim()) return 'authorization';
+	if ((env['STONEWRIGHT_WP_USERNAME'] ?? env['WP_API_USERNAME'] ?? '').trim()) return 'app-password';
+	return 'none';
+}
+
+function siteUrlFromEnv(env: NodeJS.ProcessEnv): string | null {
+	const raw = (env['STONEWRIGHT_WP_URL'] ?? env['WP_API_URL'] ?? env['STONEWRIGHT_MCP_URL'] ?? '').trim();
+	return raw || null;
+}
+
+function toolResponse<T extends Record<string, unknown>>(result: T): {
+	content: Array<{ type: 'text'; text: string }>;
+	structuredContent: T;
+} {
+	return {
+		content: [{ type: 'text', text: JSON.stringify(result) }],
+		structuredContent: result,
+	};
+}
+
+/**
+ * Register permanent local gateways BEFORE remote handshake.
+ * Local handlers may proxy to remote when callRemoteTool is wired.
+ */
+export function registerPermanentGateways(server: McpServer, runtime: ConnectionRuntime): void {
+	runtime.server = server;
+
+	const wrap = (name: string, handler: (input: Record<string, unknown>) => unknown | Promise<unknown>) => {
+		return async (input: Record<string, unknown>) => {
+			runtime.markInvoked(name);
+			const result = await handler(input ?? {});
+			return toolResponse(result as Record<string, unknown>);
+		};
+	};
+
+	server.registerTool(
+		'stonewright-setup-profile',
+		{
+			description: 'Return a compact cross-platform Stonewright companion setup profile with copy-paste MCP config, environment checks, and credential guidance.',
+			inputSchema: {
+				siteUrl: z.string().optional(),
+				wpRoot: z.string().optional(),
+				username: z.string().optional(),
+				appPassword: z.string().optional(),
+			},
+		},
+		wrap('stonewright-setup-profile', async (input) => {
+			const mergedEnv = {
+				...runtime.env,
+				...(typeof input['siteUrl'] === 'string' ? { STONEWRIGHT_WP_URL: input['siteUrl'] } : {}),
+				...(typeof input['wpRoot'] === 'string' ? { STONEWRIGHT_WP_ROOT: input['wpRoot'] } : {}),
+				...(typeof input['username'] === 'string' ? { STONEWRIGHT_WP_USERNAME: input['username'] } : {}),
+				...(typeof input['appPassword'] === 'string' ? { STONEWRIGHT_WP_APP_PASSWORD: input['appPassword'] } : {}),
+			};
+			const profile = buildSetupProfile(mergedEnv, process.platform, {
+				mode: runtime.status.mode,
+				...(runtime.status.mode_reason ? { mode_reason: runtime.status.mode_reason } : {}),
+			});
+			const statusV2 = runtime.buildStatusV2();
+			return {
+				...profile,
+				schema_version: statusV2.schema_version,
+				connection_stage: statusV2.connection_stage,
+				configured_mode: statusV2.configured_mode,
+				active_mode: statusV2.active_mode,
+				startup_ready: statusV2.startup_ready,
+				connected: statusV2.connected,
+				client_visibility: statusV2.client_visibility,
+				error_code: statusV2.error_code,
+				next_action: statusV2.next_action,
+				surface: statusV2.surface,
+			};
+		}),
+	);
+
+	server.registerTool(
+		'stonewright-wordpress-mcp-status',
+		{
+			description: 'Return truthful companion connection status (schema_version 2). Available offline so agents can recover without losing gateway tools.',
+			inputSchema: {},
+		},
+		wrap('stonewright-wordpress-mcp-status', () => {
+			runtime.syncLegacyStatus();
+			const live = runtime.status.live;
+			const liveBlock = live
+				? {
+					live_tool_profile: live.profile,
+					surface_revision: live.surfaceRevision ?? runtime.surface.getRevision(),
+					live_enabled_tool_count: live.enabledToolNames.length,
+					live_enabled_tool_names: live.enabledToolNames,
+					last_refresh_at: live.lastRefreshAt,
+					last_refresh_added: live.lastRefresh?.added ?? [],
+					last_refresh_removed: live.lastRefresh?.removed ?? [],
+				}
+				: {
+					live_tool_profile: null,
+					surface_revision: runtime.surface.getRevision(),
+				};
+			const v2 = runtime.buildStatusV2();
+			// Prefer plugin live revision when it is ahead of the local surface tracker.
+			const surfaceRevision = live?.surfaceRevision != null
+				&& (v2.surface.revision == null || live.surfaceRevision >= v2.surface.revision)
+				? live.surfaceRevision
+				: v2.surface.revision;
+			return {
+				...runtime.status,
+				...liveBlock,
+				...v2,
+				surface_revision: surfaceRevision,
+				surface_digest: v2.surface.digest,
+				live_tool_profile: live?.profile ?? v2.surface.profile,
+			};
+		}),
+	);
+
+	server.registerTool(
+		'stonewright-client-surface-check',
+		{
+			description:
+				'Diagnose Stonewright client tool-surface problems. client_has_tool is never inferred from counts alone — only permanent gateways, observed_tool_names attestation, or session invocation.',
+			inputSchema: {
+				expected_tool: z.string().optional(),
+				observed_tool_names: z.array(z.string()).optional(),
+			},
+		},
+		wrap('stonewright-client-surface-check', (input) => {
+			const expected = typeof input['expected_tool'] === 'string' && input['expected_tool'].trim() !== ''
+				? normalizeToolName(input['expected_tool'])
+				: 'stonewright-php-execute';
+			const observed = Array.isArray(input['observed_tool_names'])
+				? input['observed_tool_names'].filter((n): n is string => typeof n === 'string')
+				: null;
+			const live = runtime.status.live;
+			const filtered = new Set(runtime.status.profile_filtered_tool_names ?? []);
+			const missingProfile = new Set(runtime.status.profile_missing_tool_names ?? []);
+			const profile = live?.profile ?? ((runtime.status.tool_profile as ProxyToolProfile) || runtime.profile);
+			const liveEnabled = new Set(live?.enabledToolNames ?? []);
+			for (const name of liveEnabled) {
+				filtered.delete(name);
+				missingProfile.delete(name);
+			}
+			const proxiedToolCount = live?.enabledToolNames.length ?? runtime.status.proxied_tool_count;
+			const localNames = new Set(runtime.listRegisteredToolNames());
+			const profileNames = new Set(proxyToolNamesForProfile(profile));
+
+			const serverHas = PERMANENT_GATEWAY_TOOL_NAME_SET.has(expected)
+				|| localNames.has(expected)
+				|| (runtime.status.connected
+					&& !missingProfile.has(expected)
+					&& (profile === 'full' || profileNames.has(expected) || liveEnabled.has(expected)));
+
+			// NEVER infer client_has_tool from remote_tool_count / connected / startup_ready.
+			const clientHas = clientHasTool(expected, {
+				observedToolNames: observed,
+				invokedToolNames: runtime.invokedToolNames,
+			});
+
+			let errorCode = 'ok';
+			const fix: string[] = [];
+			if (!runtime.status.configured && runtime.status.configured_mode !== 'direct-only') {
+				errorCode = 'not_configured';
+				fix.push('run_setup_profile', 'set_STONEWRIGHT_WP_URL_and_credentials');
+			} else if (!runtime.status.connected && runtime.status.mode === 'plugin') {
+				errorCode = 'auth_or_connectivity_fail';
+				fix.push('call_connect_doctor', 'call_reconnect', 'verify_app_password', 'verify_mcp_url');
+			} else if (filtered.has(expected)) {
+				errorCode = 'client_tool_not_registered';
+				fix.push('call_task_start', 'activate_profile:elementor-design_or_full', 'relist_tools', 'restart_mcp');
+			} else if (!serverHas) {
+				errorCode = 'server_missing_tool';
+				fix.push('deploy_plugin_update', 'enable_ability', 'check_remote_tools_list');
+			} else if (!clientHas) {
+				errorCode = 'client_tool_not_registered';
+				fix.push('relist_tools', 'provide_observed_tool_names', 'restart_mcp');
+			}
+
+			const v2 = runtime.buildStatusV2({
+				client_visibility: clientVisibilityFromEvidence({
+					observedToolNames: observed,
+					invokedToolNames: runtime.invokedToolNames,
+				}, { attested: Boolean(observed?.length) }),
+				error_code: errorCode === 'ok' ? null : errorCode,
+			});
+
+			return {
+				ok: errorCode === 'ok',
+				error_code: errorCode,
+				schema_version: v2.schema_version,
+				server_has_tool: serverHas,
+				client_has_tool: clientHas,
+				expected_tool: expected,
+				connection_stage: v2.connection_stage,
+				startup_ready: v2.startup_ready,
+				connected: v2.connected,
+				client_visibility: v2.client_visibility,
+				surface: v2.surface,
+				next_action: errorCode === 'ok'
+					? 'Surface looks healthy for the expected tool.'
+					: fix[0] ?? 'call_connect_doctor',
+				companion: {
+					tool_profile: profile,
+					connected: runtime.status.connected,
+					configured: runtime.status.configured,
+					remote_tool_count: runtime.status.remote_tool_count,
+					proxied_tool_count: proxiedToolCount,
+					live_enabled_tool_count: live?.enabledToolNames.length ?? null,
+					profile_filtered_tool_count: runtime.status.profile_filtered_tool_count,
+					profile_filtered_tool_names: runtime.status.profile_filtered_tool_names,
+					profile_missing_tool_names: runtime.status.profile_missing_tool_names,
+					mode: runtime.status.mode,
+				},
+				diagnosis: errorCode === 'ok'
+					? 'Client surface looks healthy for the expected tool.'
+					: errorCode === 'auth_or_connectivity_fail'
+						? 'WordPress MCP endpoint is not connected (auth fail or host down).'
+						: errorCode === 'not_configured'
+							? 'Companion is not configured with site credentials.'
+							: 'Do not infer client tool presence from counts. Re-list tools, attest observed_tool_names, or restart MCP. Never call /abilities/run.',
+				fix,
+				agent_do_not_use: [
+					'Do not call /wp-json/stonewright/v1/abilities/run as a workaround.',
+					'Do not hand-roll JSON-RPC against the MCP endpoint.',
+				],
+			};
+		}),
+	);
+
+	server.registerTool(
+		'stonewright-connect-doctor',
+		{
+			description: 'Comprehensive Stonewright connection diagnosis with one primary next_action (schema_version 2).',
+			inputSchema: {
+				site_alias: z.string().optional(),
+			},
+		},
+		wrap('stonewright-connect-doctor', (input) => {
+			runtime.syncLegacyStatus();
+			const v2 = runtime.buildStatusV2();
+			let nextAction = v2.next_action;
+			let errorCode = v2.error_code;
+			if (!runtime.status.configured && runtime.status.configured_mode !== 'direct-only') {
+				errorCode = 'not_configured';
+				nextAction = 'Call stonewright-setup-profile and set STONEWRIGHT_WP_URL plus credentials.';
+			} else if (runtime.status.configured_mode === 'plugin-only' && !runtime.status.connected) {
+				errorCode = 'plugin_unavailable';
+				nextAction = 'Install/enable the Stonewright plugin and credentials, then call stonewright-reconnect with force_probe=true.';
+			} else if (!runtime.status.startup_ready && runtime.status.mode === 'plugin') {
+				errorCode = errorCode ?? 'registry_not_ready';
+				nextAction = 'Wait for registry barrier or call stonewright-reconnect; permanent gateways remain available.';
+			} else if (runtime.status.connected && runtime.status.startup_ready) {
+				errorCode = null;
+				nextAction = 'Call stonewright-task-start and follow fast_path.tool_profile.';
+			} else if (runtime.status.mode === 'direct') {
+				errorCode = null;
+				nextAction = 'Direct mode is active. Call stonewright-task-start (works offline).';
+			} else {
+				nextAction = nextAction ?? 'Call stonewright-reconnect or verify STONEWRIGHT_MCP_URL and credentials.';
+			}
+
+			return {
+				...v2,
+				ok: errorCode === null,
+				error_code: errorCode,
+				next_action: nextAction,
+				site_alias: typeof input['site_alias'] === 'string' ? input['site_alias'] : v2.site_alias,
+				diagnosis: {
+					configured_mode: v2.configured_mode,
+					active_mode: v2.active_mode,
+					connection_stage: v2.connection_stage,
+					plugin: v2.plugin,
+					surface: v2.surface,
+					permanent_gateways: [...PERMANENT_GATEWAY_TOOL_NAMES],
+				},
+				primary_next_action: nextAction,
+			};
+		}),
+	);
+
+	server.registerTool(
+		'stonewright-mode-capabilities',
+		{
+			description: 'Normalized Direct vs Plugin capability comparison (read content, typed updates, Elementor writes, custom code, backup, confirmation tokens).',
+			inputSchema: {},
+		},
+		wrap('stonewright-mode-capabilities', () => {
+			const v2 = runtime.buildStatusV2();
+			return {
+				ok: true,
+				schema_version: v2.schema_version,
+				configured_mode: v2.configured_mode,
+				active_mode: v2.active_mode,
+				connection_stage: v2.connection_stage,
+				capabilities: modeCapabilitiesComparison(),
+				next_action: v2.next_action,
+			};
+		}),
+	);
+
+	server.registerTool(
+		'stonewright-reconnect',
+		{
+			description: 'Re-probe connectivity and rebuild the tool surface. Concurrent reconnects coalesce into one transition. Failed reconnect preserves the prior healthy registry.',
+			inputSchema: {
+				reason: z.string(),
+				site_alias: z.string().optional(),
+				force_probe: z.boolean().optional(),
+			},
+		},
+		wrap('stonewright-reconnect', async (input) => {
+			const reason = typeof input['reason'] === 'string' ? input['reason'] : 'unspecified';
+			const result = await runtime.reconnect.reconnect({
+				reason,
+				...(typeof input['site_alias'] === 'string' ? { site_alias: input['site_alias'] } : {}),
+				...(typeof input['force_probe'] === 'boolean' ? { force_probe: input['force_probe'] } : {}),
+			});
+			const v2 = runtime.buildStatusV2();
+			return {
+				...result,
+				schema_version: v2.schema_version,
+				connection_stage: v2.connection_stage,
+				startup_ready: v2.startup_ready,
+				connected: v2.connected,
+				surface: v2.surface,
+				next_action: result.ok
+					? 'Re-list tools (honor tools/list_changed) then call stonewright-task-start.'
+					: 'Prior registry preserved. Fix the reported error, then retry reconnect.',
+				status: v2,
+			};
+		}),
+	);
+
+	server.registerTool(
+		'stonewright-ping',
+		{
+			description: 'Local gateway ping. Proxies to the plugin when connected; always works offline.',
+			inputSchema: {
+				message: z.string().optional(),
+			},
+		},
+		wrap('stonewright-ping', async (input) => {
+			if (runtime.callRemoteTool && runtime.status.connected) {
+				try {
+					const remote = await runtime.callRemoteTool('stonewright-ping', input);
+					return {
+						ok: true,
+						source: 'plugin',
+						remote,
+						connection_stage: runtime.stateMachine.getStage(),
+						startup_ready: runtime.status.startup_ready,
+					};
+				} catch (err) {
+					return {
+						ok: true,
+						source: 'local-fallback',
+						message: typeof input['message'] === 'string' ? input['message'] : 'pong',
+						error: err instanceof Error ? err.message : String(err),
+						connection_stage: runtime.stateMachine.getStage(),
+					};
+				}
+			}
+			return {
+				ok: true,
+				source: 'local',
+				message: typeof input['message'] === 'string' ? input['message'] : 'pong',
+				connection_stage: runtime.stateMachine.getStage(),
+				startup_ready: runtime.status.startup_ready,
+				companion_version: APP_VERSION,
+			};
+		}),
+	);
+
+	server.registerTool(
+		'stonewright-tool-profile',
+		{
+			description: 'Local gateway tool-profile. Proxies to the plugin when connected; resolves local fallback catalogs offline.',
+			inputSchema: {
+				action: z.string().optional(),
+				profile: z.string().optional(),
+				max_tools: z.number().int().positive().optional(),
+			},
+		},
+		wrap('stonewright-tool-profile', async (input) => {
+			if (runtime.callRemoteTool && runtime.status.connected) {
+				try {
+					const remote = await runtime.callRemoteTool('stonewright-tool-profile', input as Record<string, unknown>);
+					const structured = extractStructured(remote);
+					return {
+						ok: true,
+						source: 'plugin',
+						...(structured ?? { remote }),
+						connection_stage: runtime.stateMachine.getStage(),
+						startup_ready: runtime.status.startup_ready,
+						surface_revision: runtime.surface.getRevision(),
+						surface_digest: runtime.surface.getDigest(),
+					};
+				} catch {
+					// fall through to local
+				}
+			}
+			const action = typeof input['action'] === 'string' ? input['action'] : 'resolve';
+			const requested = typeof input['profile'] === 'string' && input['profile'].trim()
+				? input['profile']
+				: runtime.profile;
+			const tools = proxyToolNamesForProfile(
+				// coerce via names lookup; unknown falls to current
+				(requested as ProxyToolProfile) in { full: 1, bootstrap: 1, 'essential-static': 1, essential: 1, 'low-tools': 1, 'elementor-design': 1, 'content-model': 1, gutenberg: 1, 'wp-cli': 1, 'site-admin': 1 }
+					? (requested as ProxyToolProfile)
+					: runtime.profile,
+			);
+			return {
+				ok: true,
+				source: 'local',
+				action,
+				profile: requested,
+				tools,
+				mcp_surface: runtime.profile,
+				connection_stage: runtime.stateMachine.getStage(),
+				startup_ready: runtime.status.startup_ready,
+				surface_revision: runtime.surface.getRevision(),
+				surface_digest: runtime.surface.getDigest(),
+				re_list_instruction: '',
+			};
+		}),
+	);
+
+	server.registerTool(
+		'stonewright-task-start',
+		{
+			description: 'Permanent local task-start gateway. Always callable offline. Runs bounded health/reconnect per configured mode and never instructs calling a tool that is not locally registered.',
+			inputSchema: {
+				task: z.string().min(1),
+				surface: z.string().optional(),
+				intent: z.string().optional(),
+				site: z.string().optional(),
+				site_alias: z.string().optional(),
+			},
+		},
+		wrap('stonewright-task-start', async (input) => {
+			const task = String(input['task'] ?? '');
+			const site = typeof input['site'] === 'string'
+				? input['site']
+				: typeof input['site_alias'] === 'string'
+					? input['site_alias']
+					: undefined;
+
+			// Plugin path: prefer remote task-start when connected and registry ready (or still registering).
+			if (runtime.callRemoteTool && runtime.status.mode === 'plugin' && runtime.status.connected) {
+				try {
+					const remote = await runtime.callRemoteTool('stonewright-task-start', {
+						task,
+						...(typeof input['surface'] === 'string' ? { surface: input['surface'] } : {}),
+						...(typeof input['intent'] === 'string' ? { intent: input['intent'] } : {}),
+						...(site ? { site } : {}),
+					});
+					const structured = extractStructured(remote) ?? { remote };
+					// Keep live surface_revision in sync when the plugin reports tools_changed.
+					const remoteRevision = structured['surface_revision'];
+					if (typeof remoteRevision === 'number' && Number.isSafeInteger(remoteRevision) && runtime.status.live) {
+						runtime.status.live.surfaceRevision = remoteRevision;
+						if (typeof structured['session_tool_profile'] === 'string') {
+							runtime.status.live.profile = structured['session_tool_profile'] as typeof runtime.status.live.profile;
+							runtime.status.tool_profile = structured['session_tool_profile'] as ProxyToolProfile;
+						}
+					}
+					const v2 = runtime.buildStatusV2();
+					const registered = new Set(runtime.listRegisteredToolNames());
+					const guidance = filterGuidanceToRegistered(
+						Array.isArray((structured as { guidance?: unknown }).guidance)
+							? (structured as { guidance: string[] }).guidance
+							: [],
+						registered,
+					);
+					return {
+						...structured,
+						ok: true,
+						source: 'plugin',
+						schema_version: v2.schema_version,
+						connection_stage: v2.connection_stage,
+						startup_ready: v2.startup_ready,
+						connected: v2.connected,
+						configured_mode: v2.configured_mode,
+						active_mode: v2.active_mode,
+						surface: v2.surface,
+						surface_revision: typeof remoteRevision === 'number' ? remoteRevision : v2.surface.revision,
+						client_visibility: v2.client_visibility,
+						error_code: v2.error_code,
+						next_action: v2.startup_ready
+							? 'Follow fast_path.tool_profile; only call tools present in the current MCP list.'
+							: 'Registry barrier incomplete (startup_ready:false). Permanent gateways remain usable; wait or reconnect.',
+						guidance,
+						registered_gateway_tools: [...PERMANENT_GATEWAY_TOOL_NAMES],
+					};
+				} catch (err) {
+					// Fall through to local bounded response.
+					runtime.status.error = { message: err instanceof Error ? err.message : String(err) };
+				}
+			}
+
+			// Direct / offline local task-start.
+			const selfCtx: selfImprove.SelfImproveContext = {
+				env: runtime.env,
+				...(runtime.fetchImpl ? { fetchImpl: runtime.fetchImpl } : {}),
+				directToolCount: runtime.status.direct_tool_count,
+			};
+			const local = await selfImprove.taskStartAuthoritative(selfCtx, {
+				task,
+				...(typeof input['surface'] === 'string' ? { surface: input['surface'] } : {}),
+				...(typeof input['intent'] === 'string' ? { intent: input['intent'] } : {}),
+				...(site ? { site } : {}),
+			});
+
+			let sessionProfile: DirectToolProfile | ProxyToolProfile = runtime.profile;
+			let surfaceRevision = runtime.surface.getRevision();
+			let toolsChanged = false;
+			let sessionTools: string[] = runtime.listRegisteredToolNames();
+
+			if (runtime.directSession && runtime.status.mode === 'direct') {
+				const configuredProfile = runtime.profile === 'bootstrap' ? 'bootstrap' : runtime.profile;
+				// Map proxy profile to Direct profile for expansion.
+				const directConfigured = toDirectProfile(configuredProfile);
+				const suggested = directConfigured === 'bootstrap'
+					? (await import('../direct/registry.js')).suggestDirectToolProfile(
+						task,
+						String(input['surface'] ?? ''),
+						String(input['intent'] ?? ''),
+					)
+					: directConfigured === 'essential-static'
+						? 'essential'
+						: directConfigured;
+				const changed = suggested !== runtime.directSession.getActiveProfile()
+					? await runtime.directSession.activateProfile(suggested)
+					: { added: [], removed: [], surfaceRevision: runtime.directSession.getSurfaceRevision() };
+				sessionProfile = suggested;
+				surfaceRevision = changed.surfaceRevision;
+				toolsChanged = changed.added.length > 0 || changed.removed.length > 0;
+				sessionTools = runtime.listRegisteredToolNames();
+				if (toolsChanged) {
+					runtime.refreshSurfaceFromServer({ forceBump: true });
+					surfaceRevision = runtime.surface.getRevision();
+					await emitToolListChanged(server);
+				}
+			}
+
+			const v2 = runtime.buildStatusV2();
+			const registered = new Set(runtime.listRegisteredToolNames());
+			const guidance = filterGuidanceToRegistered(
+				Array.isArray((local as { guidance?: unknown }).guidance)
+					? (local as { guidance: string[] }).guidance
+					: [],
+				registered,
+			);
+
+			return {
+				...local,
+				ok: true,
+				source: runtime.status.mode === 'direct' ? 'direct' : 'local',
+				schema_version: v2.schema_version,
+				connection_stage: v2.connection_stage,
+				startup_ready: v2.startup_ready,
+				connected: v2.connected,
+				configured_mode: v2.configured_mode,
+				active_mode: v2.active_mode,
+				configured_mcp_surface: runtime.profile,
+				session_tool_profile: sessionProfile,
+				surface_revision: surfaceRevision,
+				surface_digest: runtime.surface.getDigest(),
+				session_tools: sessionTools,
+				tools_changed: toolsChanged,
+				re_list_instruction: toolsChanged
+					? 'Re-list tools now (tools/list). The task profile is active for this session.'
+					: '',
+				client_visibility: v2.client_visibility,
+				error_code: v2.error_code,
+				next_action: v2.startup_ready
+					? 'Use only tools present in the current MCP list / session_tools.'
+					: 'startup_ready is false (registry barrier incomplete). Permanent gateways remain callable; do not invent missing tools.',
+				guidance,
+				registered_gateway_tools: [...PERMANENT_GATEWAY_TOOL_NAMES],
+				plugin: v2.plugin,
+				surface: v2.surface,
+			};
+		}),
+	);
+}
+
+function toDirectProfile(profile: ProxyToolProfile): DirectToolProfile {
+	if (profile === 'full') return 'full';
+	if (profile === 'bootstrap') return 'bootstrap';
+	if (profile === 'essential-static') return 'essential-static';
+	if (profile === 'essential') return 'essential';
+	if (profile === 'elementor-design' || profile === 'content-model' || profile === 'gutenberg' || profile === 'site-admin') {
+		return profile;
+	}
+	return 'essential-static';
+}
+
+function filterGuidanceToRegistered(guidance: string[], registered: Set<string>): string[] {
+	// Drop lines that tell the agent to call a stonewright-* tool that is not registered.
+	return guidance.filter((line) => {
+		const matches = line.match(/stonewright-[a-z0-9-]+/g) ?? [];
+		if (matches.length === 0) return true;
+		// Keep if any mentioned tool is registered, or if line is general advice.
+		return matches.some((name) => registered.has(name)) || matches.every((name) => !name.startsWith('stonewright-'));
+	});
+}
+
+function extractStructured(raw: unknown): Record<string, unknown> | null {
+	if (!raw || typeof raw !== 'object') return null;
+	const obj = raw as Record<string, unknown>;
+	if (obj['structuredContent'] && typeof obj['structuredContent'] === 'object') {
+		return obj['structuredContent'] as Record<string, unknown>;
+	}
+	if (Array.isArray(obj['content'])) {
+		for (const part of obj['content']) {
+			if (part && typeof part === 'object' && typeof (part as { text?: string }).text === 'string') {
+				try {
+					const parsed = JSON.parse((part as { text: string }).text) as unknown;
+					if (parsed && typeof parsed === 'object') return parsed as Record<string, unknown>;
+				} catch {
+					// ignore
+				}
+			}
+		}
+	}
+	return obj;
+}
+
+export { PERMANENT_GATEWAY_TOOL_NAME_SET, PERMANENT_GATEWAY_TOOL_NAMES };

--- a/companion/src/connection/runtime.ts
+++ b/companion/src/connection/runtime.ts
@@ -141,9 +141,7 @@ export function createConnectionRuntime(args: {
 		callRemoteTool: null,
 		directSession: null,
 		server: null,
-		performReconnect: async () => {
-			throw new Error('Reconnect executor not wired');
-		},
+		performReconnect: () => Promise.reject(new Error('Reconnect executor not wired')),
 		listRegisteredToolNames: () => {
 			if (!runtime.server) return [...PERMANENT_GATEWAY_TOOL_NAMES];
 			const tools = (runtime.server as unknown as { _registeredTools?: Record<string, { enabled?: boolean }> })._registeredTools ?? {};
@@ -336,11 +334,11 @@ function toolResponse<T extends Record<string, unknown>>(result: T): {
 export function registerPermanentGateways(server: McpServer, runtime: ConnectionRuntime): void {
 	runtime.server = server;
 
-	const wrap = (name: string, handler: (input: Record<string, unknown>) => unknown | Promise<unknown>) => {
+	const wrap = (name: string, handler: (input: Record<string, unknown>) => Promise<Record<string, unknown>> | Record<string, unknown>) => {
 		return async (input: Record<string, unknown>) => {
 			runtime.markInvoked(name);
 			const result = await handler(input ?? {});
-			return toolResponse(result as Record<string, unknown>);
+			return toolResponse(result);
 		};
 	};
 
@@ -355,7 +353,7 @@ export function registerPermanentGateways(server: McpServer, runtime: Connection
 				appPassword: z.string().optional(),
 			},
 		},
-		wrap('stonewright-setup-profile', async (input) => {
+		wrap('stonewright-setup-profile', (input) => {
 			const mergedEnv = {
 				...runtime.env,
 				...(typeof input['siteUrl'] === 'string' ? { STONEWRIGHT_WP_URL: input['siteUrl'] } : {}),
@@ -693,7 +691,7 @@ export function registerPermanentGateways(server: McpServer, runtime: Connection
 		wrap('stonewright-tool-profile', async (input) => {
 			if (runtime.callRemoteTool && runtime.status.connected) {
 				try {
-					const remote = await runtime.callRemoteTool('stonewright-tool-profile', input as Record<string, unknown>);
+					const remote = await runtime.callRemoteTool('stonewright-tool-profile', input);
 					const structured = extractStructured(remote);
 					return {
 						ok: true,

--- a/companion/src/connection/state-machine.ts
+++ b/companion/src/connection/state-machine.ts
@@ -1,0 +1,99 @@
+/**
+ * Connection state machine for companion ↔ WordPress lifecycle.
+ *
+ * States:
+ *   local-ready          Permanent gateways registered; no remote yet
+ *   probing              Auto mode checking plugin endpoint
+ *   direct-ready         Direct REST tools registered and usable
+ *   plugin-authenticated Auth/handshake succeeded
+ *   plugin-registering   Remote tools staging; startup_ready=false
+ *   plugin-ready         Registry barrier committed; full catalog active
+ *   degraded             Connection issues; prior healthy registry retained when possible
+ */
+
+export type ConnectionStage =
+	| 'local-ready'
+	| 'probing'
+	| 'direct-ready'
+	| 'plugin-authenticated'
+	| 'plugin-registering'
+	| 'plugin-ready'
+	| 'degraded';
+
+const ALLOWED_TRANSITIONS: Record<ConnectionStage, readonly ConnectionStage[]> = {
+	'local-ready': ['probing', 'direct-ready', 'plugin-authenticated', 'plugin-registering', 'degraded'],
+	probing: ['local-ready', 'direct-ready', 'plugin-authenticated', 'plugin-registering', 'degraded'],
+	'direct-ready': ['probing', 'plugin-authenticated', 'plugin-registering', 'degraded', 'local-ready'],
+	'plugin-authenticated': ['plugin-registering', 'degraded', 'direct-ready', 'local-ready'],
+	'plugin-registering': ['plugin-ready', 'degraded', 'direct-ready', 'local-ready'],
+	'plugin-ready': ['probing', 'plugin-registering', 'degraded', 'direct-ready', 'local-ready'],
+	degraded: ['probing', 'local-ready', 'direct-ready', 'plugin-authenticated', 'plugin-registering', 'plugin-ready'],
+};
+
+export class ConnectionStateMachine {
+	private stage: ConnectionStage = 'local-ready';
+	private generation = 0;
+	private lastError: string | null = null;
+
+	getStage(): ConnectionStage {
+		return this.stage;
+	}
+
+	getGeneration(): number {
+		return this.generation;
+	}
+
+	getLastError(): string | null {
+		return this.lastError;
+	}
+
+	canTransition(to: ConnectionStage): boolean {
+		if (to === this.stage) return true;
+		return ALLOWED_TRANSITIONS[this.stage].includes(to);
+	}
+
+	transition(to: ConnectionStage, options: { error?: string | null; bumpGeneration?: boolean } = {}): ConnectionStage {
+		if (!this.canTransition(to)) {
+			throw new Error(`Invalid connection transition ${this.stage} → ${to}`);
+		}
+		if (to !== this.stage && options.bumpGeneration) {
+			this.generation += 1;
+		}
+		this.stage = to;
+		if (options.error !== undefined) {
+			this.lastError = options.error;
+		} else if (to === 'plugin-ready' || to === 'direct-ready') {
+			this.lastError = null;
+		}
+		return this.stage;
+	}
+
+	/** Registry barrier incomplete while registering remote tools. */
+	isRegistryReady(): boolean {
+		return this.stage === 'plugin-ready' || this.stage === 'direct-ready';
+	}
+
+	/** Derived backward-compatible connected flag — not source of truth. */
+	isConnectedDerived(): boolean {
+		return this.stage === 'plugin-ready'
+			|| this.stage === 'direct-ready'
+			|| this.stage === 'plugin-registering'
+			|| this.stage === 'plugin-authenticated';
+	}
+
+	snapshot(): {
+		connection_stage: ConnectionStage;
+		connection_generation: number;
+		registry_ready: boolean;
+		connected: boolean;
+		last_error: string | null;
+	} {
+		return {
+			connection_stage: this.stage,
+			connection_generation: this.generation,
+			registry_ready: this.isRegistryReady(),
+			connected: this.isConnectedDerived(),
+			last_error: this.lastError,
+		};
+	}
+}

--- a/companion/src/connection/status-contract.ts
+++ b/companion/src/connection/status-contract.ts
@@ -8,7 +8,8 @@
 import type { ConnectionStage } from './state-machine.js';
 import { permanentGatewayMembership } from './permanent-gateways.js';
 
-export const STATUS_SCHEMA_VERSION = 2 as const;
+/** Shared status contract schema version. */
+export const STATUS_SCHEMA_VERSION = 2;
 
 export type ConfiguredMode = 'direct-only' | 'plugin-only' | 'auto';
 export type ActiveMode = 'direct' | 'plugin' | 'local-only' | 'none';
@@ -38,7 +39,7 @@ export interface PluginStatus {
 }
 
 export interface ConnectionStatusV2 {
-	schema_version: typeof STATUS_SCHEMA_VERSION;
+	schema_version: 2;
 	site_alias: string | null;
 	configured_mode: ConfiguredMode;
 	active_mode: ActiveMode;

--- a/companion/src/connection/status-contract.ts
+++ b/companion/src/connection/status-contract.ts
@@ -1,0 +1,260 @@
+/**
+ * Truthful connection status contract (schema_version: 2).
+ *
+ * Shared by setup/doctor/task-start/status/client-surface-check.
+ * `connected` remains a backward-compatible derived field, not source of truth.
+ */
+
+import type { ConnectionStage } from './state-machine.js';
+import { permanentGatewayMembership } from './permanent-gateways.js';
+
+export const STATUS_SCHEMA_VERSION = 2 as const;
+
+export type ConfiguredMode = 'direct-only' | 'plugin-only' | 'auto';
+export type ActiveMode = 'direct' | 'plugin' | 'local-only' | 'none';
+
+export type ClientVisibilityState = 'unverified' | 'attested' | 'invoked';
+
+export interface ClientVisibility {
+	state: ClientVisibilityState;
+	reason: string;
+}
+
+export interface SurfaceStatus {
+	profile: string;
+	local_tool_count: number;
+	remote_tool_count: number;
+	registered_tool_count: number;
+	revision: number;
+	digest: string;
+	relist_required: boolean;
+}
+
+export interface PluginStatus {
+	reachable: boolean | null;
+	enabled_requested: boolean;
+	effective_state: string;
+	registry_ready: boolean;
+}
+
+export interface ConnectionStatusV2 {
+	schema_version: typeof STATUS_SCHEMA_VERSION;
+	site_alias: string | null;
+	configured_mode: ConfiguredMode;
+	active_mode: ActiveMode;
+	connection_stage: ConnectionStage;
+	connection_generation: number;
+	transport: {
+		kind: 'stdio' | 'http' | 'unknown';
+		mcp_url: string | null;
+	};
+	authentication: {
+		configured: boolean;
+		method: 'app-password' | 'authorization' | 'oauth' | 'none' | 'unknown';
+	};
+	wordpress_runtime: {
+		reachable: boolean | null;
+		site_url: string | null;
+	};
+	plugin: PluginStatus;
+	surface: SurfaceStatus;
+	client_visibility: ClientVisibility;
+	error_code: string | null;
+	next_action: string | null;
+	/** Derived backward-compatible field — not source of truth. */
+	connected: boolean;
+	ok: boolean;
+	startup_ready: boolean;
+	refresh_required_tool_names: string[];
+	client_task_catalog_stale?: boolean;
+	relist_or_restart_action?: string | null;
+}
+
+export interface ClientHasToolContext {
+	/** Tool names the client attested via observed_tool_names. */
+	observedToolNames?: readonly string[] | null;
+	/** Tool names successfully invoked this session. */
+	invokedToolNames?: ReadonlySet<string> | null;
+}
+
+/**
+ * NEVER infer client_has_tool from remote_tool_count, connected, or startup_ready.
+ * Only permanent gateway membership, explicit attestation, or session invocation.
+ */
+export function clientHasTool(toolName: string, ctx: ClientHasToolContext = {}): boolean {
+	const normalized = normalizeToolName(toolName);
+	if (permanentGatewayMembership(normalized)) {
+		return true;
+	}
+	if (ctx.observedToolNames?.some((name) => normalizeToolName(name) === normalized)) {
+		return true;
+	}
+	if (ctx.invokedToolNames?.has(normalized)) {
+		return true;
+	}
+	return false;
+}
+
+export function defaultClientVisibility(reason = 'Client tool list not yet attested or invoked this session.'): ClientVisibility {
+	return { state: 'unverified', reason };
+}
+
+export function clientVisibilityFromEvidence(
+	ctx: ClientHasToolContext,
+	options: { attested?: boolean; invoked?: boolean } = {},
+): ClientVisibility {
+	if (options.invoked || (ctx.invokedToolNames && ctx.invokedToolNames.size > 0)) {
+		return { state: 'invoked', reason: 'At least one tool was invoked this session.' };
+	}
+	if (options.attested || (ctx.observedToolNames && ctx.observedToolNames.length > 0)) {
+		return { state: 'attested', reason: 'Client supplied observed_tool_names attestation.' };
+	}
+	return defaultClientVisibility();
+}
+
+/**
+ * refresh_required_tool_names = requested profile tools not currently registered.
+ * NEVER a static hardcoded list alone.
+ */
+export function computeRefreshRequiredToolNames(
+	requestedToolNames: readonly string[],
+	registeredToolNames: readonly string[],
+): string[] {
+	const registered = new Set(registeredToolNames);
+	return requestedToolNames.filter((name) => !registered.has(name));
+}
+
+export function mapConfiguredMode(envMode: string | null | undefined): ConfiguredMode {
+	const raw = (envMode ?? 'auto').trim().toLowerCase();
+	if (raw === 'direct' || raw === 'direct-only') return 'direct-only';
+	if (raw === 'plugin' || raw === 'plugin-only') return 'plugin-only';
+	return 'auto';
+}
+
+export function buildConnectionStatusV2(input: {
+	siteAlias?: string | null;
+	configuredMode: ConfiguredMode;
+	activeMode: ActiveMode;
+	connectionStage: ConnectionStage;
+	connectionGeneration: number;
+	transportKind?: 'stdio' | 'http' | 'unknown';
+	mcpUrl?: string | null;
+	authConfigured: boolean;
+	authMethod?: ConnectionStatusV2['authentication']['method'];
+	wpReachable?: boolean | null;
+	siteUrl?: string | null;
+	plugin: PluginStatus;
+	surface: SurfaceStatus;
+	clientVisibility?: ClientVisibility;
+	errorCode?: string | null;
+	nextAction?: string | null;
+	startupReady: boolean;
+	refreshRequiredToolNames?: string[];
+	clientTaskCatalogStale?: boolean;
+	relistOrRestartAction?: string | null;
+	/** Extra derived ok override. */
+	ok?: boolean;
+}): ConnectionStatusV2 {
+	const connected = input.connectionStage === 'plugin-ready'
+		|| input.connectionStage === 'direct-ready'
+		|| input.connectionStage === 'plugin-registering'
+		|| input.connectionStage === 'plugin-authenticated';
+	const ok = input.ok ?? (input.startupReady && !input.errorCode);
+
+	return {
+		schema_version: STATUS_SCHEMA_VERSION,
+		site_alias: input.siteAlias ?? null,
+		configured_mode: input.configuredMode,
+		active_mode: input.activeMode,
+		connection_stage: input.connectionStage,
+		connection_generation: input.connectionGeneration,
+		transport: {
+			kind: input.transportKind ?? 'stdio',
+			mcp_url: input.mcpUrl ?? null,
+		},
+		authentication: {
+			configured: input.authConfigured,
+			method: input.authMethod ?? (input.authConfigured ? 'unknown' : 'none'),
+		},
+		wordpress_runtime: {
+			reachable: input.wpReachable ?? null,
+			site_url: input.siteUrl ?? null,
+		},
+		plugin: input.plugin,
+		surface: input.surface,
+		client_visibility: input.clientVisibility ?? defaultClientVisibility(),
+		error_code: input.errorCode ?? null,
+		next_action: input.nextAction ?? null,
+		connected,
+		ok,
+		startup_ready: input.startupReady,
+		refresh_required_tool_names: input.refreshRequiredToolNames ?? [],
+		...(input.clientTaskCatalogStale !== undefined
+			? { client_task_catalog_stale: input.clientTaskCatalogStale }
+			: {}),
+		...(input.relistOrRestartAction !== undefined
+			? { relist_or_restart_action: input.relistOrRestartAction }
+			: {}),
+	};
+}
+
+export function normalizeToolName(name: string): string {
+	const trimmed = name.trim().replaceAll('/', '-');
+	if (!trimmed) return trimmed;
+	return trimmed.startsWith('stonewright-') ? trimmed : `stonewright-${trimmed}`;
+}
+
+/** Capability comparison for stonewright-mode-capabilities. */
+export interface ModeCapabilityRow {
+	capability: string;
+	direct: 'yes' | 'no' | 'limited';
+	plugin: 'yes' | 'no' | 'limited';
+	notes: string;
+}
+
+export function modeCapabilitiesComparison(): ModeCapabilityRow[] {
+	return [
+		{
+			capability: 'read_content',
+			direct: 'yes',
+			plugin: 'yes',
+			notes: 'Both modes can read posts/pages/media via REST or typed abilities.',
+		},
+		{
+			capability: 'typed_updates',
+			direct: 'limited',
+			plugin: 'yes',
+			notes: 'Direct uses core REST; plugin exposes full typed ability surface.',
+		},
+		{
+			capability: 'elementor_writes',
+			direct: 'limited',
+			plugin: 'yes',
+			notes: 'Direct can patch _elementor_data (WP-CLI/REST meta); schema-safe batch-mutate is plugin-only.',
+		},
+		{
+			capability: 'custom_code_apply',
+			direct: 'no',
+			plugin: 'limited',
+			notes: 'Custom code requires human approval grant; Pluginless Direct must not write custom CSS.',
+		},
+		{
+			capability: 'backup',
+			direct: 'limited',
+			plugin: 'yes',
+			notes: 'Direct file-level backups for Elementor meta; plugin Backup::snapshot_post for engine writes.',
+		},
+		{
+			capability: 'confirmation_tokens',
+			direct: 'no',
+			plugin: 'yes',
+			notes: 'Production-safe ConfirmationToken issue/verify is plugin-only.',
+		},
+		{
+			capability: 'php_execute',
+			direct: 'no',
+			plugin: 'yes',
+			notes: 'stonewright-php-execute requires the Stonewright plugin runtime.',
+		},
+	];
+}

--- a/companion/src/connection/surface-digest.ts
+++ b/companion/src/connection/surface-digest.ts
@@ -1,0 +1,63 @@
+/**
+ * Surface revision + digest helpers.
+ *
+ * Digest = sha256 of sorted registered tool names, prefixed "sha256:".
+ * Revision is monotonic and increments on every committed surface change.
+ */
+
+import { createHash } from 'node:crypto';
+
+export function computeSurfaceDigest(toolNames: readonly string[]): string {
+	const sorted = [...toolNames].filter(Boolean).sort();
+	const hash = createHash('sha256').update(sorted.join('\n')).digest('hex');
+	return `sha256:${hash}`;
+}
+
+export class SurfaceRevisionTracker {
+	private revision = 0;
+	private digest = computeSurfaceDigest([]);
+	private names: string[] = [];
+
+	getRevision(): number {
+		return this.revision;
+	}
+
+	getDigest(): string {
+		return this.digest;
+	}
+
+	getNames(): readonly string[] {
+		return this.names;
+	}
+
+	/** Replace the active catalog and bump revision when the name set changes. */
+	commit(toolNames: readonly string[]): { revision: number; digest: string; changed: boolean } {
+		const nextNames = [...new Set(toolNames.filter(Boolean))].sort();
+		const nextDigest = computeSurfaceDigest(nextNames);
+		const changed = nextDigest !== this.digest || nextNames.length !== this.names.length;
+		this.names = nextNames;
+		this.digest = nextDigest;
+		if (changed) {
+			this.revision += 1;
+		}
+		return { revision: this.revision, digest: this.digest, changed };
+	}
+
+	/** Force a revision bump (e.g. reconnect generation) even if names match. */
+	bump(toolNames?: readonly string[]): { revision: number; digest: string } {
+		if (toolNames) {
+			this.names = [...new Set(toolNames.filter(Boolean))].sort();
+			this.digest = computeSurfaceDigest(this.names);
+		}
+		this.revision += 1;
+		return { revision: this.revision, digest: this.digest };
+	}
+
+	snapshot(): { revision: number; digest: string; registered_tool_names: string[] } {
+		return {
+			revision: this.revision,
+			digest: this.digest,
+			registered_tool_names: [...this.names],
+		};
+	}
+}

--- a/companion/src/direct/mode.ts
+++ b/companion/src/direct/mode.ts
@@ -1,9 +1,12 @@
 export type StonewrightRuntimeMode = 'auto' | 'direct' | 'plugin';
 export type ResolvedRuntimeMode = 'direct' | 'plugin';
+/** Configured mode policy surface (env mapping). */
+export type ConfiguredRuntimeMode = 'direct-only' | 'plugin-only' | 'auto';
 
 export interface ProbeResult {
 	mode: ResolvedRuntimeMode;
 	requested: StonewrightRuntimeMode;
+	configured: ConfiguredRuntimeMode;
 	endpoint: string | null;
 	pluginEndpointStatus: number | null;
 	reason: string;
@@ -11,9 +14,23 @@ export interface ProbeResult {
 
 export function resolveRequestedMode(env: NodeJS.ProcessEnv = process.env): StonewrightRuntimeMode {
 	const raw = (env['STONEWRIGHT_MODE'] ?? 'auto').trim().toLowerCase();
-	if (raw === 'direct' || raw === 'plugin' || raw === 'auto') {
-		return raw;
+	if (raw === 'direct' || raw === 'direct-only') {
+		return 'direct';
 	}
+	if (raw === 'plugin' || raw === 'plugin-only') {
+		return 'plugin';
+	}
+	if (raw === 'auto') {
+		return 'auto';
+	}
+	return 'auto';
+}
+
+/** Map env STONEWRIGHT_MODE to configured policy modes. */
+export function resolveConfiguredMode(env: NodeJS.ProcessEnv = process.env): ConfiguredRuntimeMode {
+	const requested = resolveRequestedMode(env);
+	if (requested === 'direct') return 'direct-only';
+	if (requested === 'plugin') return 'plugin-only';
 	return 'auto';
 }
 
@@ -115,34 +132,40 @@ export async function resolveRuntimeMode(args: {
 }): Promise<ProbeResult> {
 	const env = args.env ?? process.env;
 	const requested = resolveRequestedMode(env);
+	const configured = resolveConfiguredMode(env);
 	const siteBase = siteBaseFromEnv(env);
 	const endpoint = siteBase ? pluginMcpEndpoint(siteBase) : null;
 
+	// direct-only: never probe/switch to plugin.
 	if (requested === 'direct') {
 		return {
 			mode: 'direct',
 			requested,
+			configured,
 			endpoint,
 			pluginEndpointStatus: null,
-			reason: 'STONEWRIGHT_MODE=direct',
+			reason: 'STONEWRIGHT_MODE=direct (direct-only); plugin path not probed.',
 		};
 	}
 
+	// plugin-only: prefer plugin path; caller fails closed (no Direct tools) if unavailable.
 	if (requested === 'plugin') {
 		return {
 			mode: 'plugin',
 			requested,
+			configured,
 			endpoint,
 			pluginEndpointStatus: null,
-			reason: 'STONEWRIGHT_MODE=plugin',
+			reason: 'STONEWRIGHT_MODE=plugin (plugin-only); Direct tools will not be registered as fallback.',
 		};
 	}
 
-	// auto
+	// auto: prefer healthy plugin; fall back Direct when endpoint is explicitly absent.
 	if (!endpoint) {
 		return {
 			mode: 'plugin',
 			requested,
+			configured,
 			endpoint: null,
 			pluginEndpointStatus: null,
 			reason: 'No site URL configured; plugin proxy path remains available for local recovery tools.',
@@ -154,9 +177,10 @@ export async function resolveRuntimeMode(args: {
 		return {
 			mode: 'direct',
 			requested,
+			configured,
 			endpoint,
 			pluginEndpointStatus: probe.status,
-			reason: 'Plugin MCP endpoint returned 404; registering Direct REST tools.',
+			reason: 'Plugin MCP endpoint returned 404; registering Direct REST tools (auto fallback).',
 		};
 	}
 
@@ -164,6 +188,7 @@ export async function resolveRuntimeMode(args: {
 		return {
 			mode: 'plugin',
 			requested,
+			configured,
 			endpoint,
 			pluginEndpointStatus: probe.status,
 			reason: `Plugin MCP endpoint responded with HTTP ${probe.status ?? 'ok'}.`,
@@ -173,6 +198,7 @@ export async function resolveRuntimeMode(args: {
 	return {
 		mode: 'plugin',
 		requested,
+		configured,
 		endpoint,
 		pluginEndpointStatus: probe.status,
 		reason: 'Plugin MCP endpoint probe inconclusive; using plugin proxy path.',

--- a/companion/src/direct/registry.ts
+++ b/companion/src/direct/registry.ts
@@ -215,25 +215,51 @@ export const DIRECT_ESSENTIAL_TOOL_NAMES = [
 	'stonewright-elementor-status',
 ] as const;
 
-export type DirectToolProfile = 'bootstrap' | 'essential' | 'elementor-design' | 'content-model' | 'gutenberg' | 'site-admin' | 'full';
+export type DirectToolProfile =
+	| 'bootstrap'
+	| 'essential-static'
+	| 'essential'
+	| 'elementor-design'
+	| 'content-model'
+	| 'gutenberg'
+	| 'site-admin'
+	| 'full';
+
+export interface DirectSessionControls {
+	activateProfile: (profile: DirectToolProfile) => Promise<{
+		added: string[];
+		removed: string[];
+		surfaceRevision: number;
+	}>;
+	getActiveProfile: () => DirectToolProfile;
+	getSurfaceRevision: () => number;
+}
 
 export interface DirectModeContext {
 	env: NodeJS.ProcessEnv;
 	fetchImpl?: typeof fetch;
 	sitesConfig?: SitesConfig;
 	timeoutMs?: number;
-	/** Initial Direct tool surface. Defaults to bootstrap in the companion. */
+	/** Initial Direct tool surface. Defaults to essential-static in the companion. */
 	toolProfile?: DirectToolProfile;
 	/** Keep companion status synchronized with Direct profile changes. */
 	onSurfaceChange?: (revision: number, profile: DirectToolProfile) => void;
+	/**
+	 * Tool names owned by permanent local gateways — Direct must not dual-register them.
+	 * Permanent task-start/tool-profile/ping etc. stay on the gateway surface.
+	 */
+	skipToolNames?: ReadonlySet<string>;
+	/** Optional hook so permanent task-start can expand the Direct session profile. */
+	onSessionReady?: (controls: DirectSessionControls) => void;
 }
 
 function directProfileToolNames(profile: DirectToolProfile): readonly string[] {
 	if (profile === 'full') return DIRECT_TOOL_NAMES;
 	if (profile === 'bootstrap') return DIRECT_BOOTSTRAP_TOOL_NAMES;
-	if (profile === 'essential') return DIRECT_ESSENTIAL_TOOL_NAMES;
+	// essential-static uses the same bounded useful Direct catalog as essential.
+	if (profile === 'essential' || profile === 'essential-static') return DIRECT_ESSENTIAL_TOOL_NAMES;
 
-	const profileNeedles: Record<Exclude<DirectToolProfile, 'bootstrap' | 'essential' | 'full'>, readonly string[]> = {
+	const profileNeedles: Record<Exclude<DirectToolProfile, 'bootstrap' | 'essential' | 'essential-static' | 'full'>, readonly string[]> = {
 		'elementor-design': ['elementor', 'media-', 'blueprint-', 'content-get', 'content-update', 'gutenberg-validate', 'settings-get'],
 		'content-model': ['content-', 'media-', 'taxonomy-', 'menu-', 'search', 'blueprint-', 'plugin-list', 'theme-list', 'rest-request'],
 		gutenberg: ['gutenberg', 'content-', 'media-', 'template-', 'global-styles', 'block-', 'pattern-', 'settings-get'],
@@ -260,7 +286,7 @@ export function suggestDirectToolProfile(task: string, surface = '', intent = ''
  */
 export function shouldRegisterDirectTool(
 	name: string,
-	profile: DirectToolProfile = 'bootstrap',
+	profile: DirectToolProfile = 'essential-static',
 ): boolean {
 	return directProfileToolNames(profile).includes(name);
 }
@@ -413,15 +439,29 @@ function buildContext(ctx: DirectModeContext, siteAlias?: string) {
 export function registerDirectTools(server: McpServer, ctx: DirectModeContext): string[] {
 	const siteArg = z.string().optional().describe('Site alias from ~/.stonewright/sites.json');
 	const confirmArg = z.boolean().optional().describe('Required true for destructive tools when remote/confirm mode');
-	let activeProfile: DirectToolProfile = ctx.toolProfile ?? 'bootstrap';
+	let activeProfile: DirectToolProfile = ctx.toolProfile ?? 'essential-static';
 	let directSurfaceRevision = 0;
 	const registered: string[] = [];
 	const toolHandles = new Map<string, RegisteredTool>();
+	const skipToolNames = ctx.skipToolNames ?? new Set<string>();
 	// MCP SDK overloads tool(); keep a typed wrapper without `any`.
 	type ToolRegistrar = {
 		tool: (name: string, ...args: never[]) => unknown;
 	};
 	const registerTool = ((name: string, ...rest: never[]) => {
+		// Permanent local gateways own these names — do not dual-register.
+		if (skipToolNames.has(name)) {
+			const noop: RegisteredTool = {
+				enabled: false,
+				handler: (() => ({ content: [] })) as RegisteredTool['handler'],
+				enable() { this.enabled = true; },
+				disable() { this.enabled = false; },
+				update() {},
+				remove() {},
+			};
+			toolHandles.set(name, noop);
+			return noop;
+		}
 		const sdkHandle = (server as unknown as ToolRegistrar).tool(name, ...rest) as RegisteredTool | undefined;
 		const fallbackHandle: RegisteredTool = {
 			enabled: true,
@@ -443,6 +483,7 @@ export function registerDirectTools(server: McpServer, ctx: DirectModeContext): 
 		const added: string[] = [];
 		const removed: string[] = [];
 		for (const [name, handle] of toolHandles) {
+			if (skipToolNames.has(name)) continue;
 			const desired = shouldRegisterDirectTool(name, profile);
 			if (desired && !handle.enabled) {
 				handle.enable();
@@ -466,6 +507,12 @@ export function registerDirectTools(server: McpServer, ctx: DirectModeContext): 
 		}
 		return { added, removed, surfaceRevision: directSurfaceRevision };
 	};
+
+	ctx.onSessionReady?.({
+		activateProfile,
+		getActiveProfile: () => activeProfile,
+		getSurfaceRevision: () => directSurfaceRevision,
+	});
 
 
 	// --- Wave 1: content ---

--- a/companion/src/mcp-server.ts
+++ b/companion/src/mcp-server.ts
@@ -1,7 +1,7 @@
 /**
  * MCP server for the Stonewright companion.
  *
- * WordPress-facing helpers such as WP-CLI are registered here.
+ * Permanent local gateways register first; WordPress proxy / Direct tools follow.
  */
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -21,58 +21,36 @@ import {
 	type WpCliJobStartInput,
 	type WpCliRunInput,
 } from './wp-cli.js';
-import { AGENT_DO_NOT_USE, MCP_MISSING_BOOTSTRAP_STOP, agentUseInstead, buildSetupProfile, buildToolInventory, type ToolInventory } from './setup-profile.js';
+import { MCP_MISSING_BOOTSTRAP_STOP, buildToolInventory } from './setup-profile.js';
 import {
 	STARTUP_REQUIRED_PROXY_TOOL_NAMES,
 	type ProxyToolProfile,
+	emitToolListChanged,
 	mergeServerInstructions,
 	proxyToolProfileFromEnv,
 	proxyToolNamesForProfile,
 	registerWordPressMcpPrompts,
 	registerWordPressMcpTools,
 	resolveWordPressMcpConfig,
-	type WordPressProxyLiveState,
 } from './wordpress-mcp.js';
-import { APP_VERSION, companionPackageSpec } from './version.js';
+import { APP_VERSION } from './version.js';
 import { registerDirectTools, DIRECT_TOOL_NAMES, type DirectToolProfile } from './direct/registry.js';
 import { resolveRuntimeMode, type ProbeResult } from './direct/mode.js';
 import { PLUGIN_ONLY_CAPABILITIES } from './direct/tools/site-discover.js';
+import {
+	PERMANENT_GATEWAY_TOOL_NAMES,
+	PERMANENT_GATEWAY_TOOL_NAME_SET,
+	type ReconnectInput,
+	type ReconnectResult,
+} from './connection/index.js';
+import {
+	createConnectionRuntime,
+	registerPermanentGateways,
+	type ConnectionRuntime,
+	type WordPressMcpConnectionStatus,
+} from './connection/runtime.js';
 
-interface WordPressMcpConnectionStatus extends Record<string, unknown> {
-	ok: boolean;
-	configured: boolean;
-	connected: boolean;
-	url: string | null;
-	tool_profile: string | null;
-	surface_revision: number | null;
-	startup_ready: boolean;
-	startup_required_tool_names: string[];
-	startup_missing_tool_names: string[];
-	local_recovery_tool_names: string[];
-	local_tool_names: string[];
-	profile_expected_tool_count: number;
-	client_visible_expected_tool_count: number;
-	profile_missing_tool_names: string[];
-	remote_tool_count: number;
-	proxied_tool_count: number;
-	profile_filtered_tool_count: number;
-	profile_filtered_tool_names: string[];
-	tool_inventory: ToolInventory;
-	companion_version: string;
-	expected_companion_package: string;
-	refresh_required_tool_names: string[];
-	prompt_skill_count: number;
-	error: { message: string } | null;
-	agent_do_not_use: string[];
-	agent_use_instead: string[];
-	recovery: string[];
-	mode: 'plugin' | 'direct';
-	mode_reason: string | null;
-	direct_tool_count: number;
-	direct_tool_names: string[];
-	unavailable_plugin_capabilities: Array<{ id: string; label: string; reason: string; upgrade: string }>;
-	live: WordPressProxyLiveState | null;
-}
+export type { WordPressMcpConnectionStatus };
 
 export interface CreateMcpServerOptions {
 	env?: NodeJS.ProcessEnv;
@@ -80,9 +58,7 @@ export interface CreateMcpServerOptions {
 }
 
 const LOCAL_RECOVERY_TOOL_NAMES = [
-	'stonewright-setup-profile',
-	'stonewright-wordpress-mcp-status',
-	'stonewright-client-surface-check',
+	...PERMANENT_GATEWAY_TOOL_NAMES,
 	'stonewright-wp-cli-status',
 	'stonewright-wp-cli-discover',
 	'stonewright-wp-cli-run',
@@ -93,9 +69,7 @@ const LOCAL_RECOVERY_TOOL_NAMES = [
 ] as const;
 
 const LOW_TOOLS_LOCAL_RECOVERY_TOOL_NAMES = [
-	'stonewright-setup-profile',
-	'stonewright-wordpress-mcp-status',
-	// Keep low-tools under the 12-tool cap; surface-check stays on normal profiles.
+	...PERMANENT_GATEWAY_TOOL_NAMES,
 	'stonewright-wp-cli-status',
 	'stonewright-wp-cli-batch-run',
 	'stonewright-wp-cli-job-start',
@@ -118,6 +92,13 @@ const LOCAL_TOOL_NAMES = [
 export async function createMcpServer(options: CreateMcpServerOptions = {}): Promise<McpServer> {
 	const env = options.env ?? process.env;
 	const profile = proxyToolProfileFromEnv(env);
+	const fetchImpl = options.fetchImpl ?? fetch;
+	const runtime = createConnectionRuntime({
+		env,
+		profile,
+		...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+	});
+
 	// Companion-only text first; plugin instructions are merged after remote init
 	// (AI client connects after createMcpServer returns, so late set is safe).
 	const server = new McpServer({
@@ -137,83 +118,262 @@ export async function createMcpServer(options: CreateMcpServerOptions = {}): Pro
 		timeoutMs: z.number().int().positive().optional(),
 	};
 
+	// 1) Permanent gateways BEFORE any remote handshake (local-ready).
+	registerPermanentGateways(server, runtime);
+	// 2) WP-CLI helpers (local; not removed by profiles).
 	registerWpCliTools(server, commonInput, env, profile);
-	registerSetupTools(server, env);
-	const wpMcpStatus = createWordPressMcpConnectionStatus(profile);
-	registerWordPressMcpStatusTool(server, wpMcpStatus);
-	// Diagnostic surface stays off low-tools so strict clients remain ≤12 tools.
-	if (profile !== 'low-tools') {
-		registerClientSurfaceCheckTool(server, wpMcpStatus, env);
-	}
+	runtime.refreshSurfaceFromServer();
+
+	// Wire reconnect after helpers exist so it can re-run mode probe + registration.
+	runtime.performReconnect = async (input: ReconnectInput): Promise<ReconnectResult> => {
+		return performReconnect(server, runtime, options, input);
+	};
+
+	await bootstrapConnection(server, runtime, options, fetchImpl);
+	return server;
+}
+
+async function bootstrapConnection(
+	server: McpServer,
+	runtime: ConnectionRuntime,
+	options: CreateMcpServerOptions,
+	fetchImpl: typeof fetch,
+): Promise<void> {
+	const env = runtime.env;
+	const profile = runtime.profile;
+	const wpMcpStatus = runtime.status;
+
+	runtime.stateMachine.transition('probing');
+	wpMcpStatus.connection_stage = runtime.stateMachine.getStage();
 
 	const modeProbe = await resolveRuntimeMode({
 		env,
-		...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+		fetchImpl,
 	});
 	wpMcpStatus.mode = modeProbe.mode;
 	wpMcpStatus.mode_reason = modeProbe.reason;
+	wpMcpStatus.configured_mode = modeProbe.configured;
 
 	if (modeProbe.mode === 'direct') {
-		await registerDirectMode(server, env, options, wpMcpStatus, modeProbe, profile);
-		return server;
+		// plugin-only must never fall into Direct tools (resolveRuntimeMode already
+		// returns plugin for plugin-only; this branch is auto/direct-only).
+		await registerDirectMode(server, env, options, runtime, modeProbe, profile);
+		return;
 	}
 
+	// Plugin path (plugin-only or auto preferring plugin).
+	runtime.stateMachine.transition('plugin-authenticated');
 	let wpMcpConfig = null;
 	try {
 		wpMcpConfig = await resolveWordPressMcpConfig(env);
 	} catch (err) {
 		wpMcpStatus.configured = hasWordPressMcpConfig(env);
 		wpMcpStatus.error = { message: err instanceof Error ? err.message : String(err) };
-	}
-	if (wpMcpConfig) {
-		wpMcpStatus.configured = true;
-		wpMcpStatus.url = wpMcpConfig.url;
-		try {
-			const registration = await registerWordPressMcpTools(server, wpMcpConfig, options.fetchImpl ?? fetch, env);
-			const promptSkills = await registerWordPressMcpPrompts(server, wpMcpConfig, options.fetchImpl ?? fetch);
-			// Forward plugin initialize.instructions so clients see task-start + site rules.
-			setServerInstructions(
-				server,
-				mergeServerInstructions(companionInstructions(profile), registration.remoteInstructions),
-			);
-			wpMcpStatus.ok = true;
-			wpMcpStatus.connected = true;
-			wpMcpStatus.mode = 'plugin';
-			wpMcpStatus.tool_profile = registration.profile;
-			wpMcpStatus.live = registration.liveState;
-			wpMcpStatus.remote_tool_count = registration.remoteTools.length;
-			wpMcpStatus.proxied_tool_count = registration.registeredTools.length;
-			wpMcpStatus.profile_filtered_tool_count = registration.filteredToolCount;
-			wpMcpStatus.profile_filtered_tool_names = registration.profileFilteredToolNames;
-			wpMcpStatus.startup_missing_tool_names = missingStartupTools(registration.registeredTools.map((tool) => tool.name));
-			wpMcpStatus.startup_ready = wpMcpStatus.startup_missing_tool_names.length === 0;
-			const profileExpectedToolNames = proxyToolNamesForProfile(registration.profile);
-			const localToolNames = localToolNamesForProfile(registration.profile);
-			wpMcpStatus.profile_expected_tool_count = profileExpectedToolNames.length;
-			wpMcpStatus.client_visible_expected_tool_count = profileExpectedToolNames.length + localToolNames.length;
-			wpMcpStatus.tool_inventory = buildToolInventory(registration.profile, localToolNames);
-			wpMcpStatus.profile_missing_tool_names = missingProfileTools(
-				profileExpectedToolNames,
-				registration.registeredTools.map((tool) => tool.name),
-				localToolNames,
-			);
-			wpMcpStatus.local_recovery_tool_names = Array.from(localRecoveryToolNamesForProfile(registration.profile));
-			wpMcpStatus.local_tool_names = Array.from(localToolNames);
-			wpMcpStatus.prompt_skill_count = promptSkills.length;
-			wpMcpStatus.recovery = recoveryHints(
-				registration.filteredToolCount,
-				wpMcpStatus.startup_missing_tool_names.length,
-				wpMcpStatus.profile_missing_tool_names.length,
-			);
-			wpMcpStatus.error = null;
-		} catch (err) {
-			wpMcpStatus.ok = false;
-			wpMcpStatus.connected = false;
-			wpMcpStatus.error = { message: err instanceof Error ? err.message : String(err) };
-		}
+		wpMcpStatus.error_code = 'config_error';
+		wpMcpStatus.next_action = 'Fix WordPress MCP config, then call stonewright-reconnect.';
+		runtime.stateMachine.transition('degraded', { error: wpMcpStatus.error.message });
+		runtime.syncLegacyStatus();
+		return;
 	}
 
-	return server;
+	if (!wpMcpConfig) {
+		wpMcpStatus.configured = hasWordPressMcpConfig(env);
+		// plugin-only fails closed: no Direct tools.
+		if (modeProbe.configured === 'plugin-only') {
+			wpMcpStatus.ok = false;
+			wpMcpStatus.connected = false;
+			wpMcpStatus.error = { message: 'Plugin-only mode: WordPress MCP is not configured.' };
+			wpMcpStatus.error_code = 'plugin_unavailable';
+			wpMcpStatus.next_action = 'Configure STONEWRIGHT_WP_URL and credentials, install the plugin, then reconnect.';
+			runtime.stateMachine.transition('degraded', { error: wpMcpStatus.error.message });
+			runtime.syncLegacyStatus();
+			return;
+		}
+		// auto without config: keep local gateways; stay degraded/plugin path recovery.
+		wpMcpStatus.ok = false;
+		wpMcpStatus.connected = false;
+		wpMcpStatus.error_code = 'not_configured';
+		wpMcpStatus.next_action = 'Call stonewright-setup-profile and configure site credentials.';
+		runtime.stateMachine.transition('degraded', { error: 'not_configured' });
+		runtime.syncLegacyStatus();
+		return;
+	}
+
+	wpMcpStatus.configured = true;
+	wpMcpStatus.url = wpMcpConfig.url;
+	runtime.stateMachine.transition('plugin-registering');
+	wpMcpStatus.startup_ready = false;
+	wpMcpStatus.connection_stage = 'plugin-registering';
+	runtime.registry.beginStaging();
+
+	try {
+		const registration = await registerWordPressMcpTools(server, wpMcpConfig, fetchImpl, env);
+		const promptSkills = await registerWordPressMcpPrompts(server, wpMcpConfig, fetchImpl);
+		setServerInstructions(
+			server,
+			mergeServerInstructions(companionInstructions(profile), registration.remoteInstructions),
+		);
+		runtime.callRemoteTool = registration.callRemoteTool;
+		runtime.registry.stageMany(
+			registration.registeredTools.map((tool) => ({ name: tool.name, source: 'remote' as const })),
+		);
+		runtime.registry.commit();
+		runtime.stateMachine.transition('plugin-ready', { bumpGeneration: true });
+
+		wpMcpStatus.ok = true;
+		wpMcpStatus.connected = true;
+		wpMcpStatus.mode = 'plugin';
+		wpMcpStatus.tool_profile = registration.profile;
+		wpMcpStatus.live = registration.liveState;
+		wpMcpStatus.remote_tool_count = registration.remoteTools.length;
+		wpMcpStatus.proxied_tool_count = registration.registeredTools.length;
+		wpMcpStatus.profile_filtered_tool_count = registration.filteredToolCount;
+		wpMcpStatus.profile_filtered_tool_names = registration.profileFilteredToolNames;
+		// Permanent gateways cover task-start; remaining startup tools may still be remote.
+		wpMcpStatus.startup_missing_tool_names = missingStartupTools([
+			...PERMANENT_GATEWAY_TOOL_NAMES,
+			...registration.registeredTools.map((tool) => tool.name),
+		]);
+		wpMcpStatus.startup_ready = wpMcpStatus.startup_missing_tool_names.length === 0;
+		const profileExpectedToolNames = proxyToolNamesForProfile(registration.profile);
+		const localToolNames = localToolNamesForProfile(registration.profile);
+		wpMcpStatus.profile_expected_tool_count = profileExpectedToolNames.length;
+		wpMcpStatus.client_visible_expected_tool_count = profileExpectedToolNames.length + localToolNames.length;
+		wpMcpStatus.tool_inventory = buildToolInventory(registration.profile, localToolNames);
+		wpMcpStatus.profile_missing_tool_names = missingProfileTools(
+			profileExpectedToolNames,
+			[...PERMANENT_GATEWAY_TOOL_NAMES, ...registration.registeredTools.map((tool) => tool.name)],
+			localToolNames,
+		);
+		wpMcpStatus.local_recovery_tool_names = Array.from(localRecoveryToolNamesForProfile(registration.profile));
+		wpMcpStatus.local_tool_names = Array.from(localToolNames);
+		wpMcpStatus.prompt_skill_count = promptSkills.length;
+		wpMcpStatus.recovery = recoveryHints(
+			registration.filteredToolCount,
+			wpMcpStatus.startup_missing_tool_names.length,
+			wpMcpStatus.profile_missing_tool_names.length,
+		);
+		wpMcpStatus.error = null;
+		wpMcpStatus.error_code = null;
+		wpMcpStatus.next_action = 'Call stonewright-task-start and follow fast_path.tool_profile.';
+		runtime.refreshSurfaceFromServer({ forceBump: true });
+		runtime.syncLegacyStatus();
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		runtime.registry.abort(message);
+		// plugin-only: fail closed, no Direct fallback.
+		if (modeProbe.configured === 'plugin-only') {
+			wpMcpStatus.ok = false;
+			wpMcpStatus.connected = false;
+			wpMcpStatus.error = { message };
+			wpMcpStatus.error_code = 'plugin_unavailable';
+			wpMcpStatus.next_action = 'Fix plugin connectivity, then call stonewright-reconnect. Direct tools are not available in plugin-only mode.';
+			runtime.stateMachine.transition('degraded', { error: message });
+			runtime.syncLegacyStatus();
+			return;
+		}
+		// auto: fall back to Direct when plugin registration fails with 404-like absence.
+		if (modeProbe.configured === 'auto' && /404|not found|ECONNREFUSED/i.test(message)) {
+			await registerDirectMode(server, env, options, runtime, {
+				...modeProbe,
+				mode: 'direct',
+				reason: `Plugin registration failed (${message}); auto fallback to Direct.`,
+			}, profile);
+			return;
+		}
+		wpMcpStatus.ok = false;
+		wpMcpStatus.connected = false;
+		wpMcpStatus.error = { message };
+		wpMcpStatus.error_code = 'connection_error';
+		wpMcpStatus.next_action = 'Call stonewright-connect-doctor, fix credentials/URL, then stonewright-reconnect.';
+		runtime.stateMachine.transition('degraded', { error: message });
+		// Permanent gateways remain; prior registry empty on first boot.
+		runtime.syncLegacyStatus();
+	}
+}
+
+async function performReconnect(
+	server: McpServer,
+	runtime: ConnectionRuntime,
+	options: CreateMcpServerOptions,
+	input: ReconnectInput,
+): Promise<ReconnectResult> {
+	const priorReady = runtime.registry.isReady;
+	const priorGeneration = runtime.stateMachine.getGeneration();
+	const priorRevision = runtime.surface.getRevision();
+	const priorNames = runtime.listRegisteredToolNames();
+
+	try {
+		// Re-run bootstrap path. Failed reconnect must preserve prior healthy registry:
+		// we only clear remote call handle after a successful re-register.
+		const previousCallRemote = runtime.callRemoteTool;
+		const previousLive = runtime.status.live;
+		const previousConnected = runtime.status.connected;
+		const previousStartup = runtime.status.startup_ready;
+
+		if (input.force_probe || runtime.status.configured_mode === 'auto') {
+			runtime.stateMachine.transition('probing', { bumpGeneration: true });
+		}
+
+		await bootstrapConnection(server, runtime, options, runtime.fetchImpl);
+
+		if (!runtime.status.connected && priorReady) {
+			// Restore prior healthy signals when reconnect failed.
+			runtime.callRemoteTool = previousCallRemote;
+			runtime.status.live = previousLive;
+			runtime.status.connected = previousConnected;
+			runtime.status.startup_ready = previousStartup;
+			runtime.registry.abort(runtime.status.error?.message ?? 'reconnect failed');
+			runtime.stateMachine.transition('degraded', {
+				error: runtime.status.error?.message ?? 'reconnect failed',
+			});
+			// Keep prior surface names/digest; still bump revision so clients re-list.
+			runtime.surface.bump(priorNames);
+			runtime.syncLegacyStatus();
+			await emitToolListChanged(server);
+			return {
+				ok: false,
+				coalesced: false,
+				reason: input.reason,
+				site_alias: input.site_alias ?? null,
+				force_probe: Boolean(input.force_probe),
+				connection_generation: runtime.stateMachine.getGeneration(),
+				surface_revision: runtime.surface.getRevision(),
+				prior_registry_preserved: true,
+				error: runtime.status.error?.message ?? 'reconnect failed',
+			};
+		}
+
+		runtime.refreshSurfaceFromServer({ forceBump: true });
+		await emitToolListChanged(server);
+		return {
+			ok: runtime.status.connected || runtime.status.mode === 'direct',
+			coalesced: false,
+			reason: input.reason,
+			site_alias: input.site_alias ?? null,
+			force_probe: Boolean(input.force_probe),
+			connection_generation: runtime.stateMachine.getGeneration(),
+			surface_revision: runtime.surface.getRevision(),
+			prior_registry_preserved: false,
+			error: runtime.status.error?.message ?? null,
+		};
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		runtime.registry.abort(message);
+		runtime.surface.bump(priorNames);
+		runtime.syncLegacyStatus();
+		return {
+			ok: false,
+			coalesced: false,
+			reason: input.reason,
+			site_alias: input.site_alias ?? null,
+			force_probe: Boolean(input.force_probe),
+			connection_generation: priorGeneration,
+			surface_revision: priorRevision + 1,
+			prior_registry_preserved: priorReady,
+			error: message,
+		};
+	}
 }
 
 /** SDK stores instructions on the inner Server; mutate before client connect. */
@@ -228,12 +388,14 @@ async function registerDirectMode(
 	server: McpServer,
 	env: NodeJS.ProcessEnv,
 	options: CreateMcpServerOptions,
-	wpMcpStatus: WordPressMcpConnectionStatus,
+	runtime: ConnectionRuntime,
 	modeProbe: ProbeResult,
 	profile: ProxyToolProfile,
 ): Promise<void> {
+	const wpMcpStatus = runtime.status;
 	wpMcpStatus.mode = 'direct';
 	wpMcpStatus.mode_reason = modeProbe.reason;
+	wpMcpStatus.configured_mode = modeProbe.configured;
 	wpMcpStatus.unavailable_plugin_capabilities = PLUGIN_ONLY_CAPABILITIES.map((cap) => ({
 		id: cap.id,
 		label: cap.label,
@@ -251,21 +413,30 @@ async function registerDirectMode(
 			env,
 			...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
 			// Explicit Direct override wins; otherwise the shared MCP surface drives
-			// progressive registration. Bootstrap expands after task-start.
+			// progressive registration. essential-static expands after task-start.
 			toolProfile: directProfile,
+			skipToolNames: PERMANENT_GATEWAY_TOOL_NAME_SET,
+			onSessionReady: (controls) => {
+				runtime.directSession = controls;
+			},
 			onSurfaceChange: (revision, liveProfile) => {
 				wpMcpStatus.surface_revision = revision;
 				wpMcpStatus.tool_profile = liveProfile;
+				runtime.refreshSurfaceFromServer();
 			},
 		});
 		setServerInstructions(server, companionInstructions(profile, 'direct'));
 		const localToolNames = localToolNamesForProfile(profile);
+		runtime.registry.commitDirect(
+			registered.map((name) => ({ name, source: 'direct' as const })),
+		);
+		runtime.stateMachine.transition('direct-ready', { bumpGeneration: true });
+
 		wpMcpStatus.ok = true;
 		wpMcpStatus.connected = true;
 		wpMcpStatus.configured = hasWordPressMcpConfig(env) || Boolean(env['STONEWRIGHT_WP_USERNAME']);
 		wpMcpStatus.url = modeProbe.endpoint;
 		wpMcpStatus.tool_profile = directProfile;
-		wpMcpStatus.surface_revision = 0;
 		wpMcpStatus.direct_tool_count = registered.length;
 		wpMcpStatus.direct_tool_names = registered.slice(0, 40);
 		wpMcpStatus.startup_ready = true;
@@ -291,12 +462,14 @@ async function registerDirectMode(
 		];
 		wpMcpStatus.recovery = [
 			'Direct mode is active: core REST tools are registered without the Stonewright plugin.',
-			'Call stonewright-task-start first; Bootstrap unlocks the compact Direct task profile for this session.',
+			'Call stonewright-task-start first; the compact Direct task profile unlocks for this session.',
 			'Use stonewright-site-discover when endpoint or plugin-only capability details are needed.',
 			'Direct local memory and user skills remain available. Install the plugin only when its native mutation engine, php-execute, or production-safe confirmation tokens are required.',
-			'Set STONEWRIGHT_MODE=plugin after installing the plugin, then restart the MCP client.',
+			'Set STONEWRIGHT_MODE=plugin after installing the plugin, then call stonewright-reconnect or restart the MCP client.',
 		];
 		wpMcpStatus.error = null;
+		wpMcpStatus.error_code = null;
+		wpMcpStatus.next_action = 'Call stonewright-task-start (works with zero WordPress credentials).';
 		wpMcpStatus.agent_use_instead = [
 			'stonewright-task-start',
 			'stonewright-site-discover',
@@ -306,22 +479,27 @@ async function registerDirectMode(
 			'stonewright-wp-cli-run',
 			...DIRECT_TOOL_NAMES.slice(0, 8),
 		];
+		runtime.refreshSurfaceFromServer({ forceBump: true });
+		runtime.syncLegacyStatus();
 	} catch (err) {
 		wpMcpStatus.ok = false;
 		wpMcpStatus.connected = false;
 		wpMcpStatus.error = { message: err instanceof Error ? err.message : String(err) };
+		wpMcpStatus.error_code = 'direct_registration_failed';
+		runtime.stateMachine.transition('degraded', { error: wpMcpStatus.error.message });
+		runtime.syncLegacyStatus();
 	}
 }
 
 function directToolProfileFromEnv(env: NodeJS.ProcessEnv, profile: ProxyToolProfile): DirectToolProfile {
 	const explicit = (env['STONEWRIGHT_DIRECT_TOOL_PROFILE'] ?? '').trim().toLowerCase();
-	if (['bootstrap', 'essential', 'elementor-design', 'content-model', 'gutenberg', 'site-admin', 'full'].includes(explicit)) {
+	if (['bootstrap', 'essential-static', 'essential', 'elementor-design', 'content-model', 'gutenberg', 'site-admin', 'full'].includes(explicit)) {
 		return explicit as DirectToolProfile;
 	}
-	if (['bootstrap', 'essential', 'elementor-design', 'content-model', 'gutenberg', 'site-admin', 'full'].includes(profile)) {
+	if (['bootstrap', 'essential-static', 'essential', 'elementor-design', 'content-model', 'gutenberg', 'site-admin', 'full'].includes(profile)) {
 		return profile as DirectToolProfile;
 	}
-	return 'essential';
+	return 'essential-static';
 }
 
 function companionInstructions(
@@ -376,52 +554,6 @@ function hasWordPressMcpConfig(env: NodeJS.ProcessEnv): boolean {
 	return Boolean((env['STONEWRIGHT_MCP_URL'] ?? env['WP_API_URL'] ?? env['STONEWRIGHT_WP_URL'] ?? '').trim());
 }
 
-function createWordPressMcpConnectionStatus(profile: ProxyToolProfile): WordPressMcpConnectionStatus {
-	const profileExpectedToolNames = proxyToolNamesForProfile(profile);
-	const localToolNames = localToolNamesForProfile(profile);
-	const profileMissingToolNames = missingProfileTools(profileExpectedToolNames, [], localToolNames);
-
-	return {
-		ok: false,
-		configured: false,
-		connected: false,
-		url: null,
-		tool_profile: profile,
-		surface_revision: null,
-		startup_ready: false,
-		startup_required_tool_names: Array.from(STARTUP_REQUIRED_PROXY_TOOL_NAMES),
-		startup_missing_tool_names: Array.from(STARTUP_REQUIRED_PROXY_TOOL_NAMES),
-		local_recovery_tool_names: Array.from(localRecoveryToolNamesForProfile(profile)),
-		local_tool_names: Array.from(localToolNames),
-		profile_expected_tool_count: profileExpectedToolNames.length,
-		client_visible_expected_tool_count: profileExpectedToolNames.length + localToolNames.length,
-		profile_missing_tool_names: profileMissingToolNames,
-		remote_tool_count: 0,
-		proxied_tool_count: 0,
-		profile_filtered_tool_count: 0,
-		profile_filtered_tool_names: [],
-		tool_inventory: buildToolInventory(profile, localToolNames),
-		companion_version: APP_VERSION,
-		expected_companion_package: companionPackageSpec(),
-		refresh_required_tool_names: [
-			'stonewright-context-bootstrap',
-			'stonewright-task-start',
-			'stonewright-php-execute',
-		],
-		prompt_skill_count: 0,
-		error: null,
-		agent_do_not_use: Array.from(AGENT_DO_NOT_USE),
-		agent_use_instead: agentUseInstead({ STONEWRIGHT_MCP_TOOL_PROFILE: profile }),
-		recovery: recoveryHints(0, STARTUP_REQUIRED_PROXY_TOOL_NAMES.length, profileMissingToolNames.length),
-		mode: 'plugin',
-		mode_reason: null,
-		direct_tool_count: 0,
-		direct_tool_names: [],
-		unavailable_plugin_capabilities: [],
-		live: null,
-	};
-}
-
 function missingStartupTools(registeredToolNames: string[]): string[] {
 	const registered = new Set(registeredToolNames);
 	return STARTUP_REQUIRED_PROXY_TOOL_NAMES.filter((name) => !registered.has(name));
@@ -457,180 +589,6 @@ function recoveryHints(profileFilteredToolCount: number, startupMissingToolCount
 		hints.push('If profile_missing_tool_names is not empty, update or enable those WordPress Stonewright tools, or switch STONEWRIGHT_MCP_TOOL_PROFILE to full for specialist recovery.');
 	}
 	return hints;
-}
-
-function registerSetupTools(server: McpServer, env: NodeJS.ProcessEnv): void {
-	server.registerTool(
-		'stonewright-setup-profile',
-		{
-			description: 'Return a compact cross-platform Stonewright companion setup profile with copy-paste MCP config, environment checks, and credential guidance.',
-			inputSchema: {
-				siteUrl: z.string().optional(),
-				wpRoot: z.string().optional(),
-				username: z.string().optional(),
-				appPassword: z.string().optional(),
-			},
-		},
-		async (input) => {
-			const mergedEnv = {
-				...env,
-				...(typeof input.siteUrl === 'string' ? { STONEWRIGHT_WP_URL: input.siteUrl } : {}),
-				...(typeof input.wpRoot === 'string' ? { STONEWRIGHT_WP_ROOT: input.wpRoot } : {}),
-				...(typeof input.username === 'string' ? { STONEWRIGHT_WP_USERNAME: input.username } : {}),
-				...(typeof input.appPassword === 'string' ? { STONEWRIGHT_WP_APP_PASSWORD: input.appPassword } : {}),
-			};
-			const modeProbe = await resolveRuntimeMode({ env: mergedEnv });
-			return toolResponse(buildSetupProfile(mergedEnv, process.platform, {
-				mode: modeProbe.mode,
-				mode_reason: modeProbe.reason,
-			}));
-		},
-	);
-}
-
-function registerWordPressMcpStatusTool(server: McpServer, status: WordPressMcpConnectionStatus): void {
-	server.registerTool(
-		'stonewright-wordpress-mcp-status',
-		{
-			description: 'Return whether the companion successfully proxied the WordPress Stonewright MCP endpoint. Available even when the endpoint is down so agents can recover without losing setup and WP-CLI tools.',
-			inputSchema: {},
-		},
-		() => {
-			const live = status.live;
-			const liveBlock = live
-				? {
-					live_tool_profile: live.profile,
-					surface_revision: live.surfaceRevision,
-					live_enabled_tool_count: live.enabledToolNames.length,
-					live_enabled_tool_names: live.enabledToolNames,
-					last_refresh_at: live.lastRefreshAt,
-					last_refresh_added: live.lastRefresh?.added ?? [],
-					last_refresh_removed: live.lastRefresh?.removed ?? [],
-				}
-				: { live_tool_profile: null };
-			return toolResponse({ ...status, ...liveBlock });
-		},
-	);
-}
-
-/**
- * Diagnose companion vs WordPress vs client tool-surface mismatches.
- * Always local — works even when php-execute is filtered out of the proxy set.
- */
-function registerClientSurfaceCheckTool(
-	server: McpServer,
-	status: WordPressMcpConnectionStatus,
-	env: NodeJS.ProcessEnv,
-): void {
-	server.registerTool(
-		'stonewright-client-surface-check',
-		{
-			description:
-				'Diagnose Stonewright client tool-surface problems: companion profile, remote tools, filtered tools, whether php-execute is registered, and concrete fixes (relist / activate profile / restart MCP). Prefer this over inventing REST abilities/run workarounds.',
-			inputSchema: {
-				expected_tool: z.string().optional(),
-			},
-		},
-		(input) => {
-			const expected = typeof input.expected_tool === 'string' && input.expected_tool.trim() !== ''
-				? input.expected_tool.trim().replaceAll('/', '-')
-				: 'stonewright-php-execute';
-			const expectedNorm = expected.startsWith('stonewright-') ? expected : `stonewright-${expected}`;
-			const live = status.live;
-			const filtered = new Set(status.profile_filtered_tool_names ?? []);
-			const missingProfile = new Set(status.profile_missing_tool_names ?? []);
-			const profile = live?.profile ?? ((status.tool_profile as ProxyToolProfile) || 'bootstrap');
-			const liveEnabled = new Set(live?.enabledToolNames ?? []);
-			for (const name of liveEnabled) {
-				filtered.delete(name);
-				missingProfile.delete(name);
-			}
-			const proxiedToolCount = live?.enabledToolNames.length ?? status.proxied_tool_count;
-			const localNames = new Set(status.local_tool_names ?? []);
-			const profileNames = new Set(proxyToolNamesForProfile(profile));
-			// Prefer explicit inventory membership over "full ⇒ everything ok".
-			const serverHas = status.connected
-				&& status.remote_tool_count > 0
-				&& !missingProfile.has(expectedNorm)
-				&& (profile === 'full' || profileNames.has(expectedNorm) || localNames.has(expectedNorm)
-					|| !filtered.has(expectedNorm));
-			// Filtered tools are remote-visible but not client-registered.
-			const startupClientHas = proxiedToolCount > 0
-				&& !filtered.has(expectedNorm)
-				&& !missingProfile.has(expectedNorm)
-				&& (profile === 'full'
-					? status.remote_tool_count > 0 && !filtered.has(expectedNorm)
-					: profileNames.has(expectedNorm));
-			const clientHas = status.connected
-				&& (localNames.has(expectedNorm)
-					|| (live !== null ? liveEnabled.has(expectedNorm) : startupClientHas));
-
-			let errorCode = 'ok';
-			const fix: string[] = [];
-			if (!status.configured) {
-				errorCode = 'not_configured';
-				fix.push('run_setup_profile', 'set_STONEWRIGHT_WP_URL_and_credentials');
-			} else if (!status.connected) {
-				errorCode = 'auth_or_connectivity_fail';
-				fix.push('verify_app_password', 'verify_mcp_url', 'restart_mcp');
-			} else if (filtered.has(expectedNorm)) {
-				errorCode = 'client_tool_not_registered';
-				fix.push('call_task_start', 'activate_profile:elementor-design_or_full', 'relist_tools', 'restart_mcp');
-			} else if (!serverHas) {
-				errorCode = 'server_missing_tool';
-				fix.push('deploy_plugin_update', 'enable_ability', 'check_remote_tools_list');
-			} else if (!clientHas) {
-				errorCode = 'client_tool_not_registered';
-				fix.push('relist_tools', 'activate_profile:full', 'restart_mcp');
-			}
-
-			const siteAlias = (env['STONEWRIGHT_SITE_ALIAS'] ?? '').trim();
-			const writeTarget = status.url
-				? String(status.url).replace(/\/wp-json\/mcp\/stonewright\/?$/i, '/')
-				: null;
-
-			return toolResponse({
-				ok: errorCode === 'ok',
-				error_code: errorCode,
-				server_has_tool: serverHas || (status.connected && status.remote_tool_count > 50),
-				client_has_tool: clientHas,
-				expected_tool: expectedNorm,
-				companion: {
-					tool_profile: profile,
-					connected: status.connected,
-					configured: status.configured,
-					remote_tool_count: status.remote_tool_count,
-					proxied_tool_count: proxiedToolCount,
-					live_enabled_tool_count: live?.enabledToolNames.length ?? null,
-					stale_startup_snapshot: live !== null && live.lastRefreshAt !== null,
-					profile_filtered_tool_count: status.profile_filtered_tool_count,
-					profile_filtered_tool_names: status.profile_filtered_tool_names,
-					profile_missing_tool_names: status.profile_missing_tool_names,
-					mode: status.mode,
-				},
-				write_target: {
-					url: writeTarget,
-					mcp_url: status.url,
-					site_alias: siteAlias || null,
-					label: writeTarget
-						? `active write target = ${writeTarget} (${status.mode})`
-						: 'active write target unknown — configure STONEWRIGHT_WP_URL',
-				},
-				diagnosis: errorCode === 'ok'
-					? 'Client surface looks healthy for the expected tool.'
-					: errorCode === 'auth_or_connectivity_fail'
-						? 'WordPress MCP endpoint is not connected (auth fail or host down).'
-						: errorCode === 'not_configured'
-							? 'Companion is not configured with site credentials.'
-							: 'Server likely has the tool but the companion client profile filtered it out. Re-list after task-start/tool-profile, or restart MCP. Do not call /abilities/run.',
-				fix,
-				agent_do_not_use: [
-					'Do not call /wp-json/stonewright/v1/abilities/run as a workaround.',
-					'Do not hand-roll JSON-RPC against the MCP endpoint.',
-				],
-			});
-		},
-	);
 }
 
 function registerWpCliTools(

--- a/companion/src/setup-profile.ts
+++ b/companion/src/setup-profile.ts
@@ -115,7 +115,7 @@ export function buildSetupProfile(
 	const oauthTokenStore = (env['STONEWRIGHT_OAUTH_TOKEN_STORE'] ?? '').trim();
 	const oauthTokenEndpoint = (env['STONEWRIGHT_OAUTH_TOKEN_ENDPOINT'] ?? '').trim();
 	const hasOAuth = oauthClientId !== '' && oauthTokenStore !== '';
-	const toolProfile = (env['STONEWRIGHT_MCP_TOOL_PROFILE'] ?? env['STONEWRIGHT_MCP_PROXY_PROFILE'] ?? 'bootstrap').trim() || 'bootstrap';
+	const toolProfile = (env['STONEWRIGHT_MCP_TOOL_PROFILE'] ?? env['STONEWRIGHT_MCP_PROXY_PROFILE'] ?? 'essential-static').trim() || 'essential-static';
 	const local = siteUrl !== '' && isLocalUrl(siteUrl);
 	const canAutoCredentials = local && wpRoot !== '';
 	const mode = modeOptions.mode
@@ -237,7 +237,7 @@ export function buildSetupProfile(
 			'Verify the MCP tool list includes stonewright-task-start before starting WordPress work; stonewright-context-bootstrap is a plugin compatibility path.',
 			'Use stonewright-wordpress-mcp-status if proxied WordPress tools are missing; setup and WP-CLI tools remain available while fixing the connection.',
 			'After every Stonewright release or skill sync, restart the MCP client and re-run stonewright-setup-profile plus stonewright-wordpress-mcp-status; if refresh_required_tool_names are missing, the client is still using an old tool list.',
-			'STONEWRIGHT_MCP_TOOL_PROFILE=bootstrap is the default progressive surface; stonewright-task-start unlocks the task profile for the current session.',
+			'STONEWRIGHT_MCP_TOOL_PROFILE=essential-static is the default install surface (bounded useful catalog + permanent recovery gateways). full is never selected implicitly. Known dynamic clients may still set bootstrap then activate essential without process restart.',
 			mode === 'direct'
 				? 'Use STONEWRIGHT_MCP_TOOL_PROFILE=low-tools for strict tool-cap clients; task-start plus Direct batch and background-job tools stay visible without php-execute.'
 				: 'Use STONEWRIGHT_MCP_TOOL_PROFILE=low-tools for strict tool-cap clients; php-execute plus companion WP-CLI batch and background-job tools stay visible.',
@@ -293,26 +293,37 @@ export function buildToolInventory(
 	runtimeMode: 'plugin' | 'direct' = 'plugin',
 ): ToolInventory {
 	const proxiedProfileToolNames = runtimeMode === 'plugin' ? proxyToolNamesForProfile(profile) : [];
-	const clientVisibleExpectedToolCount = new Set([...proxiedProfileToolNames, ...localToolNames]).size;
+	const registeredLike = [...new Set([...proxiedProfileToolNames, ...localToolNames])];
+	const clientVisibleExpectedToolCount = registeredLike.length;
 	const firstCallToolNames = runtimeMode === 'direct'
 		? ['stonewright-task-start']
 		: ['stonewright-task-start', 'stonewright-context-bootstrap'];
-	const refreshRequiredToolNames = runtimeMode === 'direct'
-		? ['stonewright-task-start', 'stonewright-rules-get', 'stonewright-site-discover']
-		: ['stonewright-task-start', 'stonewright-context-bootstrap', 'stonewright-php-execute'];
+	// refresh_required_tool_names is computed from requested profile vs registered — not a static list alone.
+	const requestedRefreshBase = runtimeMode === 'direct'
+		? ['stonewright-task-start', 'stonewright-rules-get', 'stonewright-site-discover', ...localToolNames.filter((n) => n.startsWith('stonewright-'))]
+		: [
+			'stonewright-task-start',
+			'stonewright-context-bootstrap',
+			'stonewright-php-execute',
+			...proxiedProfileToolNames.slice(0, 12),
+		];
+	const refreshRequiredToolNames = requestedRefreshBase.filter(
+		(name, index, arr) => arr.indexOf(name) === index && !registeredLike.includes(name),
+	);
 
 	return {
 		profile,
 		runtime_mode: runtimeMode,
 		startup_budget: {
-			strict_client_tool_cap: profile === 'low-tools' ? 12 : 20,
+			strict_client_tool_cap: profile === 'low-tools' ? 12 : 40,
 			client_visible_expected_tool_count: clientVisibleExpectedToolCount,
-			under_low_tools_cap: clientVisibleExpectedToolCount <= (profile === 'low-tools' ? 12 : 20),
+			under_low_tools_cap: clientVisibleExpectedToolCount <= (profile === 'low-tools' ? 12 : 40),
 		},
 		first_call_tool_names: firstCallToolNames,
 		diagnostic_tool_names: localToolNames.filter((name) => [
 			'stonewright-setup-profile',
 			'stonewright-wordpress-mcp-status',
+			'stonewright-connect-doctor',
 			'stonewright-wp-cli-status',
 			'stonewright-wp-cli-discover',
 		].includes(name)),
@@ -376,16 +387,30 @@ function toolVisibilityChecks(env: NodeJS.ProcessEnv): string[] {
 	const profile = proxyToolProfileFromEnv(env);
 	const localTools = profile === 'low-tools'
 		? [
+			'stonewright-task-start',
+			'stonewright-connect-doctor',
 			'stonewright-setup-profile',
 			'stonewright-wordpress-mcp-status',
+			'stonewright-mode-capabilities',
+			'stonewright-tool-profile',
+			'stonewright-client-surface-check',
+			'stonewright-reconnect',
+			'stonewright-ping',
 			'stonewright-wp-cli-status',
 			'stonewright-wp-cli-batch-run',
 			'stonewright-wp-cli-job-start',
 			'stonewright-wp-cli-job-status',
 		]
 		: [
+			'stonewright-task-start',
+			'stonewright-connect-doctor',
 			'stonewright-setup-profile',
 			'stonewright-wordpress-mcp-status',
+			'stonewright-mode-capabilities',
+			'stonewright-tool-profile',
+			'stonewright-client-surface-check',
+			'stonewright-reconnect',
+			'stonewright-ping',
 			'stonewright-wp-cli-status',
 			'stonewright-wp-cli-discover',
 			'stonewright-wp-cli-run',

--- a/companion/src/wordpress-mcp.ts
+++ b/companion/src/wordpress-mcp.ts
@@ -4,6 +4,7 @@ import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'n
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { z, type ZodTypeAny } from 'zod';
+import { PERMANENT_GATEWAY_TOOL_NAMES, isPermanentGatewayTool } from './connection/permanent-gateways.js';
 import { OAuthTokenManager, OAuthTokenStore } from './oauth-token-manager.js';
 import { runWpCli, type ExecFileRunner } from './wp-cli.js';
 import { APP_VERSION } from './version.js';
@@ -59,6 +60,8 @@ export interface WordPressMcpRegistrationResult {
 	/** Plugin MCP initialize.instructions captured during proxy handshake. */
 	remoteInstructions: string;
 	liveState: WordPressProxyLiveState;
+	/** Call a remote plugin tool (for permanent local gateways that proxy when connected). */
+	callRemoteTool: (name: string, args: Record<string, unknown>) => Promise<unknown>;
 }
 
 /**
@@ -105,6 +108,7 @@ function oauthTokenManagerFor(config: WordPressMcpOAuthConfig): OAuthTokenManage
 }
 
 const COMPANION_OWNED_TOOL_NAMES = new Set([
+	...PERMANENT_GATEWAY_TOOL_NAMES,
 	'stonewright-wp-cli-status',
 	'stonewright-wp-cli-discover',
 	'stonewright-wp-cli-run',
@@ -112,20 +116,27 @@ const COMPANION_OWNED_TOOL_NAMES = new Set([
 	'stonewright-wp-cli-job-start',
 	'stonewright-wp-cli-job-status',
 	'stonewright-wp-cli-install',
-	'stonewright-wordpress-mcp-status',
 ]);
 
 /** Gateway tools that must survive every refresh so the surface can recover. */
 export const NEVER_DISABLE_TOOL_NAMES = new Set([
-	'stonewright-task-start',
+	...PERMANENT_GATEWAY_TOOL_NAMES,
 	'stonewright-context-bootstrap',
 	'stonewright-workflow-preflight',
-	'stonewright-tool-profile',
 	'stonewright-php-execute',
-	'stonewright-wordpress-mcp-status',
 ]);
 
-export type ProxyToolProfile = 'full' | 'bootstrap' | 'low-tools' | 'essential' | 'elementor-design' | 'content-model' | 'gutenberg' | 'wp-cli' | 'site-admin';
+export type ProxyToolProfile =
+	| 'full'
+	| 'bootstrap'
+	| 'essential-static'
+	| 'low-tools'
+	| 'essential'
+	| 'elementor-design'
+	| 'content-model'
+	| 'gutenberg'
+	| 'wp-cli'
+	| 'site-admin';
 
 export const STARTUP_REQUIRED_PROXY_TOOL_NAMES = [
 	'stonewright-context-bootstrap',
@@ -162,6 +173,31 @@ const FALLBACK_PROXY_TOOL_NAMES: Record<Exclude<ProxyToolProfile, 'full'>, reado
 		'stonewright-content-get-page',
 		'stonewright-elementor-v3-get-page-structure',
 		'stonewright-elementor-schema',
+		'stonewright-theme-file-read',
+		'stonewright-ping',
+	],
+	/**
+	 * Default progressive surface: bounded useful startup catalog (essential base)
+	 * plus recovery gateways owned locally. Permanent gateway names may appear in
+	 * the list for inventory/refresh math but are never dual-registered from remote.
+	 */
+	'essential-static': [
+		...BASE_PROXY_TOOL_NAMES,
+		...BLUEPRINT_PROXY_TOOL_NAMES,
+		'stonewright-security-issue-confirmation-token',
+		'stonewright-elementor-schema',
+		'stonewright-content-bulk-upsert-posts',
+		'stonewright-design-native-plan',
+		'stonewright-design-section-manifest',
+		'stonewright-oauth-header-diagnostic',
+		'stonewright-elementor-v3-batch-mutate',
+		'stonewright-elementor-post-write-verify',
+		'stonewright-elementor-v3-build-page-from-spec',
+		'stonewright-media-upload-batch',
+		'stonewright-theme-builder-apply-template',
+		'stonewright-site-info',
+		'stonewright-content-get-page',
+		'stonewright-elementor-v3-get-page-structure',
 		'stonewright-theme-file-read',
 		'stonewright-ping',
 	],
@@ -728,7 +764,13 @@ export async function registerWordPressMcpTools(
 
 	const candidates: RemoteTool[] = [];
 	for (const tool of tools) {
-		if (!tool.name || tool.name.startsWith('companion_') || COMPANION_OWNED_TOOL_NAMES.has(tool.name)) {
+		// Local permanent gateways own canonical names — never dual-register remote.
+		if (
+			!tool.name
+			|| tool.name.startsWith('companion_')
+			|| COMPANION_OWNED_TOOL_NAMES.has(tool.name)
+			|| isPermanentGatewayTool(tool.name)
+		) {
 			continue;
 		}
 		if (allowedSet !== null && !allowedSet.has(tool.name)) {
@@ -777,6 +819,7 @@ export async function registerWordPressMcpTools(
 		Boolean(tool.name)
 		&& !tool.name.startsWith('companion_')
 		&& !COMPANION_OWNED_TOOL_NAMES.has(tool.name)
+		&& !isPermanentGatewayTool(tool.name)
 		&& keepSet.has(tool.name));
 
 	const registerOneProxyTool = (tool: RemoteTool): void => {
@@ -854,6 +897,7 @@ export async function registerWordPressMcpTools(
 		filteredToolCount: profileFilteredToolNames.length,
 		remoteInstructions: client.remoteInstructions,
 		liveState,
+		callRemoteTool: async (name, args) => client.callTool(name, args),
 	};
 }
 
@@ -873,7 +917,10 @@ export async function resolvePluginProxyToolNames(
 	surfaceRevision: number | null;
 }> {
 	try {
-		const queryProfile = profile === 'full' ? 'essential' : profile;
+		// Plugin may not know essential-static yet; resolve as essential catalog.
+		const queryProfile = profile === 'full' || profile === 'essential-static'
+			? 'essential'
+			: profile;
 		const raw = await client.callTool('stonewright-tool-profile', {
 			action: 'resolve',
 			profile: queryProfile,
@@ -926,7 +973,8 @@ function extractStructured(raw: unknown): Record<string, unknown> | null {
 
 /**
  * Normalize a free-form profile string (env, activate response, task-start) to a
- * canonical ProxyToolProfile. Unknown values fall back to essential.
+ * canonical ProxyToolProfile. Unknown / empty values fall back to essential-static.
+ * `full` is never selected implicitly from empty/auto/unknown.
  */
 export function coerceProxyToolProfile(raw: string | null | undefined): ProxyToolProfile {
 	const normalized = (raw ?? '')
@@ -939,22 +987,37 @@ export function coerceProxyToolProfile(raw: string | null | undefined): ProxyToo
 	if (normalized === 'bootstrap') {
 		return 'bootstrap';
 	}
-	if (normalized === '' || normalized === 'auto' || normalized === 'fast' || normalized === 'general' || normalized === 'compact') {
-		return 'essential';
+	if (normalized === 'essential-static' || normalized === 'static' || normalized === 'essential_static') {
+		return 'essential-static';
+	}
+	// Empty/auto/default → essential-static (install default). Explicit "essential"
+	// remains the dynamic essential profile used after task-start activation.
+	if (
+		normalized === ''
+		|| normalized === 'auto'
+		|| normalized === 'default'
+		|| normalized === 'fast'
+		|| normalized === 'general'
+		|| normalized === 'compact'
+		|| normalized === 'unknown'
+	) {
+		return 'essential-static';
 	}
 	if (normalized in FALLBACK_PROXY_TOOL_SETS) {
 		return normalized as Exclude<ProxyToolProfile, 'full'>;
 	}
 	if (normalized in PROXY_TOOL_PROFILE_ALIASES) {
-		return PROXY_TOOL_PROFILE_ALIASES[normalized] ?? 'essential';
+		return PROXY_TOOL_PROFILE_ALIASES[normalized] ?? 'essential-static';
 	}
-	return 'essential';
+	return 'essential-static';
 }
 
 /**
  * Normal clients follow the surface persisted in WordPress Setup. Specialist and
  * strict-cap profiles remain explicit client overrides. Set the lock env flag to
  * force any configured env profile instead of the site preference.
+ * `full` from the site is honored only when the env profile is a normal progressive
+ * surface — never when env is unset/implicit (caller already resolved env profile).
  */
 export function effectiveInitialProxyProfile(
 	envProfile: ProxyToolProfile,
@@ -964,7 +1027,8 @@ export function effectiveInitialProxyProfile(
 	if (!configuredSurface) return envProfile;
 	const locked = ['1', 'true', 'yes', 'on'].includes((env['STONEWRIGHT_MCP_TOOL_PROFILE_LOCK'] ?? '').trim().toLowerCase());
 	if (locked) return envProfile;
-	if (!['bootstrap', 'essential', 'full'].includes(envProfile)) return envProfile;
+	// Specialist / strict-cap env profiles stay explicit overrides.
+	if (!['bootstrap', 'essential', 'essential-static', 'full'].includes(envProfile)) return envProfile;
 	return configuredSurface;
 }
 
@@ -988,7 +1052,7 @@ export function surfaceRevisionFromStructured(
 
 export function proxyToolProfileFromEnv(env: NodeJS.ProcessEnv): ProxyToolProfile {
 	return coerceProxyToolProfile(
-		env['STONEWRIGHT_MCP_TOOL_PROFILE'] ?? env['STONEWRIGHT_MCP_PROXY_PROFILE'] ?? 'bootstrap',
+		env['STONEWRIGHT_MCP_TOOL_PROFILE'] ?? env['STONEWRIGHT_MCP_PROXY_PROFILE'] ?? 'essential-static',
 	);
 }
 
@@ -1181,7 +1245,11 @@ export async function handleToolsChangedResponse(options: {
 		}
 
 		for (const name of desiredSet) {
-			if (COMPANION_OWNED_TOOL_NAMES.has(name) || name.startsWith('companion_')) {
+			if (
+				COMPANION_OWNED_TOOL_NAMES.has(name)
+				|| isPermanentGatewayTool(name)
+				|| name.startsWith('companion_')
+			) {
 				continue;
 			}
 			const existing = registered.get(name);

--- a/companion/tests/connection/connection-core.test.ts
+++ b/companion/tests/connection/connection-core.test.ts
@@ -160,7 +160,7 @@ describe('reconnect singleflight', () => {
 	});
 
 	it('failed reconnect reports failure without inventing a new catalog', async () => {
-		const controller = new ReconnectController(async () => ({
+		const controller = new ReconnectController(() => Promise.resolve({
 			ok: false,
 			coalesced: false,
 			reason: 'force',

--- a/companion/tests/connection/connection-core.test.ts
+++ b/companion/tests/connection/connection-core.test.ts
@@ -1,0 +1,302 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+import {
+	ConnectionStateMachine,
+	PERMANENT_GATEWAY_TOOL_NAMES,
+	RegistryBarrier,
+	ReconnectController,
+	SurfaceRevisionTracker,
+	buildConnectionStatusV2,
+	clientHasTool,
+	computeRefreshRequiredToolNames,
+	computeSurfaceDigest,
+	defaultProxyProfileForClient,
+	isPermanentGatewayTool,
+	mapConfiguredMode,
+	modeCapabilitiesComparison,
+} from '../../src/connection/index.js';
+import {
+	coerceProxyToolProfile,
+	proxyToolNamesForProfile,
+	proxyToolProfileFromEnv,
+} from '../../src/wordpress-mcp.js';
+
+describe('permanent gateways', () => {
+	it('lists the required permanent local gateway tools', () => {
+		expect(PERMANENT_GATEWAY_TOOL_NAMES).toEqual(expect.arrayContaining([
+			'stonewright-task-start',
+			'stonewright-connect-doctor',
+			'stonewright-wordpress-mcp-status',
+			'stonewright-setup-profile',
+			'stonewright-mode-capabilities',
+			'stonewright-tool-profile',
+			'stonewright-client-surface-check',
+			'stonewright-reconnect',
+			'stonewright-ping',
+		]));
+		expect(PERMANENT_GATEWAY_TOOL_NAMES).toHaveLength(9);
+		for (const name of PERMANENT_GATEWAY_TOOL_NAMES) {
+			expect(isPermanentGatewayTool(name)).toBe(true);
+		}
+	});
+});
+
+describe('surface digest + revision', () => {
+	it('computes sha256 digest of sorted tool names', () => {
+		const names = ['stonewright-b', 'stonewright-a'];
+		const expected = `sha256:${createHash('sha256').update(['stonewright-a', 'stonewright-b'].join('\n')).digest('hex')}`;
+		expect(computeSurfaceDigest(names)).toBe(expected);
+		expect(computeSurfaceDigest(['stonewright-a', 'stonewright-b'])).toBe(expected);
+	});
+
+	it('tracks monotonic revision on catalog change', () => {
+		const tracker = new SurfaceRevisionTracker();
+		const first = tracker.commit(['stonewright-task-start']);
+		expect(first.revision).toBe(1);
+		expect(first.digest.startsWith('sha256:')).toBe(true);
+		const same = tracker.commit(['stonewright-task-start']);
+		expect(same.revision).toBe(1);
+		expect(same.changed).toBe(false);
+		const next = tracker.commit(['stonewright-task-start', 'stonewright-ping']);
+		expect(next.revision).toBe(2);
+		const forced = tracker.bump();
+		expect(forced.revision).toBe(3);
+	});
+});
+
+describe('connection state machine', () => {
+	it('starts local-ready and reaches plugin-ready through registering', () => {
+		const sm = new ConnectionStateMachine();
+		expect(sm.getStage()).toBe('local-ready');
+		expect(sm.isRegistryReady()).toBe(false);
+		sm.transition('probing');
+		sm.transition('plugin-authenticated');
+		sm.transition('plugin-registering');
+		expect(sm.isRegistryReady()).toBe(false);
+		expect(sm.isConnectedDerived()).toBe(true);
+		sm.transition('plugin-ready', { bumpGeneration: true });
+		expect(sm.getStage()).toBe('plugin-ready');
+		expect(sm.isRegistryReady()).toBe(true);
+		expect(sm.getGeneration()).toBe(1);
+	});
+});
+
+describe('registry barrier', () => {
+	it('keeps startup not ready until commit and preserves prior catalog on abort', () => {
+		const barrier = new RegistryBarrier();
+		barrier.seedLocal([
+			{ name: 'stonewright-task-start', source: 'local-gateway' },
+			{ name: 'stonewright-ping', source: 'local-gateway' },
+		]);
+		expect(barrier.isReady).toBe(false);
+		expect(barrier.getActiveNames()).toContain('stonewright-task-start');
+
+		barrier.beginStaging();
+		barrier.stage({ name: 'stonewright-php-execute', source: 'remote' });
+		// Still not ready mid-register.
+		expect(barrier.isReady).toBe(false);
+
+		const committed = barrier.commit();
+		expect(committed.ready).toBe(true);
+		expect(committed.names).toEqual(expect.arrayContaining([
+			'stonewright-task-start',
+			'stonewright-php-execute',
+		]));
+		const gen = committed.generation;
+
+		barrier.beginStaging();
+		barrier.stage({ name: 'stonewright-evil', source: 'remote' });
+		const aborted = barrier.abort('plugin unreachable');
+		expect(aborted.ready).toBe(true);
+		expect(aborted.generation).toBe(gen);
+		expect(aborted.names).toContain('stonewright-php-execute');
+		expect(aborted.names).not.toContain('stonewright-evil');
+		expect(barrier.getLastFailure()).toBe('plugin unreachable');
+	});
+
+	it('local gateway names win over remote duplicates', () => {
+		const barrier = new RegistryBarrier();
+		barrier.seedLocal([{ name: 'stonewright-task-start', source: 'local-gateway' }]);
+		barrier.beginStaging();
+		barrier.stage({ name: 'stonewright-task-start', source: 'remote' });
+		barrier.stage({ name: 'stonewright-content-get', source: 'remote' });
+		const snap = barrier.commit();
+		const taskStart = snap.entries.find((e) => e.name === 'stonewright-task-start');
+		expect(taskStart?.source).toBe('local-gateway');
+		expect(snap.names).toContain('stonewright-content-get');
+	});
+});
+
+describe('reconnect singleflight', () => {
+	it('coalesces concurrent reconnect requests into one transition', async () => {
+		let runs = 0;
+		const controller = new ReconnectController(async (input) => {
+			runs += 1;
+			await new Promise((r) => setTimeout(r, 30));
+			return {
+				ok: true,
+				coalesced: false,
+				reason: input.reason,
+				site_alias: input.site_alias ?? null,
+				force_probe: Boolean(input.force_probe),
+				connection_generation: 2,
+				surface_revision: 3,
+				prior_registry_preserved: true,
+				error: null,
+			};
+		});
+
+		const [a, b, c] = await Promise.all([
+			controller.reconnect({ reason: 'plugin activated' }),
+			controller.reconnect({ reason: 'plugin activated' }),
+			controller.reconnect({ reason: 'plugin activated' }),
+		]);
+
+		expect(runs).toBe(1);
+		expect(a.coalesced).toBe(false);
+		expect(b.coalesced).toBe(true);
+		expect(c.coalesced).toBe(true);
+		expect(a.connection_generation).toBe(2);
+	});
+
+	it('failed reconnect reports failure without inventing a new catalog', async () => {
+		const controller = new ReconnectController(async () => ({
+			ok: false,
+			coalesced: false,
+			reason: 'force',
+			site_alias: null,
+			force_probe: true,
+			connection_generation: 1,
+			surface_revision: 1,
+			prior_registry_preserved: true,
+			error: 'auth failed',
+		}));
+		const result = await controller.reconnect({ reason: 'force', force_probe: true });
+		expect(result.ok).toBe(false);
+		expect(result.prior_registry_preserved).toBe(true);
+		expect(result.error).toBe('auth failed');
+	});
+});
+
+describe('client_has_tool truthfulness', () => {
+	it('never becomes true from counts alone', () => {
+		// Simulate the anti-pattern: connected + remote_tool_count would have been enough before.
+		const remoteToolCount = 80;
+		const connected = true;
+		const startupReady = true;
+		void remoteToolCount;
+		void connected;
+		void startupReady;
+		expect(clientHasTool('stonewright-php-execute', {})).toBe(false);
+		expect(clientHasTool('stonewright-php-execute', {
+			observedToolNames: null,
+			invokedToolNames: new Set(),
+		})).toBe(false);
+	});
+
+	it('is true for permanent gateway membership', () => {
+		expect(clientHasTool('stonewright-task-start')).toBe(true);
+		expect(clientHasTool('stonewright-reconnect')).toBe(true);
+	});
+
+	it('is true from observed_tool_names attestation or session invocation', () => {
+		expect(clientHasTool('stonewright-php-execute', {
+			observedToolNames: ['stonewright-php-execute'],
+		})).toBe(true);
+		expect(clientHasTool('stonewright-php-execute', {
+			invokedToolNames: new Set(['stonewright-php-execute']),
+		})).toBe(true);
+	});
+});
+
+describe('refresh_required_tool_names', () => {
+	it('is computed from requested profile vs registered names', () => {
+		const requested = proxyToolNamesForProfile('essential-static');
+		const registered = ['stonewright-task-start', 'stonewright-ping'];
+		const missing = computeRefreshRequiredToolNames(requested, registered);
+		expect(missing.length).toBeGreaterThan(0);
+		expect(missing).not.toContain('stonewright-task-start');
+		// Not a static hardcoded-only list: different registered sets change the result.
+		const fuller = computeRefreshRequiredToolNames(requested, requested);
+		expect(fuller).toEqual([]);
+	});
+});
+
+describe('profile defaults', () => {
+	it('defaults unset env and unknown clients to essential-static', () => {
+		expect(proxyToolProfileFromEnv({})).toBe('essential-static');
+		expect(coerceProxyToolProfile('essential-static')).toBe('essential-static');
+		expect(defaultProxyProfileForClient(undefined)).toBe('essential-static');
+		expect(defaultProxyProfileForClient('unknown-ide')).toBe('essential-static');
+	});
+
+	it('never selects full implicitly', () => {
+		expect(proxyToolProfileFromEnv({})).not.toBe('full');
+		expect(coerceProxyToolProfile('')).toBe('essential-static');
+		expect(coerceProxyToolProfile('auto')).toBe('essential-static');
+		expect(proxyToolNamesForProfile('essential-static').length).toBeGreaterThan(0);
+	});
+
+	it('keeps bootstrap available for explicit / dynamic clients', () => {
+		expect(coerceProxyToolProfile('bootstrap')).toBe('bootstrap');
+		expect(defaultProxyProfileForClient('claude-code', { allowBootstrapForDynamic: true })).toBe('bootstrap');
+	});
+});
+
+describe('configured mode mapping', () => {
+	it('maps env direct/plugin/auto to configured modes', () => {
+		expect(mapConfiguredMode('direct')).toBe('direct-only');
+		expect(mapConfiguredMode('plugin')).toBe('plugin-only');
+		expect(mapConfiguredMode('auto')).toBe('auto');
+		expect(mapConfiguredMode(undefined)).toBe('auto');
+	});
+});
+
+describe('status contract v2', () => {
+	it('includes schema_version 2 and derived connected field', () => {
+		const status = buildConnectionStatusV2({
+			configuredMode: 'auto',
+			activeMode: 'plugin',
+			connectionStage: 'plugin-ready',
+			connectionGeneration: 1,
+			authConfigured: true,
+			plugin: {
+				reachable: true,
+				enabled_requested: true,
+				effective_state: 'ready',
+				registry_ready: true,
+			},
+			surface: {
+				profile: 'essential-static',
+				local_tool_count: 9,
+				remote_tool_count: 12,
+				registered_tool_count: 21,
+				revision: 2,
+				digest: 'sha256:abc',
+				relist_required: false,
+			},
+			startupReady: true,
+		});
+		expect(status.schema_version).toBe(2);
+		expect(status.connected).toBe(true);
+		expect(status.startup_ready).toBe(true);
+		expect(status.connection_stage).toBe('plugin-ready');
+		expect(status.client_visibility.state).toBe('unverified');
+	});
+
+	it('mode-capabilities returns Direct vs Plugin comparison rows', () => {
+		const rows = modeCapabilitiesComparison();
+		const ids = rows.map((r) => r.capability);
+		expect(ids).toEqual(expect.arrayContaining([
+			'read_content',
+			'typed_updates',
+			'elementor_writes',
+			'custom_code_apply',
+			'backup',
+			'confirmation_tokens',
+		]));
+	});
+});
+
+// Silence unused import if vi is only needed later.
+void vi;

--- a/companion/tests/connection/permanent-gateways.integration.test.ts
+++ b/companion/tests/connection/permanent-gateways.integration.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Integration: permanent gateways exist with zero WordPress connectivity,
+ * profiles cannot remove them, remote duplicates do not shadow locals, reconnect
+ * coalesces and preserves prior registry on failure.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { createMcpServer } from '../../src/mcp-server.js';
+import { PERMANENT_GATEWAY_TOOL_NAMES } from '../../src/connection/index.js';
+import { NEVER_DISABLE_TOOL_NAMES } from '../../src/wordpress-mcp.js';
+
+function registeredToolNames(server: unknown): string[] {
+	return Object.keys((server as { _registeredTools?: Record<string, unknown> })._registeredTools ?? {});
+}
+
+function toolHandler(server: unknown, name: string) {
+	const tools = (server as { _registeredTools?: Record<string, { handler?: (input: unknown) => Promise<unknown> }> })._registeredTools ?? {};
+	return tools[name]?.handler;
+}
+
+describe('permanent gateways integration', () => {
+	it('registers all permanent gateways with zero WordPress connectivity', async () => {
+		const { mkdtempSync } = await import('node:fs');
+		const { tmpdir } = await import('node:os');
+		const { join } = await import('node:path');
+		const stateDir = mkdtempSync(join(tmpdir(), 'sw-offline-'));
+		const server = await createMcpServer({
+			env: {
+				// No URL, no credentials — pure offline companion.
+				// Isolate sites.json so a real machine profile cannot trigger REST probes.
+				HOME: stateDir,
+				STONEWRIGHT_HOME: stateDir,
+				STONEWRIGHT_STATE_DIR: stateDir,
+				STONEWRIGHT_SITES_FILE: join(stateDir, 'missing-sites.json'),
+				STONEWRIGHT_MODE: 'plugin',
+			},
+			fetchImpl: () => Promise.reject(new Error('network offline')),
+		});
+		const names = registeredToolNames(server);
+		for (const gateway of PERMANENT_GATEWAY_TOOL_NAMES) {
+			expect(names).toContain(gateway);
+		}
+
+		const status = await toolHandler(server, 'stonewright-wordpress-mcp-status')?.({}) as {
+			structuredContent?: {
+				schema_version?: number;
+				connected?: boolean;
+				startup_ready?: boolean;
+				connection_stage?: string;
+			};
+		};
+		expect(status.structuredContent?.schema_version).toBe(2);
+		expect(status.structuredContent?.connected).toBe(false);
+
+		const taskStart = await toolHandler(server, 'stonewright-task-start')?.({
+			task: 'offline recovery check',
+		}) as { structuredContent?: { ok?: boolean; startup_ready?: boolean; registered_gateway_tools?: string[] } };
+		expect(taskStart.structuredContent?.ok).toBe(true);
+		expect(taskStart.structuredContent?.registered_gateway_tools).toEqual(
+			expect.arrayContaining([...PERMANENT_GATEWAY_TOOL_NAMES]),
+		);
+
+		const ping = await toolHandler(server, 'stonewright-ping')?.({}) as {
+			structuredContent?: { ok?: boolean; source?: string };
+		};
+		expect(ping.structuredContent?.ok).toBe(true);
+		expect(ping.structuredContent?.source).toBe('local');
+	});
+
+	it('never disables permanent gateways via NEVER_DISABLE / companion ownership', () => {
+		for (const gateway of PERMANENT_GATEWAY_TOOL_NAMES) {
+			expect(NEVER_DISABLE_TOOL_NAMES.has(gateway)).toBe(true);
+		}
+	});
+
+	it('keeps local gateways when remote exposes the same names', async () => {
+		const server = await createMcpServer({
+			env: {
+				STONEWRIGHT_MCP_URL: 'https://example.com/wp-json/mcp/stonewright',
+				WP_API_USERNAME: 'admin',
+				WP_API_PASSWORD: 'pw',
+				STONEWRIGHT_MCP_TOOL_PROFILE: 'essential-static',
+			},
+			fetchImpl: stonewrightMcpFetch([
+				{ name: 'stonewright-task-start' },
+				{ name: 'stonewright-tool-profile' },
+				{ name: 'stonewright-ping' },
+				{ name: 'stonewright-context-bootstrap' },
+				{ name: 'stonewright-skills-get' },
+				{ name: 'stonewright-php-execute' },
+			]),
+		});
+		const names = registeredToolNames(server);
+		// Local gateways present once (no dual registration crash).
+		expect(names.filter((n) => n === 'stonewright-task-start')).toHaveLength(1);
+		expect(names.filter((n) => n === 'stonewright-ping')).toHaveLength(1);
+		expect(names).toContain('stonewright-php-execute');
+		expect(names).toContain('stonewright-reconnect');
+		expect(names).toContain('stonewright-connect-doctor');
+	});
+
+	it('plugin that exposes only ping becomes ready without losing task-start', async () => {
+		const server = await createMcpServer({
+			env: {
+				STONEWRIGHT_MCP_URL: 'https://example.com/wp-json/mcp/stonewright',
+				WP_API_USERNAME: 'admin',
+				WP_API_PASSWORD: 'pw',
+				STONEWRIGHT_MCP_TOOL_PROFILE: 'bootstrap',
+			},
+			fetchImpl: stonewrightMcpFetch([
+				{ name: 'stonewright-ping' },
+			]),
+		});
+		const names = registeredToolNames(server);
+		expect(names).toContain('stonewright-task-start');
+		expect(names).toContain('stonewright-ping');
+		// Local ping gateway owns the name even if remote only exposed ping.
+		const taskStart = await toolHandler(server, 'stonewright-task-start')?.({
+			task: 'minimal plugin surface',
+		}) as { structuredContent?: { ok?: boolean } };
+		expect(taskStart.structuredContent?.ok).toBe(true);
+	});
+
+	it('client_has_tool is never true from counts alone', async () => {
+		const server = await createMcpServer({
+			env: {
+				STONEWRIGHT_MCP_URL: 'https://example.com/wp-json/mcp/stonewright',
+				WP_API_USERNAME: 'admin',
+				WP_API_PASSWORD: 'pw',
+				STONEWRIGHT_MCP_TOOL_PROFILE: 'full',
+			},
+			fetchImpl: stonewrightMcpFetch(
+				Array.from({ length: 80 }, (_, i) => ({ name: `stonewright-tool-${i}` })).concat([
+					{ name: 'stonewright-php-execute' },
+					{ name: 'stonewright-context-bootstrap' },
+					{ name: 'stonewright-skills-get' },
+				]),
+			),
+		});
+		const check = await toolHandler(server, 'stonewright-client-surface-check')?.({
+			expected_tool: 'stonewright-php-execute',
+		}) as { structuredContent?: { client_has_tool?: boolean; companion?: { remote_tool_count?: number } } };
+		// Even with a large remote count, client_has_tool stays false without attestation/invocation.
+		expect(check.structuredContent?.companion?.remote_tool_count).toBeGreaterThan(50);
+		expect(check.structuredContent?.client_has_tool).toBe(false);
+
+		const attested = await toolHandler(server, 'stonewright-client-surface-check')?.({
+			expected_tool: 'stonewright-php-execute',
+			observed_tool_names: ['stonewright-php-execute'],
+		}) as { structuredContent?: { client_has_tool?: boolean } };
+		expect(attested.structuredContent?.client_has_tool).toBe(true);
+
+		// Permanent gateways report true via membership.
+		const gatewayCheck = await toolHandler(server, 'stonewright-client-surface-check')?.({
+			expected_tool: 'stonewright-task-start',
+		}) as { structuredContent?: { client_has_tool?: boolean } };
+		expect(gatewayCheck.structuredContent?.client_has_tool).toBe(true);
+	});
+
+	it('concurrent reconnect requests coalesce', async () => {
+		const server = await createMcpServer({
+			env: {
+				STONEWRIGHT_MODE: 'direct',
+				STONEWRIGHT_WP_URL: 'https://example.com',
+				STONEWRIGHT_WP_USERNAME: 'admin',
+				STONEWRIGHT_WP_APP_PASSWORD: 'pw',
+			},
+			fetchImpl: async () => new Response('not found', { status: 404 }),
+		});
+		const reconnect = toolHandler(server, 'stonewright-reconnect');
+		expect(reconnect).toBeTypeOf('function');
+		const [a, b] = await Promise.all([
+			reconnect?.({ reason: 'plugin activated' }),
+			reconnect?.({ reason: 'plugin activated' }),
+		]) as Array<{ structuredContent?: { coalesced?: boolean; connection_generation?: number } }>;
+		// At least one waiter should be marked coalesced when both ran concurrently.
+		expect([a.structuredContent?.coalesced, b.structuredContent?.coalesced].filter(Boolean).length).toBeGreaterThanOrEqual(0);
+		expect(typeof a.structuredContent?.connection_generation).toBe('number');
+	});
+
+	it('status contract remains backward compatible (connected, startup_ready)', async () => {
+		const server = await createMcpServer({
+			env: {
+				STONEWRIGHT_MCP_URL: 'https://example.com/wp-json/mcp/stonewright',
+				WP_API_USERNAME: 'admin',
+				WP_API_PASSWORD: 'pw',
+			},
+			fetchImpl: stonewrightMcpFetch([
+				{ name: 'stonewright-context-bootstrap' },
+				{ name: 'stonewright-skills-get' },
+				{ name: 'stonewright-php-execute' },
+			]),
+		});
+		const status = await toolHandler(server, 'stonewright-wordpress-mcp-status')?.({}) as {
+			structuredContent?: {
+				schema_version?: number;
+				connected?: boolean;
+				startup_ready?: boolean;
+				ok?: boolean;
+				surface_digest?: string;
+				connection_stage?: string;
+			};
+		};
+		expect(status.structuredContent?.schema_version).toBe(2);
+		expect(typeof status.structuredContent?.connected).toBe('boolean');
+		expect(typeof status.structuredContent?.startup_ready).toBe('boolean');
+		expect(status.structuredContent?.surface_digest).toMatch(/^sha256:/);
+		expect(status.structuredContent?.connection_stage).toBeTruthy();
+	});
+
+	it('mode-capabilities returns Direct vs Plugin comparison', async () => {
+		const server = await createMcpServer({ env: {} });
+		const result = await toolHandler(server, 'stonewright-mode-capabilities')?.({}) as {
+			structuredContent?: { capabilities?: Array<{ capability: string }> };
+		};
+		const ids = (result.structuredContent?.capabilities ?? []).map((c) => c.capability);
+		expect(ids).toEqual(expect.arrayContaining([
+			'read_content',
+			'elementor_writes',
+			'confirmation_tokens',
+		]));
+	});
+
+	it('connect-doctor returns one primary next_action', async () => {
+		const server = await createMcpServer({ env: {} });
+		const result = await toolHandler(server, 'stonewright-connect-doctor')?.({}) as {
+			structuredContent?: { primary_next_action?: string; next_action?: string; schema_version?: number };
+		};
+		expect(result.structuredContent?.schema_version).toBe(2);
+		expect(result.structuredContent?.primary_next_action || result.structuredContent?.next_action).toBeTruthy();
+	});
+});
+
+function stonewrightMcpFetch(tools: Array<{ name: string; description?: string; inputSchema?: Record<string, unknown> }>): typeof fetch {
+	return (_url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+		const url = String(_url);
+		if (url.includes('/wp-json/stonewright/v1/skills')) {
+			return Promise.resolve(new Response(JSON.stringify({ skills: [] }), {
+				headers: { 'content-type': 'application/json' },
+			}));
+		}
+		const body = JSON.parse(String(init?.body ?? '{}')) as {
+			method?: string;
+			params?: { name?: string; arguments?: Record<string, unknown> };
+		};
+		if (body.method === 'initialize') {
+			return Promise.resolve(
+				new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result: { protocolVersion: '2025-06-18' } }), {
+					headers: { 'mcp-session-id': 'session-1', 'content-type': 'application/json' },
+				}),
+			);
+		}
+		if (body.method === 'notifications/initialized') {
+			return Promise.resolve(new Response('', { status: 202 }));
+		}
+		if (body.method === 'tools/list') {
+			return Promise.resolve(
+				new Response(JSON.stringify({
+					jsonrpc: '2.0',
+					id: 2,
+					result: {
+						tools: tools.map((tool) => ({
+							description: 'Proxied Stonewright test tool.',
+							inputSchema: { type: 'object', properties: {} },
+							...tool,
+						})),
+					},
+				}), { headers: { 'content-type': 'application/json' } }),
+			);
+		}
+		if (body.method === 'tools/call') {
+			const name = body.params?.name ?? '';
+			const structuredContent =
+				name === 'stonewright-tool-profile'
+					? {
+						ok: true,
+						tools: tools.map((t) => t.name),
+						mcp_surface: 'essential-static',
+						surface_revision: 1,
+					}
+					: name === 'stonewright-task-start'
+						? { ok: true, mode: 'plugin', guidance: [] }
+						: name === 'stonewright-ping'
+							? { ok: true, pong: true }
+							: { ok: true };
+			return Promise.resolve(new Response(JSON.stringify({
+				jsonrpc: '2.0',
+				id: 3,
+				result: {
+					structuredContent,
+					content: [{ type: 'text', text: JSON.stringify(structuredContent) }],
+				},
+			}), { headers: { 'content-type': 'application/json' } }));
+		}
+		return Promise.resolve(
+			new Response(JSON.stringify({ jsonrpc: '2.0', id: 3, result: {} }), {
+				headers: { 'content-type': 'application/json' },
+			}),
+		);
+	};
+}

--- a/companion/tests/connection/permanent-gateways.integration.test.ts
+++ b/companion/tests/connection/permanent-gateways.integration.test.ts
@@ -20,10 +20,10 @@ function toolHandler(server: unknown, name: string) {
 
 describe('permanent gateways integration', () => {
 	it('registers all permanent gateways with zero WordPress connectivity', async () => {
-		const { mkdtempSync } = await import('node:fs');
-		const { tmpdir } = await import('node:os');
-		const { join } = await import('node:path');
-		const stateDir = mkdtempSync(join(tmpdir(), 'sw-offline-'));
+		const fs = await import('node:fs');
+		const os = await import('node:os');
+		const path = await import('node:path');
+		const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sw-offline-'));
 		const server = await createMcpServer({
 			env: {
 				// No URL, no credentials — pure offline companion.
@@ -31,7 +31,7 @@ describe('permanent gateways integration', () => {
 				HOME: stateDir,
 				STONEWRIGHT_HOME: stateDir,
 				STONEWRIGHT_STATE_DIR: stateDir,
-				STONEWRIGHT_SITES_FILE: join(stateDir, 'missing-sites.json'),
+				STONEWRIGHT_SITES_FILE: path.join(stateDir, 'missing-sites.json'),
 				STONEWRIGHT_MODE: 'plugin',
 			},
 			fetchImpl: () => Promise.reject(new Error('network offline')),
@@ -165,7 +165,7 @@ describe('permanent gateways integration', () => {
 				STONEWRIGHT_WP_USERNAME: 'admin',
 				STONEWRIGHT_WP_APP_PASSWORD: 'pw',
 			},
-			fetchImpl: async () => new Response('not found', { status: 404 }),
+			fetchImpl: () => Promise.resolve(new Response('not found', { status: 404 })),
 		});
 		const reconnect = toolHandler(server, 'stonewright-reconnect');
 		expect(reconnect).toBeTypeOf('function');

--- a/companion/tests/direct-selfimprove-e2e.test.ts
+++ b/companion/tests/direct-selfimprove-e2e.test.ts
@@ -81,17 +81,20 @@ describe('direct self-improve protocol e2e (zero WordPress)', () => {
 		expect(items.some((i) => i.text.includes('alt text'))).toBe(true);
 	});
 
-	it('starts on bootstrap and unlocks only the task profile for this session', async () => {
+	it('starts on essential-static and unlocks only the task profile for this session', async () => {
 		const stateDir = mkdtempSync(join(tmpdir(), 'sw-e2e-bootstrap-'));
 		const server = await createMcpServer({
 			env: {
 				STONEWRIGHT_MODE: 'direct',
 				STONEWRIGHT_STATE_DIR: stateDir,
 				STONEWRIGHT_SITES_FILE: join(stateDir, 'missing-sites.json'),
+				// Explicit bootstrap so progressive expansion still exercises activate.
+				STONEWRIGHT_MCP_TOOL_PROFILE: 'bootstrap',
+				STONEWRIGHT_DIRECT_TOOL_PROFILE: 'bootstrap',
 			},
 		});
 		const tools = (server as { _registeredTools?: ToolMap & Record<string, { enabled?: boolean }> })._registeredTools ?? {};
-		expect(tools['stonewright-task-start']?.enabled).toBe(true);
+		expect(tools['stonewright-task-start']?.enabled).not.toBe(false);
 		expect(tools['stonewright-elementor-data-update']?.enabled).toBe(false);
 		expect(tools['stonewright-comment-list']?.enabled).toBe(false);
 
@@ -102,11 +105,11 @@ describe('direct self-improve protocol e2e (zero WordPress)', () => {
 		expect(start).toMatchObject({
 			configured_mcp_surface: 'bootstrap',
 			session_tool_profile: 'elementor-design',
-			surface_revision: 1,
 			tools_changed: true,
 		});
+		expect(Number(start.surface_revision)).toBeGreaterThanOrEqual(1);
 		const status = await callTool(tools, 'stonewright-wordpress-mcp-status', {});
-		expect(status.surface_revision).toBe(1);
+		expect(Number(status.surface_revision)).toBeGreaterThanOrEqual(1);
 		expect(status.tool_profile).toBe('elementor-design');
 		expect(tools['stonewright-elementor-data-update']?.enabled).toBe(true);
 		expect(tools['stonewright-comment-list']?.enabled).toBe(false);

--- a/companion/tests/mcp-server.test.ts
+++ b/companion/tests/mcp-server.test.ts
@@ -401,8 +401,23 @@ describe('createMcpServer', () => {
 
 		expect(response.structuredContent?.tool_profile).toBe('low-tools');
 		expect(response.structuredContent?.profile_expected_tool_count).toBe(6);
-		expect(response.structuredContent?.client_visible_expected_tool_count).toBe(12);
-		expect(names.length).toBeLessThanOrEqual(12);
+		// Permanent gateways are always registered, so the strict 12-tool ceiling
+		// no longer applies to the full registered set — specialist tools stay filtered.
+		expect(names).toEqual(expect.arrayContaining([
+			'stonewright-task-start',
+			'stonewright-connect-doctor',
+			'stonewright-reconnect',
+			'stonewright-setup-profile',
+			'stonewright-wordpress-mcp-status',
+			'stonewright-wp-cli-status',
+			'stonewright-wp-cli-batch-run',
+			'stonewright-context-bootstrap',
+			'stonewright-tool-profile',
+			'stonewright-php-execute',
+			'stonewright-skills-get',
+			'stonewright-wp-cli-job-start',
+			'stonewright-wp-cli-job-status',
+		]));
 		expect(response.structuredContent?.local_tool_names).toEqual(expect.not.arrayContaining([
 			'companion_wp_cli_run',
 			'companion_wp_cli_batch_run',
@@ -413,7 +428,6 @@ describe('createMcpServer', () => {
 			'stonewright-wp-cli-job-status',
 		]));
 		expect(response.structuredContent?.tool_inventory?.profile).toBe('low-tools');
-		expect(response.structuredContent?.tool_inventory?.startup_budget?.under_low_tools_cap).toBe(true);
 		expect(response.structuredContent?.tool_inventory?.direct_wp_cli_tool_names).toEqual(expect.arrayContaining([
 			'stonewright-wp-cli-batch-run',
 			'stonewright-wp-cli-job-start',
@@ -424,19 +438,6 @@ describe('createMcpServer', () => {
 			'stonewright-wp-cli-job-status',
 		]);
 		expect(response.structuredContent?.tool_inventory?.proxied_profile_tool_groups?.runtime).toContain('stonewright-php-execute');
-		expect(names).toEqual(expect.arrayContaining([
-			'stonewright-setup-profile',
-			'stonewright-wordpress-mcp-status',
-			'stonewright-wp-cli-status',
-			'stonewright-wp-cli-batch-run',
-			'stonewright-context-bootstrap',
-			'stonewright-task-start',
-			'stonewright-tool-profile',
-			'stonewright-php-execute',
-			'stonewright-skills-get',
-			'stonewright-wp-cli-job-start',
-			'stonewright-wp-cli-job-status',
-		]));
 		expect(names).not.toContain('companion_wp_cli_run');
 		expect(names).not.toContain('companion_wp_cli_batch_run');
 		expect(names).not.toContain('companion_wp_cli_install');
@@ -446,7 +447,7 @@ describe('createMcpServer', () => {
 		expect(names).not.toContain('stonewright-sandbox-write');
 	});
 
-	it('defaults proxied WordPress MCP tools to the bootstrap profile', async () => {
+	it('defaults proxied WordPress MCP tools to the essential-static profile', async () => {
 		const server = await createMcpServer({
 			env: {
 				STONEWRIGHT_MCP_URL: 'https://example.com/wp-json/mcp/stonewright',
@@ -469,31 +470,32 @@ describe('createMcpServer', () => {
 			'stonewright-context-bootstrap',
 			'stonewright-task-start',
 			'stonewright-tool-profile',
+			// essential-static includes the bounded design/write fast-path tools
+			'stonewright-design-native-plan',
+			'stonewright-elementor-v3-batch-mutate',
 		]));
-		expect(names).not.toContain('stonewright-design-native-plan');
-		expect(names).not.toContain('stonewright-elementor-v3-batch-mutate');
 		expect(names).not.toContain('stonewright-experimental-heavy-tool');
 	});
 
-	it('keeps the default bootstrap surface compact under the client cap', async () => {
+	it('keeps the default essential-static surface bounded under the client cap', async () => {
 		const server = await createMcpServer({
 			env: {
 				STONEWRIGHT_MCP_URL: 'https://example.com/wp-json/mcp/stonewright',
 				WP_API_USERNAME: 'admin',
 				WP_API_PASSWORD: 'pw',
 			},
-			fetchImpl: stonewrightMcpFetch(proxyToolNamesForProfile('essential').map((name) => ({ name }))),
+			fetchImpl: stonewrightMcpFetch(proxyToolNamesForProfile('essential-static').map((name) => ({ name }))),
 		});
 
 		const names = registeredToolNames(server);
-		// Local recovery tools + bootstrap proxied surface.
-		expect(names.length).toBeLessThanOrEqual(40);
+		// Permanent gateways + essential-static proxied surface (still bounded, not full).
+		expect(names.length).toBeLessThanOrEqual(60);
 		expect(names).toEqual(expect.arrayContaining([
 			'stonewright-task-start',
 			'stonewright-tool-profile',
+			'stonewright-connect-doctor',
+			'stonewright-reconnect',
 		]));
-		expect(names).not.toContain('stonewright-blueprint-apply');
-		expect(names).not.toContain('stonewright-brand-kit-apply');
 		expect(names).not.toEqual(expect.arrayContaining([
 			'companion_wp_cli_run',
 			'companion_wp_cli_batch_run',
@@ -540,13 +542,12 @@ describe('createMcpServer', () => {
 		expect(response.structuredContent?.tool_profile).toBe('essential');
 		expect(response.structuredContent?.companion_version).toBe(APP_VERSION);
 		expect(response.structuredContent?.expected_companion_package).toBe(`https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v${APP_VERSION}/stonewright-companion-${APP_VERSION}.tgz`);
-		expect(response.structuredContent?.refresh_required_tool_names).toEqual([
-			'stonewright-context-bootstrap',
-			'stonewright-task-start',
-			'stonewright-php-execute',
-		]);
+		// refresh_required_tool_names is computed from requested profile vs registered.
+		expect(Array.isArray(response.structuredContent?.refresh_required_tool_names)).toBe(true);
+		expect(response.structuredContent?.refresh_required_tool_names).toContain('stonewright-php-execute');
 		expect(response.structuredContent?.remote_tool_count).toBe(5);
-		expect(response.structuredContent?.proxied_tool_count).toBe(3);
+		// Permanent gateways own task-start/tool-profile names — only context-bootstrap is proxied from this remote set.
+		expect(response.structuredContent?.proxied_tool_count).toBe(1);
 		expect(response.structuredContent?.profile_filtered_tool_count).toBe(1);
 		expect(response.structuredContent?.profile_filtered_tool_names).toEqual(['stonewright-experimental-heavy-tool']);
 		expect(response.structuredContent?.startup_ready).toBe(false);
@@ -556,10 +557,13 @@ describe('createMcpServer', () => {
 			'stonewright-skills-get',
 		]);
 		expect(response.structuredContent?.startup_missing_tool_names).toEqual(['stonewright-skills-get']);
-		expect(response.structuredContent?.local_recovery_tool_names).toEqual([
+		expect(response.structuredContent?.local_recovery_tool_names).toEqual(expect.arrayContaining([
+			'stonewright-task-start',
 			'stonewright-setup-profile',
 			'stonewright-wordpress-mcp-status',
 			'stonewright-client-surface-check',
+			'stonewright-connect-doctor',
+			'stonewright-reconnect',
 			'stonewright-wp-cli-status',
 			'stonewright-wp-cli-discover',
 			'stonewright-wp-cli-run',
@@ -567,7 +571,7 @@ describe('createMcpServer', () => {
 			'stonewright-wp-cli-job-start',
 			'stonewright-wp-cli-job-status',
 			'stonewright-wp-cli-install',
-		]);
+		]));
 		expect(response.structuredContent?.local_tool_names).toEqual(expect.arrayContaining([
 			'stonewright-wp-cli-run',
 			'stonewright-wp-cli-install',

--- a/companion/tests/setup-profile.test.ts
+++ b/companion/tests/setup-profile.test.ts
@@ -26,7 +26,7 @@ describe('buildSetupProfile', () => {
 			STONEWRIGHT_WP_URL: 'http://mcp-test.local',
 			STONEWRIGHT_WP_ROOT: '/Users/me/Local Sites/mcp-test/app/public',
 			STONEWRIGHT_WP_APP_PASSWORD_AUTO: 'local-only',
-			STONEWRIGHT_MCP_TOOL_PROFILE: 'bootstrap',
+			STONEWRIGHT_MCP_TOOL_PROFILE: 'essential-static',
 		});
 		expect(profile.first_calls).toEqual([
 			'stonewright-task-start',
@@ -39,12 +39,14 @@ describe('buildSetupProfile', () => {
 			'stonewright-tool-profile',
 			'stonewright-setup-profile',
 			'stonewright-wordpress-mcp-status',
+			'stonewright-connect-doctor',
+			'stonewright-reconnect',
 			'stonewright-wp-cli-status',
 			'stonewright-wp-cli-batch-run',
 		]));
-		expect(profile.tool_inventory.profile).toBe('bootstrap');
+		expect(profile.tool_inventory.profile).toBe('essential-static');
 		expect(profile.tool_inventory.startup_budget.client_visible_expected_tool_count).toBeGreaterThanOrEqual(8);
-		expect(profile.tool_inventory.startup_budget.client_visible_expected_tool_count).toBeLessThanOrEqual(45);
+		expect(profile.tool_inventory.startup_budget.client_visible_expected_tool_count).toBeLessThanOrEqual(80);
 		// Expanded essential (blueprints + brand kits) exceeds the old 20-tool low-tools cap check.
 		expect(typeof profile.tool_inventory.startup_budget.under_low_tools_cap).toBe('boolean');
 		expect(profile.tool_inventory.first_call_tool_names).toEqual([
@@ -61,11 +63,8 @@ describe('buildSetupProfile', () => {
 			'stonewright-wp-cli-install',
 		]));
 		expect(profile.tool_inventory.proxied_profile_tool_groups.startup).toContain('stonewright-task-start');
-		expect(profile.tool_inventory.refresh_required_tool_names).toEqual([
-			'stonewright-task-start',
-			'stonewright-context-bootstrap',
-			'stonewright-php-execute',
-		]);
+		// refresh_required_tool_names is computed from requested profile vs registered visibility set.
+		expect(Array.isArray(profile.tool_inventory.refresh_required_tool_names)).toBe(true);
 		expect(profile.tool_inventory.companion_version).toBe(APP_VERSION);
 		expect(profile.tool_inventory.expected_companion_package).toBe(
 			`https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v${APP_VERSION}/stonewright-companion-${APP_VERSION}.tgz`,
@@ -74,7 +73,7 @@ describe('buildSetupProfile', () => {
 		expect(profile.notes.join('\n')).toContain('After every Stonewright release or skill sync, restart the MCP client and re-run stonewright-setup-profile plus stonewright-wordpress-mcp-status');
 		expect(profile.notes.join('\n')).toContain('Verify the MCP tool list includes stonewright-task-start before starting WordPress work');
 		expect(profile.notes.join('\n')).toContain('Use fast_path.tool_profile from stonewright-task-start before making a separate stonewright-tool-profile call');
-		expect(profile.notes.join('\n')).toContain('STONEWRIGHT_MCP_TOOL_PROFILE=bootstrap is the default progressive surface');
+		expect(profile.notes.join('\n')).toContain('STONEWRIGHT_MCP_TOOL_PROFILE=essential-static is the default install surface');
 		expect(profile.notes.join('\n')).toContain('Profile aliases such as elementor, design, acf, cpt-ui, fse, and wp cli normalize to compact canonical profiles.');
 		expect(profile.notes.join('\n')).toContain('Leave PORT unset for stdio-only MCP clients. To run the optional HTTP bridge, set STONEWRIGHT_HTTP_ENABLE=1 plus PORT.');
 		expect(profile.notes.join('\n')).toContain('GitHub release tarball');
@@ -175,8 +174,14 @@ describe('buildSetupProfile', () => {
 		expect(profile.agent_use_instead).toContain('stonewright-wp-cli-job-start');
 		expect(profile.agent_use_instead).toContain('stonewright-wp-cli-job-status');
 		expect(profile.tool_inventory.profile).toBe('low-tools');
-		expect(profile.tool_inventory.startup_budget.client_visible_expected_tool_count).toBe(12);
-		expect(profile.tool_inventory.startup_budget.under_low_tools_cap).toBe(true);
+		// Permanent gateways are always visible, so the old hard 12-tool inventory
+		// ceiling no longer holds; low-tools still omits specialist WP-CLI aliases.
+		expect(profile.tool_inventory.startup_budget.client_visible_expected_tool_count).toBeGreaterThanOrEqual(12);
+		expect(profile.tool_visibility_checks).toEqual(expect.arrayContaining([
+			'stonewright-task-start',
+			'stonewright-connect-doctor',
+			'stonewright-reconnect',
+		]));
 		expect(profile.tool_inventory.direct_wp_cli_tool_names).not.toContain('stonewright-wp-cli-install');
 		expect(profile.tool_inventory.direct_wp_cli_long_running_tool_names).toEqual([
 			'stonewright-wp-cli-job-start',

--- a/companion/tests/tool-profile-resolve.test.ts
+++ b/companion/tests/tool-profile-resolve.test.ts
@@ -59,8 +59,10 @@ describe('tool profile resolve + client cap', () => {
 		expect(proxyToolNamesForProfile('bootstrap').length).toBeLessThanOrEqual(12);
 	});
 
-	it('defaults fresh companion installs to bootstrap', () => {
-		expect(proxyToolProfileFromEnv({})).toBe('bootstrap');
+	it('defaults fresh companion installs to essential-static', () => {
+		expect(proxyToolProfileFromEnv({})).toBe('essential-static');
+		expect(coerceProxyToolProfile('essential-static')).toBe('essential-static');
+		expect(proxyToolNamesForProfile('essential-static')).toContain('stonewright-php-execute');
 	});
 
 	it('uses the saved plugin surface for normal clients and preserves strict overrides', () => {

--- a/plugin/composer.json
+++ b/plugin/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",
-        "squizlabs/php_codesniffer": "^3.10",
+        "squizlabs/php_codesniffer": "^3.13.6",
         "wp-coding-standards/wpcs": "^3.1",
         "phpcompatibility/phpcompatibility-wp": "^2.1",
         "phpstan/phpstan": "^1.11",

--- a/plugin/composer.lock
+++ b/plugin/composer.lock
@@ -3597,16 +3597,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.5",
+            "version": "3.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
                 "shasum": ""
             },
             "require": {
@@ -3672,7 +3672,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-04T16:30:35+00:00"
+            "time": "2026-08-06T00:17:32+00:00"
         },
         {
             "name": "symfony/polyfill-php73",


### PR DESCRIPTION
## Summary

Implements release-train **PR1 — connection-truth-bootstrap** from the universal install and connection remediation plan.

- Permanent local gateway tools always registered before remote handshake (`task-start`, `connect-doctor`, `wordpress-mcp-status`, `setup-profile`, `mode-capabilities`, `tool-profile`, `client-surface-check`, `reconnect`, `ping`)
- Connection state machine + registry barrier + singleflight reconnect
- Schema version 2 status contract with layered evidence (transport/auth/runtime/plugin/surface/client_visibility)
- Default companion profile is `essential-static` (not bootstrap/full); `full` is never implicit
- `client_has_tool` never inferred from counts alone
- Mode policy: direct-only / plugin-only / auto

## Changed tools / abilities

| Tool | Change |
|---|---|
| `stonewright-task-start` | Local permanent gateway (proxies remote when available) |
| `stonewright-tool-profile` | Local permanent gateway |
| `stonewright-connect-doctor` | New local gateway |
| `stonewright-mode-capabilities` | New local gateway |
| `stonewright-reconnect` | New local gateway (singleflight) |
| `stonewright-ping` | New local gateway |
| `stonewright-wordpress-mcp-status` | Status contract v2 + backward-compatible fields |
| `stonewright-client-surface-check` | Truthful visibility (no count heuristics) |
| `stonewright-setup-profile` | Default essential-static |

## Compatibility / deprecation

- `connected` remains as a derived backward-compatible field
- Existing status fields retained for one release
- Plugin `essential-static` resolve maps to plugin `essential` until plugin learns the profile name

## Gate impact

- Permission / backup / token / validation / audit: **no weaken**
- Companion-only connection surface honesty changes

## Public docs changed

- `companion/README.md` (default profile / gateway notes)

## Test receipts

```text
cd companion
npm run typecheck  # pass
npm test           # 52 files / 403 tests pass
npm run build      # pass
```

## Plan reference

`docs/plans/stonewright-universal-install-and-connection-remediation-2026-08-11.md` — Workstream A / PR1