### PR TITLE
chore: prepare Stonewright 1.0.0-beta.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ were never stable releases and are not part of the supported public history.
 
 ## [Unreleased]
 
+## [1.0.0-beta.5] - 2026-08-12
+
 ### Added
 
 - Add deterministic plugin/companion OAuth contract matrices, per-client

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Stonewright is a WordPress MCP stack for AI coding agents. **Elementor** is a fi
 
 Counts are derived from `docs/ability-truth-matrix.md` (plugin) and `DIRECT_TOOL_NAMES` (Direct). Do not hand-edit totals without regenerating the matrix.
 
-### Plugin mode — **359** abilities
+### Plugin mode — **360** abilities
 
 Counts below are grouped by the `includes/Abilities/` subdirectory each ability
 lives in, and sum to the total. Regenerate with `composer docs:matrix`.
@@ -57,20 +57,20 @@ lives in, and sum to the total. Regenerate with `composer docs:matrix`.
 |---|---:|---|
 | Elementor widgets (compat) | 94 | Generated per-widget builders |
 | Elementor widget builder | 4 | Custom widget project helpers |
-| Elementor V3 | 31 | Structure edit, batch-mutate, post-write verification, legacy-debt report, kit globals, build-from-spec, transactions |
+| Elementor V3 | 33 | Structure edit, batch-mutate, post-write verification, legacy-debt report, kit globals, build-from-spec, transactions |
 | Elementor V4 | 14 | Atomic nodes, variables, classes (experimental) |
 | Design | 28 | DesignSpec validate/render, native plan, intent, versioned Design Directions, manifests, comparison, guarded kit sync, rendered quality checks |
 | Site | 17 | Snapshot, inventory, health, pulse, plugins, theme, shortcodes |
 | Gutenberg + FSE + patterns | 24 | Blocks, theme.json, templates, global styles, transactional block batches |
-| Content + media | 20 | Pages/posts, bulk upsert, content model, upload, stock |
+| Content + media | 16 | Pages/posts, bulk upsert, upload, stock |
 | ACF + SEO | 8 | Field groups/values, multi-plugin SEO |
 | Comments / users / widgets / settings / themes / theme builder / plugins / revisions | 35 | REST-parity admin ops |
 | WP-CLI | 6 | Status, discover, run, batch, jobs |
 | Memory + skills + expertise + knowledge | 20 | Learning, memory generalization, skills, expertise packs |
-| Security + sandbox | 10 | Tokens, one-time links, sandbox lifecycle |
+| Security + sandbox | 12 | Tokens, one-time links, sandbox lifecycle |
 | Diagnostics | 3 | OAuth header, form delivery, and object capability diagnostics |
 | System | 11 | Task start, native rules, tool profiles, ability list |
-| Menus, blueprints, brand kits, runtime, search, WooCommerce | 30 | Native Woo catalog CRUD/audit; see full [matrix](docs/ability-truth-matrix.md) |
+| Menus, blueprints, brand kits, runtime, search, WooCommerce, content model, custom code | 35 | Native Woo catalog CRUD/audit and typed approval-gated code providers; see full [matrix](docs/ability-truth-matrix.md) |
 
 ### Direct mode — **100** tools (pluginless)
 
@@ -137,7 +137,7 @@ The companion authenticates with a WordPress Application Password and exposes **
 
 ## Quick Start
 
-**Plugin mode (about five steps):**
+**Plugin mode (six steps):**
 
 1. Download the latest `stonewright-*.zip` from the [current GitHub release](https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/latest).
 2. In WordPress: **Plugins → Add New → Upload Plugin** → activate **Stonewright**.
@@ -322,60 +322,81 @@ Two optional inputs cut payload without losing precision:
 ## Architecture
 
 ```mermaid
-flowchart LR
-  Client[AI / MCP client]
-  Browser[User-approved external browser provider]
-  Companion[Stonewright Companion]
-  Registry[Site registry + credential references]
-  Clients[Transactional client adapters]
-  CompFilter[Companion profile filter]
-  Plugin[Stonewright plugin]
-  Surface[Surface gate: bootstrap / essential / full]
-  Session[Per-session tool profile]
-  Rev[surface_revision -> tools/list_changed]
-  REST[WordPress REST API]
-  Rules[Native rules + digest cache]
-  WP[WordPress core]
-  Guten[Gutenberg / FSE]
-  Elem[Elementor]
-  Integrity[Elementor integrity gate: double-encode / size-collapse / widgetType-remap / delta-scoped validate]
-  Content[Content / media / menus]
-  Mem[Memory / skills]
-  Users[Users / comments / widgets]
-  WC[WooCommerce native catalog]
-  Gates[Backup / validation / readback / audit]
+flowchart TD
+  Client["AI / MCP client"]
+  Browser["Optional user-approved browser provider"]
 
-  Client --> Companion
-  Client --> Clients
-  Clients --> Companion
-  Companion --> Registry
-  Client --> Browser
+  subgraph Local["Local stdio and client configuration"]
+    Adapters["Transactional per-client adapters"]
+    Registry["Multi-site registry: alias, environment, mode, Step 1 expectations"]
+    Credentials["OS credential store or explicit env reference"]
+    Companion["Stonewright Companion"]
+    CompFilter["Companion profile: bootstrap, essential-static, essential, low-tools, full"]
+    Direct["Pluginless Direct adapters"]
+    DirectState["Private Direct skills, memory, and redacted audit"]
+  end
+
+  subgraph PluginMode["Plugin mode"]
+    Auth["OAuth grant or Application Password boundary"]
+    Step1["Step 1: enabled, mode, surface, Elementor V4"]
+    Surface["Plugin surface gate: bootstrap, essential, full"]
+    Session["Per-session task profile"]
+    Revision["surface_revision and tools/list_changed"]
+    Plugin["Stonewright plugin ability kernel"]
+    Code["Typed custom-code providers"]
+    Approval["Dry run, human grant, confirmation, snapshot, readback"]
+    Elementor["Elementor V3 / V4 / kit schema routing"]
+    Closure["Lease, snapshot, validate, write, readback, rollback, visual QA"]
+    Audit["Coalesced audit with actor attribution"]
+    Incidents["Incident lifecycle"]
+    Memory["Verified repair promotion to memory"]
+  end
+
+  WordPress["WordPress core, REST, Gutenberg/FSE, content, WooCommerce"]
+
+  Client -->|"local stdio"| Companion
+  Client -->|"remote Streamable HTTP"| Auth
+  Client --> Adapters
+  Adapters --> Registry
+  Registry --> Credentials
+  Registry --> Companion
   Companion --> CompFilter
-  Companion --> Rules
-  CompFilter -->|Plugin mode| Plugin
-  CompFilter -->|Direct mode| REST
-  Companion --> Skills[Local skills / memory]
-  Plugin --> Surface
-  Surface --> Session
-  Session --> Rev
-  Rev -. re-list .-> Client
-  Plugin --> Gates
-  Plugin --> Rules
-  Plugin --> Guten
-  Plugin --> Elem
-  Elem --> Integrity
-  Plugin --> Content
-  Plugin --> Mem
-  Plugin --> Users
-  Plugin --> WC
-  REST --> Users
-  REST --> WP
-  WP --> Content
-  Plugin --> WP
-  Browser -. verification or approved dashboard interaction .-> WP
+  CompFilter -->|"Plugin mode"| Auth
+  CompFilter -->|"Direct mode"| Direct
+  Direct --> WordPress
+  Direct --> DirectState
+  Auth --> Plugin
+  Step1 --> Surface --> Session --> Plugin
+  Step1 --> Revision -. "re-list / restart contract" .-> Client
+  Plugin --> WordPress
+  Plugin --> Code --> Approval --> WordPress
+  Plugin --> Elementor --> Closure --> WordPress
+  Plugin --> Audit --> Incidents --> Memory
+  Client -. "provider choice plus scan/install consent" .-> Browser
+  Browser -. "rendered verification or approved dashboard action" .-> WordPress
 ```
 
-Tool visibility is filtered twice before a client sees it: the plugin’s **surface gate** (`bootstrap` / `essential` / `full`) and optional **per-session tool profile** decide which abilities the MCP endpoint exposes, then the **companion profile filter** narrows that set again for the client. A monotonic `surface_revision` on every gateway response drives `tools/list_changed` so clients re-list when the surface changes.
+Tool visibility is filtered twice before a client sees it: the plugin’s
+**surface gate** (`bootstrap`, `essential`, or `full`) and optional per-session
+task profile decide which abilities the MCP endpoint exposes, then the
+**companion profile filter** (`bootstrap`, `essential-static`, `essential`,
+`low-tools`, or `full`) may narrow that set for the client. A monotonic
+`surface_revision` on every gateway response drives `tools/list_changed`;
+clients that cannot process it use the documented re-list/restart path.
+`bootstrap` is diagnostic, while `essential` is the normal bounded working
+profile for known clients.
+
+OAuth credentials remain inside the plugin grant/token boundary. Application
+Passwords stay in private client configuration or the OS-backed site registry;
+paste-to-agent prompts contain placeholders. Direct mode has no plugin approval
+boundary, so it cannot write arbitrary PHP, CSS, JavaScript, HTML, WPCode, Code
+Snippets, or theme files. Plugin-mode custom-code providers always stop after a
+typed dry run until the user issues the exact one-time grant.
+
+Audit success does not erase unrelated failures. Events coalesce noisy OAuth
+terminals, preserve the best available actor attribution, and feed an explicit
+incident lifecycle. Only a correlated verified repair or user correction may
+promote durable guidance into memory.
 
 Browser automation is external and consent-bound. The agent asks once per
 site/client whether to use Playwright (recommended), another connected browser,

--- a/companion/CHANGELOG.md
+++ b/companion/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.0.0-beta.5] - 2026-08-12
+
 ### Added
 
 - Add `stonewright connect add/list/use/verify/repair/remove/migrate` with a

--- a/companion/package-lock.json
+++ b/companion/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@stonewright/companion",
-	"version": "1.0.0-beta.4",
+	"version": "1.0.0-beta.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@stonewright/companion",
-			"version": "1.0.0-beta.4",
+			"version": "1.0.0-beta.5",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/companion/package.json
+++ b/companion/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@stonewright/companion",
-	"version": "1.0.0-beta.4",
+	"version": "1.0.0-beta.5",
 	"description": "Node companion for the Stonewright WordPress MCP plugin: WP-CLI, health checks, and optional MCP HTTP proxy.",
 	"type": "module",
 	"license": "MIT",

--- a/companion/src/version.ts
+++ b/companion/src/version.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = '1.0.0-beta.4';
+export const APP_VERSION = '1.0.0-beta.5';
 
 export function companionPackageSpec(version: string = APP_VERSION): string {
 	return `https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v${version}/stonewright-companion-${version}.tgz`;

--- a/docs/admin/configuration.md
+++ b/docs/admin/configuration.md
@@ -35,8 +35,11 @@ switch. When it is `false`, the MCP server rejects inbound tool calls except for
 the built-in `ping` ability, which always responds so clients can test
 connectivity.
 
-Flip the toggle, click **Save Settings**, and registered abilities become
-available on the next tool-call attempt.
+In the supported JavaScript flow, flipping the toggle saves immediately and
+updates the visible effective state without a page reload. **Apply now** retries
+and verifies the same Step 1 transaction. The no-JavaScript form still uses
+**Save Settings**. A connected client sees the new state through the surface
+revision/re-list contract described below.
 
 ### Mode selector
 

--- a/docs/admin/connect-clients.md
+++ b/docs/admin/connect-clients.md
@@ -191,7 +191,7 @@ args = ["-y", "--package", "https://github.com/cosmincraciun97/stonewright-wp-mc
 STONEWRIGHT_WP_URL = "https://your-site.com"
 STONEWRIGHT_WP_USERNAME = "your-wp-username"
 STONEWRIGHT_WP_APP_PASSWORD = "xxxx xxxx xxxx xxxx xxxx xxxx"
-        STONEWRIGHT_MCP_TOOL_PROFILE = "essential"
+STONEWRIGHT_MCP_TOOL_PROFILE = "essential"
 ```
 
 In the Codex IDE extension, open the gear menu, choose **Codex Settings >

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,33 +16,57 @@ and connects straight to the WordPress plugin over HTTPS.
 ```mermaid
 flowchart TD
     Client["MCP client"]
-    Companion["Local stdio companion"]
-    Http["Remote Streamable HTTP"]
-    Plugin["Stonewright WordPress plugin"]
-    Direct["Direct mode adapters"]
-    WordPress["WordPress runtime"]
-    PluginState["WordPress database<br/>memory, user skills, audit"]
-    DirectState["Private ~/.stonewright state<br/>sites, memory, user skills, redacted audit"]
-    Registry["Schema-v2 site registry<br/>aliases, environment, mode, Step 1 expectations"]
-    Credentials["OS credential store or explicit env reference"]
-    ClientConfig["Transactional per-client MCP adapters"]
-    Builtins["Packaged generic skills<br/>and native rules"]
+    Browser["Optional user-approved browser provider"]
 
-    Client --> Companion
+    subgraph Local["Local stdio and connection state"]
+        ClientConfig["Transactional per-client MCP adapters"]
+        Registry["Schema-v2 site registry<br/>alias, environment, mode, Step 1 expectations"]
+        Credentials["OS credential store or explicit env reference"]
+        Companion["Stonewright companion"]
+        CompanionProfile["Companion profile<br/>bootstrap, essential-static, essential, low-tools, full"]
+        Direct["Pluginless Direct adapters"]
+        DirectState["Private ~/.stonewright state<br/>sites, memory, user skills, redacted audit"]
+    end
+
+    subgraph PluginMode["Plugin mode"]
+        Auth["OAuth grant or Application Password"]
+        Step1["Step 1 controls<br/>enabled, mode, surface, Elementor V4"]
+        Surface["Plugin surface gate<br/>bootstrap, essential, full"]
+        Session["Per-session task profile"]
+        Revision["surface_revision<br/>tools/list_changed"]
+        Plugin["Ability kernel"]
+        Code["Typed custom-code providers"]
+        Approval["Dry run, human grant, confirmation, snapshot, readback"]
+        Elementor["Elementor V3, V4, and kit schema router"]
+        Closure["Lease, snapshot, validation, write, readback, rollback, visual QA"]
+        Audit["Coalesced audit and actor attribution"]
+        Incidents["Incident lifecycle"]
+        PluginState["WordPress database<br/>memory, user skills, audit"]
+    end
+
+    WordPress["WordPress runtime<br/>REST, Gutenberg/FSE, content, WooCommerce"]
+    Builtins["Packaged generic skills and native rules"]
+
+    Client -->|"local stdio"| Companion
+    Client -->|"remote Streamable HTTP"| Auth
     Client --> ClientConfig
-    ClientConfig --> Companion
-    Companion --> Registry
-    Registry --> Credentials
-    Client --> Http
-    Companion --> Plugin
-    Companion --> Direct
-    Http --> Plugin
-    Plugin --> WordPress
+    ClientConfig --> Registry --> Credentials
+    Registry --> Companion --> CompanionProfile
+    CompanionProfile -->|"Plugin mode"| Auth
+    CompanionProfile -->|"Direct mode"| Direct
     Direct --> WordPress
-    Plugin --> PluginState
     Direct --> DirectState
+    Auth --> Plugin
+    Step1 --> Surface --> Session --> Plugin
+    Step1 --> Revision -. "re-list or restart" .-> Client
+    Plugin --> WordPress
+    Plugin --> Code --> Approval --> WordPress
+    Plugin --> Elementor --> Closure --> WordPress
+    Plugin --> Audit --> Incidents --> PluginState
     Builtins --> Plugin
     Builtins --> Direct
+    Client -. "provider choice and separate scan/install consent" .-> Browser
+    Browser -. "rendered verification or approved dashboard action" .-> WordPress
 ```
 
 The registry enforces one alias per site and one `(canonical URL, environment)`
@@ -59,6 +83,39 @@ Plugin mode owns the broad guarded write surface. Direct mode is not a fallback:
 it owns a documented pluginless surface, local task-start profiles, persistent
 private state, and read-only WooCommerce access. Capability differences are
 explicit rather than silently emulated.
+
+### Tool surface and Step 1 propagation
+
+Setup Step 1 persists ability enablement, operating mode, MCP surface, and the
+Elementor V4 switch immediately. A real change increments one monotonic
+`surface_revision`. Remote HTTP clients see the new gate on their next
+`tools/list`; active companion sessions refresh their callable registry at
+task-start/profile activation and emit `tools/list_changed`. A client that does
+not honor live list changes must follow the explicit re-list/restart receipt.
+
+The plugin gate has three saved values: `bootstrap`, `essential`, and `full`.
+The companion additionally understands `essential-static` as the bounded
+fallback for an unknown or stale-list client and `low-tools` for a strict
+external cap. The normal known-client working profile is `essential`,
+`bootstrap` is only a startup diagnostic, and `full` is an explicit specialist
+choice. The operator's saved site surface remains the source of truth; a client
+profile may narrow it but never silently broaden it.
+
+### Authentication and custom-code boundaries
+
+Remote HTTP OAuth keeps grants, access tokens, refresh tokens, rotation, and
+revocation inside the plugin. Application Passwords are one-time WordPress
+credentials kept only in private client configuration or referenced from the
+OS-backed registry; public prompts never contain them. The in-admin generator
+holds a newly issued password only in current-tab memory, with a standalone
+no-store response as the no-JavaScript fallback.
+
+Plugin mode exposes typed providers for WPCode, Code Snippets, Customizer CSS,
+and allowlisted theme files. A provider first returns a dry-run receipt and the
+exact approval URL, then stops. Apply and rollback require the matching human
+grant plus their normal permission, concurrency, backup, readback, audit, and
+production confirmation gates. Direct mode cannot write arbitrary custom code:
+without the plugin there is no authenticated wp-admin one-time-grant boundary.
 
 ### Persistent state lifecycle
 
@@ -116,6 +173,13 @@ token events identify their registered client without an N+1 query. Terminal
 checkpoints; retryable 429 and server-side 5xx outcomes keep the short window so
 operational incidents remain visible.
 
+Audit events feed an explicit incident lifecycle (`observing`, `open`,
+`resolved`, or `suppressed`). A generic success cannot close unrelated repair
+debt: resolution requires correlated evidence for the same incident. Unresolved
+incidents are reporting state, not active learning. Only a verified repair or an
+explicit user correction may promote reusable guidance into memory; paginated
+legacy reconciliation stays retryable if any eligible memory update fails.
+
 ### External browser consent boundary
 
 Stonewright does not embed or silently install a browser provider. Before
@@ -128,6 +192,13 @@ it does not replace custom-code dry-run/approval, backup, permission, audit, or
 confirmation-token gates in Plugin or Direct mode.
 
 ### Elementor write closure
+
+Elementor routing starts from the live runtime, document architecture, widget
+registry, and control schema. V3 operations stay within reported V3-safe roots;
+Atomic targets use the V4 tree abilities instead of being converted. Native
+cover CTA, testimonial carousel, chip, and Button-icon output is selected only
+when the live widget/control contract supports the requested settings. Catalog
+presence alone is never availability proof.
 
 All typed Elementor V3 document-tree writers converge on
 `ElementorData::write()`. The write path acquires a per-post lease, validates

--- a/docs/contracts/direct-tools-v1.json
+++ b/docs/contracts/direct-tools-v1.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_at": "2026-08-11T16:35:46.036Z",
+  "generated_at": "2026-08-11T21:19:07.540Z",
   "allowlist": {
     "removed": [],
     "renamed": {},

--- a/docs/contracts/public-api-v1.json
+++ b/docs/contracts/public-api-v1.json
@@ -1,6 +1,6 @@
 {
     "version": 1,
-    "generated_at": "2026-08-11T16:35:46+00:00",
+    "generated_at": "2026-08-11T21:19:07+00:00",
     "allowlist": {
         "removed": [],
         "renamed": {},
@@ -2612,6 +2612,20 @@
                 "token": false,
                 "validator": false,
                 "audit": false
+            }
+        },
+        {
+            "ability_name": "stonewright/elementor-v3-kit-batch-mutate",
+            "mcp_name": "stonewright-elementor-v3-kit-batch-mutate",
+            "kind": "Write",
+            "input_schema_hash": "c59dc589f64b4bf74b978a6891275accd893e02f4cfbf8b942fa35e17fec6907",
+            "output_schema_hash": "9f7400d0987f9aa70b218f8fcf554127e2ebacf0998ca7f829a7f2b6ca03e1ea",
+            "permission_class": "Permissions::edit_theme_options()",
+            "gates": {
+                "backup": true,
+                "token": true,
+                "validator": false,
+                "audit": true
             }
         },
         {

--- a/docs/releases/1.0.0-beta.5.md
+++ b/docs/releases/1.0.0-beta.5.md
@@ -1,0 +1,119 @@
+# Stonewright 1.0.0-beta.5
+
+This release makes first-time setup useful by default, keeps multi-site client
+configuration transactional, closes several WordPress admin and OAuth audit
+gaps, and adds schema-backed Elementor layout primitives without weakening
+Stonewright's write-safety boundaries.
+
+## Installation and client connections
+
+- Fresh plugin installs start on the bounded `essential` surface. `bootstrap`
+  remains an explicit startup diagnostic, `essential-static` is the fallback
+  for unknown clients with stale tool lists, and `low-tools` serves clients
+  with strict tool caps.
+- `stonewright connect add/list/use/verify/repair/remove/migrate` manages
+  collision-safe site aliases, environments, mode policy, Step 1 expectations,
+  client bindings, and OS-backed credential references. Client configuration,
+  registry, and credential changes roll back together on failure.
+- `connect verify` spawns the saved client entry and proves task-start, status,
+  selected alias, version, and tool surface. Parsing a config file is never
+  reported as a live connection.
+- Application Password creation stays in the current Setup tab, updates the
+  private snippet and credential inventory in place, and never places the
+  one-time password in the paste-to-agent prompt or a WordPress transient.
+- Client descriptors now separate operational support from certification
+  priority and evidence. A tier-1 priority is not a certified claim without a
+  passing, publication-safe acceptance report.
+
+## Runtime configuration and profiles
+
+- Ability enablement, mode, MCP surface, and Elementor V4 selection apply
+  immediately in Setup. One monotonic `surface_revision` tells HTTP clients to
+  re-list and lets the companion refresh callable tools without duplicate
+  registrations.
+- Generated client profiles follow the site's explicit surface selection;
+  only strict-cap clients retain a bounded override.
+- Domain-lock mismatches preserve operator enablement intent while exposing an
+  explicit blocked state and audited rebind/rollback flow. They no longer
+  silently turn abilities off.
+- Authentication and WordPress reachability remain evidence-based when a
+  probe has not run or credentials are incomplete.
+
+## Elementor and design parity
+
+- Native row/container normalization supports two-column and nested layouts.
+- Cover CTA planning, testimonial carousel selection, chip groups, and Button
+  icons are emitted only when the live Elementor registry and control schema
+  prove the required widget and settings exist.
+- `stonewright/elementor-v3-kit-batch-mutate` updates supported kit globals
+  under one lock, snapshot, merge-only write, hash readback, rollback, and
+  post-scoped cache boundary. Identical plans are verified no-ops.
+- Unsafe icon classes, non-HTTP SVG URLs, catalog-only Pro widgets, and
+  incompatible carousel repeaters are rejected instead of being guessed.
+- The Design Library admin surface and catalog starters are hidden while the
+  typed design engines, stored user data, and native design workflow remain.
+
+## Custom code, browser automation, and safety
+
+- Plugin mode has typed providers for WPCode, Code Snippets, Customizer CSS,
+  and allowlisted theme files. Every change starts with a dry run and stops at
+  the human approval URL; apply and rollback use concurrency checks,
+  snapshots, readback, audit, and production confirmation where required.
+- Direct mode still does not write custom PHP, CSS, JavaScript, or HTML because
+  pluginless operation has no authenticated wp-admin grant boundary.
+- Browser verification asks once per site/client for Playwright, another
+  provider, or none. Scanning and installation/configuration require separate
+  consent, and a browser never bypasses a Stonewright write gate.
+
+## Audit, incidents, memory, and admin UI
+
+- Terminal OAuth client failures coalesce over 24 hours while retryable 429 and
+  server failures retain the shorter operational window.
+- Pre-login OAuth audit rows resolve registered client names in one batched
+  lookup and use explicit OAuth-client or System fallbacks instead of an
+  ambiguous unknown actor.
+- Unresolved incidents stay out of active learning memory. Durable repair
+  guidance is promoted only after correlated verified evidence or an explicit
+  user correction; legacy reconciliation is paginated and retryable.
+- Audit, Memory, Skills, and Sandbox controls now share deliberate card
+  padding, checkbox spacing, action gaps, and 32px control heights.
+
+## OAuth and client verification
+
+- Deterministic plugin and companion matrices cover discovery, PKCE,
+  resource binding, challenge handling, token rotation, replay, retries, and
+  terminal reauthorization.
+- Reusable acceptance and release-report templates keep client compatibility,
+  certification, restart, OAuth, stdio, and evidence claims reviewable.
+
+## Abilities and package versions
+
+- Plugin mode exposes **360** abilities.
+- Direct mode exposes **100** tools.
+- WordPress plugin and companion: `1.0.0-beta.5`.
+- `@stonewright/visual`: `0.4.0`.
+
+## Verification and artifacts
+
+Release gates cover the complete PHP 8.1-8.5 matrix, companion and Visual test
+suites, PHPStan, PHPCS, security and dependency audits, provenance, generated
+contracts, token budgets, documentation freshness, public-repository hygiene,
+admin UI end-to-end tests, staged package inspection, archive secret scanning,
+and WordPress activation from the extracted package.
+
+Release assets contain `stonewright-1.0.0-beta.5.zip`,
+`stonewright-companion-1.0.0-beta.5.tgz`, the Visual package, and
+`SHA256SUMS.txt`.
+
+## Upgrade
+
+For local stdio with Plugin mode, update both the plugin and companion, restart
+the AI client, call `stonewright-task-start`, and verify
+`companion_version`, `expected_companion_package`, and an empty
+`refresh_required_tool_names`. Remote Streamable HTTP updates only the plugin;
+pluginless Direct mode updates only the companion.
+
+Updates preserve existing site aliases, credentials references, settings,
+memory, user-created skills, audit history, backups, and Direct state. A fresh
+install seeds only generic product assets and starts with no user memory,
+user-created skills, or audit events.

--- a/docs/releases/acceptance-report-template.md
+++ b/docs/releases/acceptance-report-template.md
@@ -27,12 +27,23 @@ From repository root unless noted:
 - [ ] `cd plugin && composer phpcs`
 - [ ] `cd plugin && composer security:audit`
 - [ ] `cd plugin && composer dependencies:audit`
+- [ ] `cd plugin && composer provenance:lint`
+- [ ] `cd plugin && composer contracts:compat`
+- [ ] `cd plugin && composer tokens:measure`
 - [ ] `cd companion && npm run typecheck`
+- [ ] `cd companion && npm run lint`
+- [ ] `cd companion && npm run contracts:compat`
 - [ ] `cd companion && npm test`
+- [ ] `cd companion && npm run tokens:measure`
 - [ ] `cd companion && npm run build`
+- [ ] `cd companion && npm audit --omit=dev`
+- [ ] `cd visual && npm run typecheck && npm test && npm run build`
+- [ ] PR and post-merge `main` `e2e-admin-ui`
 - [ ] `node scripts/check-docs-freshness.mjs`
 - [ ] `git diff --check`
 - [ ] `node scripts/check-public-hygiene.mjs --require-private-terms` (release packaging)
+- [ ] Plugin ZIP, companion TGZ, and Visual TGZ unpacked and scanned; published
+      checksums match downloaded assets.
 - [ ] Focused OAuth matrix when OAuth changed:
   - `cd plugin && ./vendor/bin/phpunit --filter OAuth`
   - `cd companion && npx vitest run tests/oauth-matrix.test.ts tests/oauth-token-manager.test.ts tests/wordpress-mcp-oauth.test.ts`
@@ -53,7 +64,8 @@ From repository root unless noted:
 ## Client certification matrix (tier-1)
 
 Complete one [client-acceptance-template.md](client-acceptance-template.md) per
-row, or attach private evidence links.
+row, or keep environment-specific evidence private. Only a publication-safe,
+repository-relative report may be written to a public catalog descriptor.
 
 | Client | Catalog slug | Mode tested | Result | Evidence |
 |---|---|---|---|---|
@@ -77,6 +89,17 @@ Minimum for a public release:
 - [ ] Companion `doctor` (stdio) exits cleanly without printing secrets.
 - [ ] Terminal OAuth reauth path: invalid/revoked refresh forces browser reauthorization (no infinite retry).
 - [ ] Status / gateway honesty: disconnected and unauthorized states are not reported as healthy.
+- [ ] Step 1 enablement, mode, surface, and Elementor V4 changes expose the
+      documented surface revision and re-list/restart contract.
+- [ ] Application Password generation stays in the current Setup tab and the
+      credential-free prompt remains placeholder-only.
+- [ ] Two synthetic site/environment aliases coexist; duplicate endpoints and
+      a forced config failure leave registry, credential, and client config
+      state unchanged.
+- [ ] Browser provider selection, scan consent, and install/config consent are
+      separate and no provider is silently installed.
+- [ ] Custom-code dry run stops at human approval; Direct mode has no custom-code
+      write path.
 
 ## Security and hygiene
 

--- a/docs/releases/checklist.md
+++ b/docs/releases/checklist.md
@@ -11,6 +11,9 @@ Run from `plugin/` unless noted.
 - [ ] `composer phpcs` - zero style violations.
 - [ ] `composer security:audit` - exits 0.
 - [ ] `composer dependencies:audit` - exits 0 and reports any abandoned compatibility packages.
+- [ ] `composer provenance:lint` - imported/derived source provenance is complete.
+- [ ] `composer contracts:compat` - the public ability contract remains compatible.
+- [ ] `composer tokens:measure` - every plugin profile stays within its budget.
 - [ ] Clean `vendor/`, run `composer install --no-dev --classmap-authoritative`,
       then `composer package:verify-manifests`.
 - [ ] `composer docs:matrix` - regenerates the ability matrix cleanly.
@@ -18,8 +21,19 @@ Run from `plugin/` unless noted.
 - [ ] `cd .. && node scripts/check-public-hygiene.mjs --require-private-terms` - source tree is free of configured private project terms.
 - [ ] `cd .. && node scripts/package-verify.mjs --strict-vendor` - production package inputs and Jetpack manifests are complete.
 - [ ] `cd ../companion && npm run typecheck` - zero TypeScript errors.
+- [ ] `cd ../companion && npm run lint` - zero lint errors.
+- [ ] `cd ../companion && npm run contracts:compat` - Direct contract remains compatible.
 - [ ] `cd ../companion && npm test` - all Vitest tests pass.
+- [ ] `cd ../companion && npm run tokens:measure` - Direct profiles stay within budget.
 - [ ] `cd ../companion && npm run build` - build succeeds.
+- [ ] `cd ../companion && npm audit --omit=dev` - zero production advisories.
+- [ ] `cd ../visual && npm run typecheck && npm test && npm run build` - Visual is green.
+- [ ] The PR and post-merge `main` CI both pass `e2e-admin-ui` against the
+      packaged plugin, including the Setup no-refresh flow and admin spacing.
+- [ ] Build the exact plugin ZIP, companion TGZ, and Visual TGZ through the
+      release workflow recipe; unpack and scan each archive for secrets,
+      private terms, runtime state, development junk, and missing dependencies.
+- [ ] `git diff --check` - zero whitespace errors.
 
 ## Publish
 
@@ -32,6 +46,8 @@ Run from `plugin/` unless noted.
 4. Confirm the GitHub release links to the expected assets and checksums.
 5. Confirm the staged ZIP passes the private-term scan and Jetpack manifest
    verification before upload.
+6. Download every published asset, run `sha256sum -c SHA256SUMS.txt`, and
+   confirm the archive metadata reports the released plugin/companion version.
 
 ## Client certification (tier-1)
 
@@ -115,6 +131,44 @@ Run from `plugin/` unless noted.
 - [ ] Start a new MCP session.
 - [ ] Call `stonewright-task-start`.
 - [ ] Confirm the manual instruction, skill, or memory entry is present in the task-start response.
+
+### 10. Setup and multi-site connection
+
+- [ ] Confirm ability enablement, mode, surface, and Elementor V4 save without a
+      full-page reload and increment one shared `surface_revision` only on a
+      real change.
+- [ ] Confirm HTTP re-list and companion task-start/profile refresh expose the
+      selected surface; document a restart only for a client that keeps a stale
+      startup snapshot.
+- [ ] Generate an Application Password in Setup and confirm the URL, auth tab,
+      client selection, private snippet, and password inventory update in place.
+- [ ] Add two synthetic aliases on different environments, reject a duplicate
+      canonical endpoint, and prove config/credential rollback after a forced
+      registry or adapter failure.
+
+### 11. Custom code and browser consent
+
+- [ ] Confirm each installed typed custom-code provider returns an exact dry-run
+      handoff and refuses apply without the matching human grant.
+- [ ] Confirm Direct mode cannot write custom PHP/CSS/JS/HTML.
+- [ ] Confirm browser provider choice, scan consent, and install/config consent
+      are independent, persistent per site/client, and never silently granted.
+
+### 12. Audit, memory, and actor attribution
+
+- [ ] Confirm terminal OAuth failures coalesce, retryable/server failures retain
+      operational visibility, and pre-login actors resolve without N+1 queries.
+- [ ] Confirm generic success cannot close an unrelated incident and unresolved
+      incidents do not become active learning memory.
+- [ ] Confirm paginated legacy reconciliation remains retryable after a
+      synthetic eligible-memory failure.
+
+### 13. Upgrade preservation
+
+- [ ] Upgrade a fixture containing settings, audit rows, memory, user skills,
+      site aliases, credential references, and Direct state.
+- [ ] Confirm all state remains and no fresh-install seed creates user memory,
+      user skills, or audit events.
 
 ## Rollback
 

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.0.0-beta.5] - 2026-08-12
+
 ### Added
 
 - Add deterministic OAuth discovery, PKCE, resource-binding, challenge,

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,6 +1,6 @@
 # Stonewright Plugin
 
-Version: 1.0.0-beta.4
+Version: 1.0.0-beta.5
 Requires WordPress: 6.7+
 Requires PHP: 8.1+
 License: AGPL-3.0-or-later

--- a/plugin/stonewright.php
+++ b/plugin/stonewright.php
@@ -3,7 +3,7 @@
  * Plugin Name: Stonewright
  * Plugin URI: https://github.com/cosmincraciun97/stonewright-wp-mcp
  * Description: Guarded WordPress MCP tools for Elementor, Gutenberg/FSE, WooCommerce catalogs, content models, PHP runtime execution, and tokenized WP-CLI.
- * Version: 1.0.0-beta.4
+ * Version: 1.0.0-beta.5
  * Requires at least: 6.7
  * Requires PHP: 8.1
  * Author: Stonewright
@@ -33,7 +33,7 @@ if ( defined( 'STONEWRIGHT_FILE' ) ) {
 define( 'STONEWRIGHT_FILE', __FILE__ );
 define( 'STONEWRIGHT_DIR', plugin_dir_path( __FILE__ ) );
 define( 'STONEWRIGHT_URL', plugin_dir_url( __FILE__ ) );
-define( 'STONEWRIGHT_VERSION', '1.0.0-beta.4' );
+define( 'STONEWRIGHT_VERSION', '1.0.0-beta.5' );
 define( 'STONEWRIGHT_MIN_PHP', '8.1' );
 define( 'STONEWRIGHT_MIN_WP', '6.7' );
 

--- a/plugin/tests/Unit/Support/ReleaseRetentionTest.php
+++ b/plugin/tests/Unit/Support/ReleaseRetentionTest.php
@@ -19,7 +19,7 @@ final class ReleaseRetentionTest extends TestCase {
 				$versioned[] = $name;
 			}
 		}
-		self::assertSame( [ '1.0.0-beta.1.md', '1.0.0-beta.2.md', '1.0.0-beta.3.md', '1.0.0-beta.4.md' ], $versioned );
+		self::assertSame( [ '1.0.0-beta.1.md', '1.0.0-beta.2.md', '1.0.0-beta.3.md', '1.0.0-beta.4.md', '1.0.0-beta.5.md' ], $versioned );
 	}
 
 	public function test_root_changelog_has_at_most_five_versions_plus_unreleased(): void {
@@ -34,7 +34,7 @@ final class ReleaseRetentionTest extends TestCase {
 			)
 		);
 		self::assertContains( 'Unreleased', $headers );
-		self::assertSame( [ '1.0.0-beta.4', '1.0.0-beta.3', '1.0.0-beta.2', '1.0.0-beta.1' ], $versions );
+		self::assertSame( [ '1.0.0-beta.5', '1.0.0-beta.4', '1.0.0-beta.3', '1.0.0-beta.2', '1.0.0-beta.1' ], $versions );
 		self::assertStringContainsString( 'public changelog starts with the first beta', $raw );
 	}
 }


### PR DESCRIPTION
## Summary

- bump the plugin and companion to `1.0.0-beta.5` without replacing any existing tag or release
- move the complete Unreleased notes into beta.5 and add versioned release notes
- update the root architecture and detailed architecture for multi-site state, authentication, Step 1 propagation, profiles, custom-code approval, Elementor V3/V4/kit closure, audit incidents, memory promotion, and browser consent
- correct the root capability table to the generated totals: 360 plugin abilities and 100 Direct tools
- regenerate both public contracts; the plugin contract now includes the already-merged kit batch ability
- expand the release and acceptance checklists for package scans, UI E2E, connection transactions, state preservation, and client evidence

## Ability and safety impact

No new runtime ability implementation is introduced by this release-preparation PR. The generated public contract catches up with `stonewright/elementor-v3-kit-batch-mutate`, which is already on main. Permission, backup, confirmation-token, validation, audit, and Direct-mode custom-code boundaries are unchanged.

## Public documentation

Updated root/plugin/companion changelogs, root and plugin READMEs, Setup and client connection guides, architecture prose and diagrams, release/acceptance templates, and the beta.5 release note. Evergreen download links continue to use the `VERSION` placeholder.

## Local validation

- PHPUnit: 6,817 tests / 36,101 assertions
- PHPStan: 675 files, zero errors
- PHPCS: 772 files, zero violations
- security audit: all six checks pass
- dependency audit: zero vulnerabilities; the documented abandoned `wordpress/abilities-api` compatibility package remains
- provenance: 42 imported files verified
- public contract: 5 tests / 7,576 assertions
- plugin profiles: 360 full / 30 essential / 12 low-tools, within budgets
- companion: typecheck, lint, 57 files / 451 tests, contracts, tool budgets, build, and production audit all pass
- Visual: typecheck, 8 files / 80 tests, build, and production audit all pass
- docs freshness: 672 classified Markdown files, 155 maintained, beta.5, 360/100
- diff and local public-hygiene scans pass; CI remains authoritative for configured private terms
- exact local artifacts built and unpacked: plugin ZIP, companion TGZ, Visual TGZ; runtime state/dev junk absent and all three SHA-256 checks pass

Docker is not available in the local environment, so packaged admin UI E2E and the configured private-term gate remain required CI checks before merge.