### PR TITLE
fix: deterministic Plugin-mode connections and Setup save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,33 @@ All notable changes to Stonewright are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-The public changelog starts with the first beta. Pre-beta development builds
-were never stable releases and are not part of the supported public history.
+The public changelog keeps the five latest releases inline. Older public betas
+remain available in their immutable versioned release notes. Pre-beta
+development builds were never stable releases.
 
 ## [Unreleased]
+
+## [1.0.0-beta.6] - 2026-08-12
+
+### Changed
+
+- Make the installed-plugin setup prompt choose one transport, require a unique
+  alias and `plugin-only` policy for companion stdio, and reuse an existing
+  credential through `connect repair --mode` instead of creating a generic or
+  duplicate server entry.
+- Add a synthetic, privacy-safe Dashboard overview to the main documentation.
+
+### Fixed
+
+- Keep domain-lock recovery forms outside the Settings API form so **Save
+  Settings** returns to Stonewright Setup instead of leaving the user on
+  `/wp-admin/options.php`.
+- Treat `STONEWRIGHT_SITE_ALIAS` as the startup routing authority, replacing
+  stale inherited WordPress environment values before Plugin/Direct mode is
+  selected and failing closed when its credential cannot be resolved.
+- Collapse duplicate legacy aliases for the same canonical site/environment
+  during secure v1 migration, and allow `connect repair --mode plugin-only` to
+  update a named client entry without requesting the saved password again.
 
 ## [1.0.0-beta.5] - 2026-08-12
 
@@ -173,7 +196,11 @@ were never stable releases and are not part of the supported public history.
   readable, remove inline click handling from category actions, and correct
   low-contrast setup code blocks and focus rings.
 
-## [1.0.0-beta.1] - 2026-07-30
+## Older releases
+
+See [1.0.0-beta.1](docs/releases/1.0.0-beta.1.md) for the first public beta.
+
+### 1.0.0-beta.1 — 2026-07-30
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,11 @@ Stonewright is a WordPress MCP stack for AI coding agents. **Elementor** is a fi
   <a href="CONTRIBUTING.md">Contributing</a>
 </p>
 
-<!-- Maintainer: add the Stonewright workflow demo here. Do not remove this comment until the asset is available. -->
+<p align="center">
+  <img src="assets/screenshots/stonewright-dashboard-overview.svg" alt="Stonewright dashboard showing a verified Plugin-mode connection" width="1200" />
+</p>
+
+<p align="center"><sub>Synthetic product view. No customer site, credential, memory, or audit data is shown.</sub></p>
 
 ## Capabilities
 
@@ -154,40 +158,33 @@ MCP surface modes (`bootstrap` / `essential-static` / `essential` / `full`) cont
 <details>
 <summary>MCP client config (Plugin mode companion)</summary>
 
-Use the latest companion package URL from [Releases](https://github.com/cosmincraciun97/stonewright-wp-mcp/releases) (do not hardcode a stale version):
+Use the versioned installer from the latest
+[release](https://github.com/cosmincraciun97/stonewright-wp-mcp/releases).
+Because this flow starts from an installed plugin, choose `plugin-only`; it
+fails closed instead of silently falling back to Direct mode.
 
-```json
-{
-  "mcpServers": {
-    "stonewright": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "--package",
-        "https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz",
-        "stonewright-mcp"
-      ],
-      "env": {
-        "STONEWRIGHT_WP_URL": "https://your-site.example.com",
-        "STONEWRIGHT_WP_USERNAME": "admin",
-        "STONEWRIGHT_WP_APP_PASSWORD": "xxxx xxxx xxxx xxxx xxxx xxxx",
-        "STONEWRIGHT_MCP_TOOL_PROFILE": "essential"
-      }
-    }
-  }
-}
+```bash
+npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz stonewright connect add \
+  --alias site-a --url https://site-a.example --username editor \
+  --env production --mode plugin-only --client codex \
+  --plugin-enabled yes --wp-mode production-safe --wp-surface essential
 ```
 
-Replace `VERSION` with the exact release version without the leading `v`, as
-shown on the GitHub Releases page. Keep real credentials in private client
-config; paste-to-agent prompts use placeholders only. Site MCP endpoint when
-using the WordPress MCP adapter directly:
+The installer requests the Application Password through a hidden prompt,
+stores it in the OS credential store, and writes a collision-safe named client
+entry containing `STONEWRIGHT_SITE_ALIAS`, never the password. If the alias is
+already registered, reuse its saved credential and switch the existing entry:
 
-```text
-https://your-site.example.com/wp-json/mcp/stonewright
+```bash
+npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz stonewright connect repair site-a --client codex --mode plugin-only
 ```
 
-HTTP local sites are supported; Setup treats plain HTTP as informational, not a hard failure.
+Restart the client and run `stonewright connect verify site-a --client codex`.
+The receipt must report the requested alias, `configured_mode=plugin-only`,
+`active_mode=plugin`, task-start/status availability, the expected companion,
+and no required tool refresh. OAuth remote HTTP is a separate connection to
+`/wp-json/mcp/stonewright-oauth`; do not combine both transports under one
+generic `stonewright` server name.
 
 </details>
 
@@ -247,7 +244,10 @@ Each `(canonical URL, environment)` is unique and each site has a stable alias.
 Application Passwords remain in Keychain, Windows protected storage, Linux
 Secret Service, or an explicit `env://` reference. A client entry carries only
 `STONEWRIGHT_SITE_ALIAS`, so startup resolves exactly that site without loading
-unrelated credentials. The registry also retains Direct/Plugin policy, WordPress
+unrelated credentials. The explicit alias is authoritative over inherited
+legacy `STONEWRIGHT_WP_*` values. Secure v1 migration collapses duplicate
+aliases for the same canonical site/environment to one stable record. The
+registry also retains Direct/Plugin policy, WordPress
 mode and tool surface, Elementor V4 selection, plus the browser choice and its
 separate scan/install consent for each client. See [Installation](docs/installation.md).
 

--- a/assets/screenshots/stonewright-dashboard-overview.svg
+++ b/assets/screenshots/stonewright-dashboard-overview.svg
@@ -1,0 +1,114 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="810" viewBox="0 0 1440 810" role="img" aria-labelledby="title desc">
+  <title id="title">Stonewright WordPress dashboard</title>
+  <desc id="desc">Synthetic product illustration of the Stonewright dashboard with no customer or runtime data.</desc>
+  <defs>
+    <linearGradient id="page" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f7f8fc"/>
+      <stop offset="1" stop-color="#eef1f8"/>
+    </linearGradient>
+    <linearGradient id="brand" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#6557ff"/>
+      <stop offset="1" stop-color="#315efb"/>
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="140%">
+      <feDropShadow dx="0" dy="8" stdDeviation="14" flood-color="#17213a" flood-opacity=".08"/>
+    </filter>
+  </defs>
+
+  <rect width="1440" height="810" fill="url(#page)"/>
+  <rect width="1440" height="58" fill="#15171d"/>
+  <path d="M25 20 36 14 47 20v18L36 44 25 38Z" fill="url(#brand)"/>
+  <path d="m31 22 5-3 5 3v13l-5 3-5-3Z" fill="#b9c5ff" opacity=".85"/>
+  <text x="58" y="36" font-family="Inter,Arial,sans-serif" font-size="17" font-weight="700" fill="#fff">Stonewright</text>
+  <rect x="159" y="9" width="94" height="40" rx="7" fill="#37307d"/>
+  <text x="177" y="35" font-family="Inter,Arial,sans-serif" font-size="14" font-weight="700" fill="#fff">Dashboard</text>
+  <g font-family="Inter,Arial,sans-serif" font-size="13" font-weight="600" fill="#b9bbc4">
+    <text x="278" y="35">Setup</text>
+    <text x="337" y="35">AI Abilities</text>
+    <text x="445" y="35">Workflows</text>
+    <text x="544" y="35">Sandbox</text>
+    <text x="627" y="35">Prompts</text>
+    <text x="716" y="35">Audit Log</text>
+    <text x="803" y="35">Memory</text>
+    <text x="875" y="35">Skills</text>
+  </g>
+  <rect x="1245" y="14" width="132" height="30" rx="15" fill="#262a36" stroke="#51586c"/>
+  <circle cx="1264" cy="29" r="5" fill="#49c78e"/>
+  <text x="1276" y="34" font-family="Inter,Arial,sans-serif" font-size="12" font-weight="700" fill="#dfe5f4">plugin mode</text>
+
+  <g transform="translate(150 108)">
+    <text x="0" y="26" font-family="Inter,Arial,sans-serif" font-size="28" font-weight="750" fill="#202331">Dashboard</text>
+    <text x="0" y="52" font-family="Inter,Arial,sans-serif" font-size="14" fill="#687086">Live overview of mode, tools, companion, and recent MCP activity.</text>
+
+    <g transform="translate(0 82)" filter="url(#shadow)">
+      <rect width="1140" height="142" rx="16" fill="#fff" stroke="#dce1ec"/>
+      <path d="M190 0v142M380 0v142M570 0v142M760 0v142M950 0v142" stroke="#e4e7ef"/>
+      <g font-family="Inter,Arial,sans-serif">
+        <g transform="translate(24 27)">
+          <circle cx="9" cy="9" r="9" fill="#e8f8f0"/><path d="m5 9 3 3 6-7" fill="none" stroke="#24a56c" stroke-width="2"/>
+          <text x="27" y="15" font-size="18" font-weight="750" fill="#202331">Ready</text>
+          <text x="0" y="46" font-size="12" font-weight="700" fill="#687086">Site pulse</text>
+          <text x="0" y="69" font-size="12" fill="#8a91a3">Health checks available</text>
+        </g>
+        <g transform="translate(214 27)">
+          <circle cx="9" cy="9" r="9" fill="#eef0ff"/><path d="M9 4v10M4 9h10" stroke="#6557ff" stroke-width="1.8"/>
+          <text x="27" y="15" font-size="17" font-weight="750" fill="#202331">production-safe</text>
+          <text x="0" y="46" font-size="12" font-weight="700" fill="#687086">WordPress mode</text>
+          <text x="0" y="69" font-size="12" fill="#8a91a3">Confirmation gates active</text>
+        </g>
+        <g transform="translate(404 27)">
+          <circle cx="9" cy="9" r="9" fill="#f2edff"/><path d="M5 13 13 5M6 5h7v7" fill="none" stroke="#7357db" stroke-width="1.8"/>
+          <text x="27" y="15" font-size="18" font-weight="750" fill="#202331">Elementor</text>
+          <text x="0" y="46" font-size="12" font-weight="700" fill="#687086">Native engines</text>
+          <text x="0" y="69" font-size="12" fill="#8a91a3">V3 + V4 ready</text>
+        </g>
+        <g transform="translate(594 27)">
+          <circle cx="9" cy="9" r="9" fill="#e9f3ff"/><path d="M5 9h8M9 5v8" stroke="#3976da" stroke-width="1.8"/>
+          <text x="27" y="15" font-size="18" font-weight="750" fill="#202331">Plugin</text>
+          <text x="0" y="46" font-size="12" font-weight="700" fill="#687086">Active connection</text>
+          <text x="0" y="69" font-size="12" fill="#8a91a3">Alias verified</text>
+        </g>
+        <g transform="translate(784 27)">
+          <circle cx="9" cy="9" r="9" fill="#f0efff"/><path d="M5 6h8M5 9h8M5 12h8" stroke="#6557ff" stroke-width="1.6"/>
+          <text x="27" y="15" font-size="18" font-weight="750" fill="#202331">Essential</text>
+          <text x="0" y="46" font-size="12" font-weight="700" fill="#687086">Tool surface</text>
+          <text x="0" y="69" font-size="12" fill="#8a91a3">Compact working set</text>
+        </g>
+        <g transform="translate(974 27)">
+          <circle cx="9" cy="9" r="9" fill="#fff3df"/><path d="M9 5v5l3 2" fill="none" stroke="#d48620" stroke-width="1.8"/>
+          <text x="27" y="15" font-size="18" font-weight="750" fill="#202331">Just now</text>
+          <text x="0" y="46" font-size="12" font-weight="700" fill="#687086">Last activity</text>
+          <text x="0" y="69" font-size="12" fill="#8a91a3">Connection verified</text>
+        </g>
+      </g>
+    </g>
+
+    <g transform="translate(0 258)" filter="url(#shadow)">
+      <rect width="548" height="330" rx="16" fill="#fff" stroke="#dce1ec"/>
+      <text x="30" y="48" font-family="Inter,Arial,sans-serif" font-size="17" font-weight="750" fill="#202331">Connection health</text>
+      <line x1="30" y1="68" x2="518" y2="68" stroke="#e6e9f1"/>
+      <rect x="30" y="94" width="488" height="74" rx="11" fill="#f7f8fc"/>
+      <circle cx="57" cy="131" r="12" fill="#e8f8f0"/>
+      <path d="m51 131 4 4 8-9" fill="none" stroke="#24a56c" stroke-width="2.2"/>
+      <text x="82" y="126" font-family="Inter,Arial,sans-serif" font-size="14" font-weight="700" fill="#202331">Named site connection verified</text>
+      <text x="82" y="148" font-family="Inter,Arial,sans-serif" font-size="12" fill="#7a8295">Correct alias, Plugin mode, and current companion.</text>
+      <rect x="30" y="188" width="232" height="94" rx="11" fill="#f7f8fc"/>
+      <text x="50" y="219" font-family="Inter,Arial,sans-serif" font-size="12" font-weight="700" fill="#687086">TASK START</text>
+      <text x="50" y="251" font-family="Inter,Arial,sans-serif" font-size="21" font-weight="750" fill="#202331">Available</text>
+      <rect x="286" y="188" width="232" height="94" rx="11" fill="#f7f8fc"/>
+      <text x="306" y="219" font-family="Inter,Arial,sans-serif" font-size="12" font-weight="700" fill="#687086">REFRESH REQUIRED</text>
+      <text x="306" y="251" font-family="Inter,Arial,sans-serif" font-size="21" font-weight="750" fill="#24a56c">None</text>
+    </g>
+
+    <g transform="translate(572 258)" filter="url(#shadow)">
+      <rect width="568" height="330" rx="16" fill="#fff" stroke="#dce1ec"/>
+      <text x="30" y="48" font-family="Inter,Arial,sans-serif" font-size="17" font-weight="750" fill="#202331">Recent activity</text>
+      <text x="448" y="48" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="700" fill="#5749ee">View audit log</text>
+      <line x1="30" y1="68" x2="538" y2="68" stroke="#e6e9f1"/>
+      <circle cx="284" cy="151" r="34" fill="#f0efff"/>
+      <path d="M270 151h28M284 137v28" stroke="#6557ff" stroke-width="2"/>
+      <text x="284" y="210" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="16" font-weight="750" fill="#202331">No recent activity</text>
+      <text x="284" y="235" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="13" fill="#7a8295">Fresh installations begin with an empty audit history.</text>
+    </g>
+  </g>
+</svg>

--- a/companion/CHANGELOG.md
+++ b/companion/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+## [1.0.0-beta.6] - 2026-08-12
+
+### Changed
+
+- Add `connect repair <alias> --mode direct-only|plugin-only|auto` so an
+  existing site can change policy and refresh its named client entry while
+  reusing the stored credential.
+
+### Fixed
+
+- Make an explicit `STONEWRIGHT_SITE_ALIAS` override stale inherited WordPress
+  URL, username, and password values before runtime mode selection.
+- Deduplicate legacy v1 aliases by canonical URL and environment during secure
+  migration, preserving the configured default or first stable alias and never
+  persisting the read-only v1 projection as schema v2.
+
 ## [1.0.0-beta.5] - 2026-08-12
 
 ### Added

--- a/companion/README.md
+++ b/companion/README.md
@@ -136,7 +136,7 @@ npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/
   --url https://site-a.example \
   --username editor \
   --env staging \
-  --mode auto \
+  --mode plugin-only \
   --plugin-enabled yes \
   --wp-mode staging \
   --wp-surface essential \
@@ -186,7 +186,7 @@ MCP client config from `connect add --client …` is secret-free:
       "command": "npx",
       "args": ["-y", "--package", "…/stonewright-companion-VERSION.tgz", "stonewright-mcp"],
       "env": {
-        "STONEWRIGHT_MODE": "auto",
+        "STONEWRIGHT_MODE": "plugin",
         "STONEWRIGHT_MCP_TOOL_PROFILE": "essential-static",
         "STONEWRIGHT_SITE_ALIAS": "site-a"
       }
@@ -197,8 +197,9 @@ MCP client config from `connect add --client …` is secret-free:
 
 At companion startup, `STONEWRIGHT_SITE_ALIAS` resolves **only that site** from
 the registry and injects `STONEWRIGHT_WP_URL`, `STONEWRIGHT_WP_USERNAME`, and
-`STONEWRIGHT_WP_APP_PASSWORD` into the runtime env. Other sites' secrets stay
-unloaded.
+`STONEWRIGHT_WP_APP_PASSWORD` into the runtime env. The alias is authoritative:
+it replaces stale or inherited `STONEWRIGHT_WP_*` values instead of allowing a
+named entry to start against another site. Other sites' secrets stay unloaded.
 
 **Modes per site:** `auto` (default probe), `plugin-only` (fail closed without
 plugin MCP), `direct-only` (skip plugin probe). Prefer `--password-env` or the
@@ -208,7 +209,7 @@ Browser provider, scan consent, and install consent are distinct per-client
 fields. `recommended` means Playwright without embedding or installing it;
 `unknown` causes an agent to ask once and never authorizes scanning or
 installation. Update them idempotently with `connect repair <alias> --client
-<id> --browser-provider … --browser-scan-consent …
+<id> --mode plugin-only --browser-provider … --browser-scan-consent …
 --browser-install-consent …`.
 
 After restarting the target client, `connect verify <alias> --client <id>`
@@ -219,7 +220,16 @@ is not a successful runtime verification.
 
 Legacy v1 `sites.json` files with plaintext `appPassword` / `applicationPassword`
 still load at runtime. Run `connect migrate` to move secrets into the OS store
-and rewrite schema v2; the migration does not leave a plaintext `.bak` on success.
+and rewrite schema v2; the migration does not leave a plaintext `.bak` on
+success. If v1 contains several aliases for the same canonical URL and
+environment, migration retains the configured default alias for that group (or
+the first stable alias) and removes the duplicates before v2 is written.
+
+`connect repair <alias> --client <id> --mode plugin-only` reuses the stored
+credential, updates the persisted mode/fallback policy, and rewrites only that
+alias-specific client entry. It does not require the Application Password again.
+For a client managed by its own CLI, omit `--client`; the same command updates
+only the saved site policy and leaves external client configuration untouched.
 
 ### Doctor (connection health)
 

--- a/companion/package-lock.json
+++ b/companion/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@stonewright/companion",
-	"version": "1.0.0-beta.5",
+	"version": "1.0.0-beta.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@stonewright/companion",
-			"version": "1.0.0-beta.5",
+			"version": "1.0.0-beta.6",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/companion/package.json
+++ b/companion/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@stonewright/companion",
-	"version": "1.0.0-beta.5",
+	"version": "1.0.0-beta.6",
 	"description": "Node companion for the Stonewright WordPress MCP plugin: WP-CLI, health checks, and optional MCP HTTP proxy.",
 	"type": "module",
 	"license": "MIT",

--- a/companion/src/cli/connect/commands.ts
+++ b/companion/src/cli/connect/commands.ts
@@ -24,7 +24,13 @@ import { WordPressMcpClient } from '../../wordpress-mcp.js';
 import { Client as McpClient } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { APP_VERSION } from '../../version.js';
-import { configuredModeToEnv, mayProbePlugin, resolveActiveMode } from './mode-policy.js';
+import {
+	configuredModeToEnv,
+	defaultFallbackPolicy,
+	defaultPreferredActiveMode,
+	mayProbePlugin,
+	resolveActiveMode,
+} from './mode-policy.js';
 import {
 	buildSiteRecord,
 	findSiteByAlias,
@@ -43,6 +49,7 @@ import {
 import { mcpServerName } from './server-name.js';
 import {
 	ConnectError,
+	type ConfiguredMode,
 	type ConnectReceipt,
 	type BrowserPreferences,
 	type ConsentState,
@@ -136,6 +143,20 @@ async function verifyAuth(
 
 function saveRegistryForContext(registry: SitesRegistryV2, ctx: ConnectContext) {
 	return (ctx.saveRegistryImpl ?? saveRegistry)(registry, ctxPaths(ctx));
+}
+
+/**
+ * Mutating connect commands must never persist the read-only v1 projection.
+ * Securely migrate first, including legacy duplicate collapse, then continue
+ * from the canonical v2 registry.
+ */
+function loadWritableRegistry(ctx: ConnectContext): ReturnType<typeof loadRegistry> {
+	let loaded = loadRegistry(ctxPaths(ctx));
+	if (loaded.schema_was === 1 && loaded.source === 'file') {
+		migrateSitesFile(ctxPaths(ctx));
+		loaded = loadRegistry(ctxPaths(ctx));
+	}
+	return loaded;
 }
 
 function credentialStoreForRef(ref: string, ctx: ConnectContext) {
@@ -799,7 +820,7 @@ export function connectList(ctx: ConnectContext = {}): number {
 }
 
 export function connectUse(alias: string, ctx: ConnectContext = {}): number {
-	const { registry } = loadRegistry(ctxPaths(ctx));
+	const { registry } = loadWritableRegistry(ctx);
 	const site = findSiteByAlias(registry, alias);
 	if (!site) {
 		writeErr(`Unknown alias "${alias}"`);
@@ -825,7 +846,7 @@ export async function connectVerify(
 	opts: { client?: string } = {},
 	ctx: ConnectContext = {},
 ): Promise<number> {
-	const { registry, path } = loadRegistry(ctxPaths(ctx));
+	const { registry, path } = loadWritableRegistry(ctx);
 	const site = findSiteByAlias(registry, alias);
 	if (!site) {
 		writeErr(`Unknown alias "${alias}"`);
@@ -972,22 +993,60 @@ export function connectRepair(
 	alias: string,
 	opts: {
 		client?: string;
+		mode?: ConfiguredMode;
 		browserProvider?: BrowserPreferences['provider'];
 		browserScanConsent?: ConsentState;
 		browserInstallConsent?: ConsentState;
 	} = {},
 	ctx: ConnectContext = {},
 ): number {
-	const { registry } = loadRegistry(ctxPaths(ctx));
+	const { registry } = loadWritableRegistry(ctx);
 	const site = findSiteByAlias(registry, alias);
 	if (!site) {
 		writeErr(`Unknown alias "${alias}"`);
 		return 1;
 	}
+	const configuredMode = opts.mode ?? site.configured_mode;
+	const repairedSite: SiteRecordV2 = {
+		...site,
+		configured_mode: configuredMode,
+		preferred_active_mode: defaultPreferredActiveMode(configuredMode),
+		fallback_policy: defaultFallbackPolicy(configuredMode),
+		plugin_expectations: {
+			...site.plugin_expectations,
+			required: configuredMode === 'plugin-only',
+			enabled_requested:
+				configuredMode === 'plugin-only'
+					? true
+					: site.plugin_expectations?.enabled_requested ?? configuredMode !== 'direct-only',
+		},
+		updated_at: new Date().toISOString(),
+	};
 	const clientId = opts.client ?? Object.keys(site.clients)[0];
 	if (!clientId) {
-		writeErr('No client binding on this site. Pass --client <id>.');
-		return 1;
+		if (!opts.mode) {
+			writeErr('No client binding on this site. Pass --client <id>, or --mode <mode> for a policy-only repair.');
+			return 1;
+		}
+		try {
+			const next = upsertSite(registry, repairedSite, { replace: true });
+			saveRegistryForContext(next, ctx);
+			writeOut(
+				receiptLines({
+					ok: true,
+					site_id: repairedSite.id,
+					site_alias: repairedSite.alias,
+					environment: repairedSite.environment,
+					configured_mode: repairedSite.configured_mode,
+					active_mode: repairedSite.preferred_active_mode,
+					message: 'Repaired site mode policy; no client binding changed',
+				}),
+			);
+			return 0;
+		} catch (err) {
+			writeErr(err instanceof Error ? err.message : String(err));
+			return 1;
+		}
 	}
 	try {
 		const priorBrowser = site.clients[clientId]?.browser;
@@ -996,7 +1055,13 @@ export function connectRepair(
 			browserScanConsent: opts.browserScanConsent ?? priorBrowser?.scan_consent ?? 'unknown',
 			browserInstallConsent: opts.browserInstallConsent ?? priorBrowser?.install_consent ?? 'unknown',
 		}, priorBrowser);
-		const { registry: next, receipt, rollback } = applyClientBinding(registry, site, clientId, ctx, browser);
+		const { registry: next, receipt, rollback } = applyClientBinding(
+			registry,
+			repairedSite,
+			clientId,
+			ctx,
+			browser,
+		);
 		try {
 			saveRegistryForContext(next, ctx);
 		} catch (err) {
@@ -1008,11 +1073,11 @@ export function connectRepair(
 		}
 		const r: ConnectReceipt = {
 			ok: true,
-			site_id: site.id,
-			site_alias: site.alias,
-			environment: site.environment,
-			configured_mode: site.configured_mode,
-			active_mode: site.preferred_active_mode,
+			site_id: repairedSite.id,
+			site_alias: repairedSite.alias,
+			environment: repairedSite.environment,
+			configured_mode: repairedSite.configured_mode,
+			active_mode: repairedSite.preferred_active_mode,
 			message: `Repaired client binding for ${clientId}`,
 			details: receipt,
 		};
@@ -1033,7 +1098,7 @@ export function connectRemove(
 	opts: { client?: string } = {},
 	ctx: ConnectContext = {},
 ): number {
-	const { registry } = loadRegistry(ctxPaths(ctx));
+	const { registry } = loadWritableRegistry(ctx);
 	const site = findSiteByAlias(registry, alias);
 	if (!site) {
 		writeErr(`Unknown alias "${alias}"`);

--- a/companion/src/cli/connect/index.ts
+++ b/companion/src/cli/connect/index.ts
@@ -31,7 +31,7 @@ Usage:
   stonewright connect list
   stonewright connect use <alias>
   stonewright connect verify <alias> [--client <id>]
-  stonewright connect repair <alias> [--client <id>]
+  stonewright connect repair <alias> [--client <id>] [--mode <mode>]
   stonewright connect remove <alias> [--client <id>]
   stonewright connect migrate
 
@@ -61,6 +61,10 @@ add options:
   --default                Make this the default site
   --sites-file <path>      Override sites.json path
   --skip-auth              Skip live REST auth (tests / offline)
+
+repair options:
+  --client <id>            Create or refresh this site's named client entry
+  --mode <mode>            Change policy without re-entering the saved password
 `);
 }
 
@@ -207,6 +211,13 @@ export async function runConnect(argv: string[]): Promise<number> {
 				const client = flagString(flags, 'client');
 				const repairOpts: Parameters<typeof connectRepair>[1] = {};
 				if (client) repairOpts.client = client;
+				const mode = flagString(flags, 'mode');
+				if (mode) {
+					if (!['direct-only', 'plugin-only', 'auto'].includes(mode)) {
+						throw new Error('--mode must be direct-only, plugin-only, or auto');
+					}
+					repairOpts.mode = mode as ConfiguredMode;
+				}
 				const browserProvider = flagString(flags, 'browser-provider');
 				if (browserProvider) repairOpts.browserProvider = browserProvider as NonNullable<typeof repairOpts.browserProvider>;
 				const scanConsent = flagString(flags, 'browser-scan-consent');

--- a/companion/src/cli/connect/registry.ts
+++ b/companion/src/cli/connect/registry.ts
@@ -391,6 +391,42 @@ function v1Url(row: SitesRegistryV1['sites'][string]): string {
 }
 
 /**
+ * Pick one stable alias for every legacy URL/environment pair.
+ *
+ * The v1 format allowed the same site to be copied under several aliases. V2
+ * deliberately forbids that ambiguity. Preserve the configured default when
+ * it belongs to a duplicate group; otherwise preserve the first legacy alias.
+ */
+function uniqueV1Entries(
+	v1: SitesRegistryV1,
+): Array<[string, SitesRegistryV1['sites'][string]]> {
+	const entries = Object.entries(v1.sites ?? {});
+	const defaultKey = typeof v1.default === 'string' ? aliasKey(v1.default) : '';
+	const ordered = defaultKey
+		? [
+			...entries.filter(([alias]) => aliasKey(alias) === defaultKey),
+			...entries.filter(([alias]) => aliasKey(alias) !== defaultKey),
+		]
+		: entries;
+	const seen = new Set<string>();
+	const unique: Array<[string, SitesRegistryV1['sites'][string]]> = [];
+
+	for (const [alias, row] of ordered) {
+		const url = v1Url(row);
+		if (!url) {
+			unique.push([alias, row]);
+			continue;
+		}
+		const fingerprint = urlFingerprint(normalizeCanonicalUrl(url), 'other');
+		if (seen.has(fingerprint)) continue;
+		seen.add(fingerprint);
+		unique.push([alias, row]);
+	}
+
+	return unique;
+}
+
+/**
  * Lossless v1 → v2 migration.
  * Moves plaintext secrets into the credential store BEFORE writing v2.
  * On secure-store failure: throws and leaves the original file untouched.
@@ -405,11 +441,9 @@ export function migrateV1ToV2(
 ): SitesRegistryV2 {
 	const sites: SiteRecordV2[] = [];
 	const now = new Date().toISOString();
-	const aliases = Object.keys(v1.sites ?? {});
+	const entries = uniqueV1Entries(v1);
 
-	for (const alias of aliases) {
-		const row = v1.sites[alias];
-		if (!row) continue;
+	for (const [alias, row] of entries) {
 		const url = v1Url(row);
 		const username = v1Username(row);
 		const password = v1Password(row);
@@ -565,7 +599,7 @@ export function loadRegistry(options: LoadRegistryOptions = {}): {
  */
 export function projectV1AsV2WithoutSecretMove(v1: SitesRegistryV1): SitesRegistryV2 {
 	const sites: SiteRecordV2[] = [];
-	for (const [alias, row] of Object.entries(v1.sites ?? {})) {
+	for (const [alias, row] of uniqueV1Entries(v1)) {
 		const url = v1Url(row);
 		const username = v1Username(row);
 		if (!url || !username) continue;

--- a/companion/src/direct/apply-site-env.ts
+++ b/companion/src/direct/apply-site-env.ts
@@ -38,9 +38,11 @@ function defaultSitesPath(env: NodeJS.ProcessEnv, home: string): string {
 /**
  * When `STONEWRIGHT_SITE_ALIAS` is set, load only that site from the registry
  * and inject `STONEWRIGHT_WP_URL`, `STONEWRIGHT_WP_USERNAME`, and
- * `STONEWRIGHT_WP_APP_PASSWORD` into `env` (overwriting empty values; leaving
- * non-empty explicit env credentials in place when already complete unless
- * `force` is true).
+ * `STONEWRIGHT_WP_APP_PASSWORD` into `env`.
+ *
+ * An explicit alias is authoritative. It always replaces inherited or stale
+ * WordPress environment values so one named client entry cannot start against
+ * a different site's credentials.
  */
 export function applySiteAliasToEnv(
 	env: NodeJS.ProcessEnv = process.env,
@@ -48,7 +50,7 @@ export function applySiteAliasToEnv(
 		sitesFile?: string | undefined;
 		homeDir?: string | undefined;
 		credentials?: CreateCredentialStoreOptions | undefined;
-		/** Overwrite existing STONEWRIGHT_WP_* even when already set. Default false. */
+		/** @deprecated Alias selection is always authoritative. */
 		force?: boolean | undefined;
 	} = {},
 ): ApplySiteAliasResult {
@@ -101,21 +103,6 @@ export function applySiteAliasToEnv(
 		return { applied: false, alias: aliasRaw, injected: false, error };
 	}
 
-	const force = options.force === true;
-	const existingUrl = (env['STONEWRIGHT_WP_URL'] ?? env['WP_API_URL'] ?? '').trim();
-	const existingUser = (env['STONEWRIGHT_WP_USERNAME'] ?? env['WP_API_USERNAME'] ?? '').trim();
-	const existingPass = (
-		env['STONEWRIGHT_WP_APP_PASSWORD'] ??
-		env['STONEWRIGHT_WP_PASSWORD'] ??
-		env['WP_API_PASSWORD'] ??
-		''
-	).trim();
-
-	// When force is off and all three are already present, skip secret resolution.
-	if (!force && existingUrl && existingUser && existingPass) {
-		return { applied: true, alias: site.alias, injected: false };
-	}
-
 	let password: string;
 	try {
 		const resolveOpts: {
@@ -133,25 +120,17 @@ export function applySiteAliasToEnv(
 	} catch (err) {
 		const error = err instanceof Error ? err.message : String(err);
 		log.warn('Failed to resolve credential for site alias', { alias: site.alias, error });
-		// Still inject URL/username so probe/diagnostics can name the site.
-		if (force || !existingUrl) {
-			env['STONEWRIGHT_WP_URL'] = site.canonical_url;
-		}
-		if (force || !existingUser) {
-			env['STONEWRIGHT_WP_USERNAME'] = site.username_hint;
-		}
+		// Name the selected site, but fail closed instead of pairing it with a
+		// password inherited from another MCP entry.
+		env['STONEWRIGHT_WP_URL'] = site.canonical_url;
+		env['STONEWRIGHT_WP_USERNAME'] = site.username_hint;
+		env['STONEWRIGHT_WP_APP_PASSWORD'] = '';
 		return { applied: true, alias: site.alias, injected: false, error };
 	}
 
-	if (force || !existingUrl) {
-		env['STONEWRIGHT_WP_URL'] = site.canonical_url;
-	}
-	if (force || !existingUser) {
-		env['STONEWRIGHT_WP_USERNAME'] = site.username_hint;
-	}
-	if (force || !existingPass) {
-		env['STONEWRIGHT_WP_APP_PASSWORD'] = password;
-	}
+	env['STONEWRIGHT_WP_URL'] = site.canonical_url;
+	env['STONEWRIGHT_WP_USERNAME'] = site.username_hint;
+	env['STONEWRIGHT_WP_APP_PASSWORD'] = password;
 
 	log.info('Applied STONEWRIGHT_SITE_ALIAS to runtime env', {
 		alias: site.alias,

--- a/companion/src/version.ts
+++ b/companion/src/version.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = '1.0.0-beta.5';
+export const APP_VERSION = '1.0.0-beta.6';
 
 export function companionPackageSpec(version: string = APP_VERSION): string {
 	return `https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v${version}/stonewright-companion-${version}.tgz`;

--- a/companion/tests/connect-cli.test.ts
+++ b/companion/tests/connect-cli.test.ts
@@ -183,7 +183,7 @@ describe('connect CLI acceptance matrix', () => {
 		// second client on same site via repair (does not remove the first binding)
 		const repairCode = connectRepair(
 			'site-a',
-			{ client: 'codex' },
+			{ client: 'codex', mode: 'plugin-only' },
 			{
 				sitesFile: h.sitesFile,
 				homeDir: h.homeDir,
@@ -194,9 +194,19 @@ describe('connect CLI acceptance matrix', () => {
 		expect(repairCode).toBe(0);
 
 		const reg = JSON.parse(readFileSync(h.sitesFile, 'utf8')) as {
-			sites: Array<{ clients: Record<string, unknown> }>;
+			sites: Array<{
+				clients: Record<string, unknown>;
+				configured_mode: string;
+				preferred_active_mode: string;
+				fallback_policy: string;
+			}>;
 		};
 		expect(Object.keys(reg.sites[0].clients).sort()).toEqual(['codex', 'cursor']);
+		expect(reg.sites[0]).toEqual(expect.objectContaining({
+			configured_mode: 'plugin-only',
+			preferred_active_mode: 'plugin',
+			fallback_policy: 'never',
+		}));
 
 		// two sites one client (cursor)
 		const cursorCfg2 = join(h.dir, 'cursor-b.json');
@@ -223,6 +233,91 @@ describe('connect CLI acceptance matrix', () => {
 
 		const codexText = readFileSync(codexCfg, 'utf8');
 		expect(codexText).toMatch(/\[mcp_servers\.stonewright-site-a/);
+		expect(codexText).toMatch(/STONEWRIGHT_MODE\s*=\s*"plugin"/);
+	});
+
+	it('repair migrates duplicate legacy aliases and reuses the saved credential', () => {
+		const h = harness();
+		capture();
+		const codexCfg = join(h.dir, '.codex', 'config.toml');
+		writeFileSync(
+			h.sitesFile,
+			JSON.stringify({
+				default: 'site-primary',
+				sites: {
+					'site-primary': {
+						url: 'https://site.example/',
+						username: 'editor',
+							appPassword: 'pass',
+					},
+					'site.example': {
+						url: 'https://site.example',
+						username: 'editor',
+							appPassword: 'p',
+					},
+				},
+			}),
+			'utf8',
+		);
+
+		const code = connectRepair(
+			'site-primary',
+			{ client: 'codex', mode: 'plugin-only' },
+			{
+				sitesFile: h.sitesFile,
+				homeDir: h.homeDir,
+				credentials: h.credentials,
+				clientConfigPath: codexCfg,
+			},
+		);
+
+		expect(code).toBe(0);
+		const registryText = readFileSync(h.sitesFile, 'utf8');
+		const registry = JSON.parse(registryText) as {
+			schema_version: number;
+			sites: Array<{ alias: string; configured_mode: string; clients: Record<string, unknown> }>;
+		};
+		expect(registry.schema_version).toBe(2);
+		expect(registry.sites).toHaveLength(1);
+		expect(registry.sites[0]).toEqual(expect.objectContaining({
+			alias: 'site-primary',
+			configured_mode: 'plugin-only',
+		}));
+		expect(registry.sites[0].clients).toHaveProperty('codex');
+		expect(registryText).not.toContain('appPassword');
+		expect(readFileSync(codexCfg, 'utf8')).toMatch(/STONEWRIGHT_SITE_ALIAS\s*=\s*"site-primary"/);
+	});
+
+	it('repair can change policy without a client binding or password prompt', async () => {
+		const h = harness();
+		capture();
+		await connectAdd(
+			{
+				alias: 'manual-client',
+				url: 'https://manual.example/',
+				username: 'editor',
+					password: 'pass',
+				mode: 'auto',
+			},
+			{ sitesFile: h.sitesFile, homeDir: h.homeDir, credentials: h.credentials, skipAuth: true },
+		);
+
+		const code = connectRepair(
+			'manual-client',
+			{ mode: 'plugin-only' },
+			{ sitesFile: h.sitesFile, homeDir: h.homeDir, credentials: h.credentials },
+		);
+
+		expect(code).toBe(0);
+		const registry = JSON.parse(readFileSync(h.sitesFile, 'utf8')) as {
+			sites: Array<{ configured_mode: string; preferred_active_mode: string; fallback_policy: string }>;
+		};
+		expect(registry.sites[0]).toEqual(expect.objectContaining({
+			configured_mode: 'plugin-only',
+			preferred_active_mode: 'plugin',
+			fallback_policy: 'never',
+		}));
+		expect(logs.join('')).toContain('no client binding changed');
 	});
 
 	it('remove one site without touching another', async () => {

--- a/companion/tests/connect-registry.test.ts
+++ b/companion/tests/connect-registry.test.ts
@@ -283,6 +283,46 @@ describe('multi-site registry schema v2', () => {
 		expect(config.sites['site-b']?.appPassword).toBe('');
 	});
 
+	it('collapses legacy aliases that point at the same canonical site', () => {
+		const { file, store } = tmpSites();
+		writeFileSync(
+			file,
+			JSON.stringify({
+				default: 'local',
+				sites: {
+					local: {
+						url: 'http://local.example/',
+						username: 'local-user',
+						appPassword: 'pass',
+					},
+					'site-primary': {
+						url: 'https://site.example/',
+						username: 'editor',
+						appPassword: 'p',
+					},
+					'site.example': {
+						url: 'https://site.example',
+						username: 'editor',
+						appPassword: 'q',
+					},
+				},
+			}),
+			'utf8',
+		);
+
+		const result = migrateSitesFile({
+			sitesFile: file,
+			credentials: { store, prefer: 'memory', allowMemoryFallback: true },
+		});
+		expect(result.site_count).toBe(2);
+		const raw = JSON.parse(readFileSync(file, 'utf8')) as {
+			sites: Array<{ alias: string; canonical_url: string }>;
+		};
+		expect(raw.sites.map((site) => site.alias)).toEqual(['local', 'site-primary']);
+		expect(raw.sites.filter((site) => site.canonical_url === 'https://site.example')).toHaveLength(1);
+		expect(JSON.stringify(raw)).not.toContain('appPassword');
+	});
+
 	it('stops migration and leaves original file when secure store unavailable', () => {
 		const { file } = tmpSites();
 		const original = {
@@ -398,6 +438,69 @@ describe('multi-site registry schema v2', () => {
 		expect(env.STONEWRIGHT_WP_APP_PASSWORD).toBe('secret-b-only');
 		// Must not have pulled site-a secret into env.
 		expect(env.STONEWRIGHT_WP_APP_PASSWORD).not.toBe('secret-a-only');
+	});
+
+	it('explicit site alias replaces a complete stale WordPress environment', () => {
+		const { file, store } = tmpSites();
+		const ref = 'memory://stonewright/site-b/app-password';
+		store.set(ref, 'secret-b-only');
+		const site = buildSiteRecord({
+			alias: 'site-b',
+			url: 'https://site-b.example/',
+			username: 'editor-b',
+			credential_ref: ref,
+		});
+		saveRegistry(
+			{ schema_version: 2, default_site_id: site.id, sites: [site] },
+			{ sitesFile: file },
+		);
+
+		const env: NodeJS.ProcessEnv = {
+			STONEWRIGHT_SITE_ALIAS: 'site-b',
+			STONEWRIGHT_WP_URL: 'https://stale.example',
+			STONEWRIGHT_WP_USERNAME: 'stale-user',
+			STONEWRIGHT_WP_APP_PASSWORD: 'pass',
+		};
+		const result = applySiteAliasToEnv(env, {
+			sitesFile: file,
+			credentials: { store, prefer: 'memory' },
+		});
+
+		expect(result).toEqual(expect.objectContaining({ applied: true, injected: true, alias: 'site-b' }));
+		expect(env.STONEWRIGHT_WP_URL).toBe('https://site-b.example');
+		expect(env.STONEWRIGHT_WP_USERNAME).toBe('editor-b');
+		expect(env.STONEWRIGHT_WP_APP_PASSWORD).toBe('secret-b-only');
+	});
+
+	it('explicit alias clears a stale password when its credential cannot resolve', () => {
+		const { file, store } = tmpSites();
+		const site = buildSiteRecord({
+			alias: 'site-b',
+			url: 'https://site-b.example/',
+			username: 'editor-b',
+			credential_ref: 'memory://stonewright/site-b/missing-password',
+		});
+		saveRegistry(
+			{ schema_version: 2, default_site_id: site.id, sites: [site] },
+			{ sitesFile: file },
+		);
+		const env: NodeJS.ProcessEnv = {
+			STONEWRIGHT_SITE_ALIAS: 'site-b',
+			STONEWRIGHT_WP_URL: 'https://stale.example',
+			STONEWRIGHT_WP_USERNAME: 'stale-user',
+			STONEWRIGHT_WP_APP_PASSWORD: 'pass',
+		};
+
+		const result = applySiteAliasToEnv(env, {
+			sitesFile: file,
+			credentials: { store, prefer: 'memory' },
+		});
+
+		expect(result).toEqual(expect.objectContaining({ applied: true, injected: false, alias: 'site-b' }));
+		expect(result.error).toBeTruthy();
+		expect(env.STONEWRIGHT_WP_URL).toBe('https://site-b.example');
+		expect(env.STONEWRIGHT_WP_USERNAME).toBe('editor-b');
+		expect(env.STONEWRIGHT_WP_APP_PASSWORD).toBe('');
 	});
 
 	it('normal v2 save may keep backup; migration never leaves plaintext bak', () => {

--- a/docs/admin/configuration.md
+++ b/docs/admin/configuration.md
@@ -41,6 +41,11 @@ and verifies the same Step 1 transaction. The no-JavaScript form still uses
 **Save Settings**. A connected client sees the new state through the surface
 revision/re-list contract described below.
 
+The Settings API form contains only Step 1 settings. Domain-lock rebind,
+rollback, and clear actions are rendered in a separate action panel outside
+that form. After a no-JavaScript save, WordPress redirects back to
+**Stonewright → Setup**; `/wp-admin/options.php` is never the final page.
+
 ### Mode selector
 
 Three modes are stored in the `stonewright_mode` option:
@@ -78,7 +83,10 @@ real change bumps one monotonic surface revision. Transport truth:
   `task-start` or `tool-profile` response and emit `tools/list_changed`; older
   companions need a client restart.
 
-Generated stdio snippets and paste-to-agent prompts use the saved surface
+Generated stdio snippets use explicit Plugin mode. Paste-to-agent prompts use
+the alias-based installer with `--mode plugin-only`, keep OAuth HTTP as a
+separately named transport, and use `connect repair --mode` to reuse an existing
+credential without creating a duplicate alias. Both flows use the saved surface
 instead of silently replacing an explicit `bootstrap` or `full` choice.
 Strict-cap clients keep the explicit `low-tools` override. Set
 `STONEWRIGHT_MCP_TOOL_PROFILE_LOCK=1` only when a client-specific profile must
@@ -182,30 +190,15 @@ Windsurf, Cline, Gemini CLI, Roo Code, Amazon Q, Zed, Kilo Code, and OpenCode.
 
 For example: `https://example.com/wp-json/mcp/stonewright`.
 
-### Recommended config block
+### Recommended installer
 
 Most local MCP clients can launch the companion through `npx` without a global
-install:
+install. Use `stonewright connect add` with a unique alias, target client, and
+`--mode plugin-only`; the installer writes an alias-specific server entry and
+keeps the Application Password in the OS credential store. Use `connect repair
+<alias> --client <client> --mode plugin-only` when the alias already exists.
 
-```json
-{
-  "mcpServers": {
-    "stonewright": {
-      "command": "npx",
-      "args": ["-y", "--package", "https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz", "stonewright-mcp"],
-      "env": {
-        "STONEWRIGHT_WP_URL": "https://example.com",
-        "STONEWRIGHT_WP_USERNAME": "your-wp-username",
-        "STONEWRIGHT_WP_APP_PASSWORD": "xxxx xxxx xxxx xxxx xxxx xxxx",
-        "STONEWRIGHT_MCP_TOOL_PROFILE": "essential"
-      }
-    }
-  }
-}
-```
-
-Use the WordPress URL, username, and Application Password from Cards 2 and 3.
-The `STONEWRIGHT_MCP_TOOL_PROFILE=essential` env value gives known clients a
+The `essential` profile gives known clients a
 bounded working surface from their first session. Unknown clients should use
 `essential-static`; `bootstrap` is an explicit diagnostic, not an install
 default.

--- a/docs/admin/connect-clients.md
+++ b/docs/admin/connect-clients.md
@@ -48,6 +48,9 @@ family and all access tokens for that grant.
 
 Direct mode requires local stdio because Direct is implemented by the
 companion. A plugin-only remote HTTP connection does not use the companion.
+Treat OAuth HTTP and local stdio as separate named connections; never merge
+them under one generic server entry. In stdio, `STONEWRIGHT_SITE_ALIAS` is the
+routing authority and replaces stale inherited WordPress environment values.
 
 ## Application Password fallback
 
@@ -93,27 +96,29 @@ HTTP Authorization header. For local development with no HTTPS, set
 
 ## Recommended stdio config
 
-Most clients can run the Stonewright companion with `npx`:
+Use the versioned installer. It creates an alias-specific server entry and
+keeps the Application Password in the OS credential store instead of copying
+it into every client configuration. Because this guide starts from an installed
+plugin, `plugin-only` is the correct policy:
 
-Replace `VERSION` with the exact release version without a leading `v`, as
-shown on the GitHub Releases page.
-
-```json
-{
-  "mcpServers": {
-    "stonewright": {
-      "command": "npx",
-      "args": ["-y", "--package", "https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz", "stonewright-mcp"],
-      "env": {
-        "STONEWRIGHT_WP_URL": "https://your-site.com",
-        "STONEWRIGHT_WP_USERNAME": "your-wp-username",
-        "STONEWRIGHT_WP_APP_PASSWORD": "xxxx xxxx xxxx xxxx xxxx xxxx",
-        "STONEWRIGHT_MCP_TOOL_PROFILE": "essential"
-      }
-    }
-  }
-}
+```bash
+npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz stonewright connect add \
+  --alias site-a --url https://site-a.example --username editor \
+  --env production --mode plugin-only --client codex \
+  --plugin-enabled yes --wp-mode production-safe --wp-surface essential
 ```
+
+If `site-a` already exists, do not register another alias or request the
+password again:
+
+```bash
+npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz stonewright connect repair site-a --client codex --mode plugin-only
+```
+
+Restart the client and run `stonewright connect verify site-a --client codex`.
+The result must identify the requested alias, `configured_mode=plugin-only`,
+`active_mode=plugin`, task-start/status, and the expected companion. If it
+identifies another site or Direct mode, stop; the wrong named entry is active.
 
 Generated configurations for known clients use the bounded working profile
 `essential`; `essential-static` is the fallback for an unknown client that may
@@ -180,24 +185,11 @@ by the companion.
 
 Codex CLI and the Codex IDE extension share MCP config from
 `~/.codex/config.toml`. Trusted projects can also use `.codex/config.toml`.
-Add Stonewright as a stdio MCP server:
+Use the installer above with `--client codex`; it writes the alias-specific
+TOML block transactionally. Do not paste a second generic block by hand.
 
-```toml
-[mcp_servers.stonewright]
-command = "npx"
-args = ["-y", "--package", "https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz", "stonewright-mcp"]
-
-[mcp_servers.stonewright.env]
-STONEWRIGHT_WP_URL = "https://your-site.com"
-STONEWRIGHT_WP_USERNAME = "your-wp-username"
-STONEWRIGHT_WP_APP_PASSWORD = "xxxx xxxx xxxx xxxx xxxx xxxx"
-STONEWRIGHT_MCP_TOOL_PROFILE = "essential"
-```
-
-In the Codex IDE extension, open the gear menu, choose **Codex Settings >
-Open config.toml**, paste the block, save, then restart Codex or reload the MCP
-session. In the Codex TUI, use `/mcp` after restart to confirm `stonewright` is
-active.
+Restart Codex or reload the MCP session. In the Codex TUI, use `/mcp` after
+restart to confirm the named Stonewright entry is active.
 
 After every Stonewright release or skill sync, run `stonewright-setup-profile`
 and `stonewright-wordpress-mcp-status`. Check `companion_version`,
@@ -215,7 +207,8 @@ matrix, replacement steps, and persistence guarantees.
 Claude Code registers MCP servers through its CLI:
 
 ```bash
-claude mcp add stonewright \
+claude mcp add stonewright-site-a \
+  --env STONEWRIGHT_MODE=plugin \
   --env STONEWRIGHT_WP_URL='https://your-site.com' \
   --env STONEWRIGHT_WP_USERNAME='your-wp-username' \
   --env STONEWRIGHT_WP_APP_PASSWORD='xxxx xxxx xxxx xxxx xxxx xxxx' \
@@ -256,10 +249,11 @@ VS Code-style clients use a `servers` top-level key instead of `mcpServers`:
 ```json
 {
   "servers": {
-    "stonewright": {
+    "stonewright-site-a": {
       "command": "npx",
       "args": ["-y", "--package", "https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz", "stonewright-mcp"],
       "env": {
+        "STONEWRIGHT_MODE": "plugin",
         "STONEWRIGHT_WP_URL": "https://your-site.com",
         "STONEWRIGHT_WP_USERNAME": "your-wp-username",
         "STONEWRIGHT_WP_APP_PASSWORD": "xxxx xxxx xxxx xxxx xxxx xxxx",
@@ -275,11 +269,12 @@ Zed uses `context_servers`:
 ```json
 {
   "context_servers": {
-    "stonewright": {
+    "stonewright-site-a": {
       "command": {
         "path": "npx",
         "args": ["-y", "--package", "https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz", "stonewright-mcp"],
         "env": {
+          "STONEWRIGHT_MODE": "plugin",
           "STONEWRIGHT_WP_URL": "https://your-site.com",
           "STONEWRIGHT_WP_USERNAME": "your-wp-username",
           "STONEWRIGHT_WP_APP_PASSWORD": "xxxx xxxx xxxx xxxx xxxx xxxx",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -72,7 +72,18 @@ flowchart TD
 The registry enforces one alias per site and one `(canonical URL, environment)`
 record. Client configs contain the alias, never the Application Password. At
 startup the companion resolves only the bound alias, then loads that record's
-credential. Add, repair, and remove operations snapshot client configuration;
+credential. The explicit alias is authoritative: URL, username, and password
+from that record replace inherited `STONEWRIGHT_WP_*` values before mode
+resolution and plugin probing. If secret resolution fails, startup clears the
+selected password and fails closed instead of pairing one site's URL with
+another site's credential.
+
+Legacy v1 registries may contain several aliases for one endpoint. Secure
+migration collapses each duplicate group before schema v2 is written, retaining
+the configured default alias for that group or its first stable alias. `connect
+repair --mode` reuses the selected alias's credential while updating its mode,
+fallback policy, plugin expectation, and client binding. Add, repair, and remove
+operations snapshot client configuration;
 if registry persistence fails, the exact previous file and newly written
 credential state are restored. `connect verify --client` reads the saved entry,
 spawns it through MCP stdio, lists tools, calls `stonewright-task-start` and

--- a/docs/getting-started/antigravity.md
+++ b/docs/getting-started/antigravity.md
@@ -40,12 +40,20 @@ In Antigravity IDE you can also open it from the agent panel:
 ## 3. Add Stonewright
 
 Use the latest release tarball shown by the Stonewright Configuration page.
-Replace `VERSION` with the exact release version without a leading `v`:
+First register the alias and credential through the hidden installer prompt:
+
+```bash
+npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz stonewright connect add \
+  --alias site-a --url https://site-a.example --username editor \
+  --mode plugin-only --profile low-tools --plugin-enabled yes
+```
+
+Then add the secret-free named entry:
 
 ```json
 {
   "mcpServers": {
-    "stonewright": {
+    "stonewright-site-a": {
       "command": "npx",
       "args": [
         "-y",
@@ -54,15 +62,17 @@ Replace `VERSION` with the exact release version without a leading `v`:
         "stonewright-mcp"
       ],
       "env": {
-        "STONEWRIGHT_WP_URL": "https://your-site.example.com",
-        "STONEWRIGHT_WP_USERNAME": "your-wp-username",
-        "STONEWRIGHT_WP_APP_PASSWORD": "xxxx xxxx xxxx xxxx xxxx xxxx",
+        "STONEWRIGHT_SITE_ALIAS": "site-a",
+        "STONEWRIGHT_MODE": "plugin",
         "STONEWRIGHT_MCP_TOOL_PROFILE": "low-tools"
       }
     }
   }
 }
 ```
+
+If the alias already exists, run `stonewright connect repair site-a --mode
+plugin-only`; do not add another alias or request the password again.
 
 For local WordPress sites, add `STONEWRIGHT_WP_ROOT` only when you want
 path-scoped WP-CLI discovery and local credential helpers:
@@ -101,8 +111,9 @@ stonewright-wp-cli-job-status
 Use this smoke test before asking for site changes:
 
 ```text
-Use Stonewright. First call stonewright-setup-profile, then verify
-stonewright-task-start or compatibility stonewright-context-bootstrap is visible.
+Use Stonewright. Verify stonewright-task-start or compatibility
+stonewright-context-bootstrap is visible, then call stonewright-task-start first.
+After task-start, call stonewright-setup-profile.
 If Stonewright is not connected, call stonewright-wordpress-mcp-status and stop
 with the exact missing config value. Do not inspect private client config
 files, create scratch helper scripts, create helper JSON argument files, launch

--- a/docs/getting-started/claude-code.md
+++ b/docs/getting-started/claude-code.md
@@ -21,7 +21,8 @@ about five minutes.
   DesignSpec, php-execute, confirmation tokens, and shared site skills/memory.
   Plugin ability inventory: [ability-truth-matrix.md](../ability-truth-matrix.md).
 
-The companion auto-detects mode (`STONEWRIGHT_MODE=direct|plugin` overrides).
+Use an explicit saved policy: `direct-only` without the plugin and
+`plugin-only` when the plugin is installed.
 
 ## Fastest start (Direct mode)
 
@@ -32,17 +33,20 @@ app-password UI), then register Stonewright.
 Replace `VERSION` with the exact release version without a leading `v`:
 
 ```bash
-claude mcp add stonewright \
-  --env STONEWRIGHT_WP_URL='https://your-site.example.com' \
-  --env STONEWRIGHT_WP_USERNAME='your-wp-username' \
-  --env STONEWRIGHT_WP_APP_PASSWORD='xxxx xxxx xxxx xxxx xxxx xxxx' \
-  --env STONEWRIGHT_DIRECT_WRITES=confirm \
+npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz stonewright connect add \
+  --alias site-a --url https://site-a.example --username editor \
+  --mode direct-only
+
+claude mcp add stonewright-site-a \
+  --env STONEWRIGHT_SITE_ALIAS=site-a \
   --env STONEWRIGHT_MODE=direct \
+  --env STONEWRIGHT_MCP_TOOL_PROFILE=essential \
   -- npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz stonewright-mcp
 ```
 
-Optional: omit `STONEWRIGHT_MODE=direct` to let the companion auto-detect (plugin
-endpoint present → plugin proxy; HTTP 404 → Direct).
+The installer requests the password through a hidden prompt and stores it
+outside Claude's config. The named Claude entry contains only the alias and
+mode policy.
 
 Claude Code is a **tier-1 certification target**. Keep Application Passwords in the
 CLI env / private config only — not in chat.
@@ -105,13 +109,20 @@ Register Stonewright. Replace `VERSION` with the exact release version without
 a leading `v`:
 
 ```bash
-claude mcp add stonewright \
-  --env STONEWRIGHT_WP_URL='https://your-site.example.com' \
-  --env STONEWRIGHT_WP_USERNAME='your-wp-username' \
-  --env STONEWRIGHT_WP_APP_PASSWORD='xxxx xxxx xxxx xxxx xxxx xxxx' \
+npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz stonewright connect add \
+  --alias site-a --url https://site-a.example --username editor \
+  --mode plugin-only --plugin-enabled yes --wp-surface essential
+
+claude mcp add stonewright-site-a \
+  --env STONEWRIGHT_SITE_ALIAS=site-a \
+  --env STONEWRIGHT_MODE=plugin \
   --env STONEWRIGHT_MCP_TOOL_PROFILE=essential \
   -- npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz stonewright-mcp
 ```
+
+If `site-a` already exists, run `stonewright connect repair site-a --mode
+plugin-only` to update its saved policy, then rerun the secret-free `claude mcp
+add` command above. Do not create another alias or ask for the password again.
 
 Add `--env STONEWRIGHT_WP_ROOT='...'` only when you want WP-CLI helper tools or
 LocalWP discovery. The value is the absolute WordPress install folder

--- a/docs/getting-started/codex.md
+++ b/docs/getting-started/codex.md
@@ -6,25 +6,28 @@ trusted project when the Stonewright connection should be project-specific.
 
 ## Add Stonewright
 
-Open `config.toml` and add the following. Replace `VERSION` with the exact
-release version without a leading `v`:
+Use the versioned installer. It creates a collision-safe alias-specific TOML
+entry and keeps the Application Password in the OS credential store:
 
-```toml
-[mcp_servers.stonewright]
-command = "npx"
-args = ["-y", "--package", "https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz", "stonewright-mcp"]
-
-[mcp_servers.stonewright.env]
-STONEWRIGHT_WP_URL = "https://your-site.com"
-STONEWRIGHT_WP_USERNAME = "your-wp-username"
-STONEWRIGHT_WP_APP_PASSWORD = "xxxx xxxx xxxx xxxx xxxx xxxx"
-STONEWRIGHT_MCP_TOOL_PROFILE = "essential"
+```bash
+npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz stonewright connect add \
+  --alias site-a --url https://site-a.example --username editor \
+  --env production --mode plugin-only --client codex \
+  --plugin-enabled yes --wp-mode production-safe --wp-surface essential
 ```
 
-For strict tool-cap sessions, use:
+The hidden prompt keeps the password off argv and shell history. Do not add a
+second generic `[mcp_servers.stonewright]` block. If the alias already exists,
+reuse its saved credential:
 
-```toml
-STONEWRIGHT_MCP_TOOL_PROFILE = "low-tools"
+```bash
+npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz stonewright connect repair site-a --client codex --mode plugin-only
+```
+
+For strict tool-cap sessions, add this installer option:
+
+```text
+--profile low-tools
 ```
 
 Codex is a **tier-1 certification target**
@@ -33,16 +36,18 @@ user-level or private config; never paste real Application Passwords into chat.
 
 ## Make Codex See It
 
-After saving the config, **restart Codex or reload the IDE MCP session** (required
+After installation, **restart Codex or reload the IDE MCP session** (required
 for tool list refresh). In the Codex TUI, run `/mcp` and confirm `stonewright`
-is listed.
+alias entry is listed. Then run `stonewright connect verify site-a --client
+codex`; require the same alias, Plugin mode, the expected companion, task-start,
+status, and no missing required tools.
 
 Then call:
 
 ```text
+stonewright-task-start
 stonewright-setup-profile
 stonewright-wordpress-mcp-status
-stonewright-task-start
 ```
 
 `stonewright-task-start` is the canonical first WordPress call. If neither it
@@ -67,6 +72,7 @@ Check these fields:
 | `expected_companion_package` | The release tarball the config should point to. |
 | `refresh_required_tool_names` | Required tools that prove the visible tool list is current. |
 
-If the version or package is old, update the `args` package URL in
-`config.toml`, save, and restart Codex. If required tools are missing, restart
-or reload the MCP session so Codex refreshes the tool list.
+If the version or package is old, rerun the versioned `connect repair` command,
+then restart Codex. If required tools are missing, reload the MCP session so
+Codex refreshes the tool list. Never copy the alias entry to a generic server
+name: that reintroduces cross-site ambiguity.

--- a/docs/getting-started/cursor.md
+++ b/docs/getting-started/cursor.md
@@ -27,48 +27,24 @@ JSON; manual smoke pending until a
   confirmation tokens, shared site skills/memory. Ability inventory:
   [ability-truth-matrix.md](../ability-truth-matrix.md).
 
-The companion auto-detects mode (`STONEWRIGHT_MODE=direct|plugin` overrides).
+Use an explicit saved policy: `direct-only` without the plugin and
+`plugin-only` when the plugin is installed. Reserve auto-detection for a
+connection where Direct fallback is intentional.
 
 ## Fastest start (Direct mode)
 
 Generate a WordPress Application Password, then add Stonewright to Cursor.
 
-Config file (user-level recommended for secrets):
+Use the installer so Cursor receives an alias-specific, secret-free entry:
 
-```text
-~/.cursor/mcp.json
+```bash
+npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz stonewright connect add \
+  --alias site-a --url https://site-a.example --username editor \
+  --mode direct-only --client cursor
 ```
 
-Project-local alternative: `.cursor/mcp.json` (do not commit secrets).
-
-Replace `VERSION` with the exact release version without a leading `v`:
-
-```json
-{
-  "mcpServers": {
-    "stonewright": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "--package",
-        "https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz",
-        "stonewright-mcp"
-      ],
-      "env": {
-        "STONEWRIGHT_WP_URL": "https://your-site.example.com",
-        "STONEWRIGHT_WP_USERNAME": "your-wp-username",
-        "STONEWRIGHT_WP_APP_PASSWORD": "xxxx xxxx xxxx xxxx xxxx xxxx",
-        "STONEWRIGHT_DIRECT_WRITES": "confirm",
-        "STONEWRIGHT_MODE": "direct"
-      }
-    }
-  }
-}
-```
-
-Optional: omit `STONEWRIGHT_MODE` for auto-detect, or set
-`STONEWRIGHT_MCP_TOOL_PROFILE` to `essential` for the normal bounded working
-surface or `low-tools` for a strict tool-cap client. Bootstrap is a diagnostic,
+Use `--profile essential` for the normal bounded working surface or
+`--profile low-tools` for a strict tool-cap client. Bootstrap is a diagnostic,
 not a permanent Cursor default.
 
 **Restart Cursor or reload MCP servers** (required). Smoke test:
@@ -91,36 +67,19 @@ Copy-paste Option B: [install-prompts.md](../install-prompts.md).
    under `wp-content/plugins`).
 2. Open **Stonewright > Configuration**, enable abilities, choose operating
    mode, and generate an Application Password.
-3. Use the same `mcpServers.stonewright` JSON shape as Direct mode, but drop
-   `STONEWRIGHT_MODE=direct` (or set `plugin` / leave auto) and set:
+3. Register an alias-specific Plugin connection:
 
-```json
-"STONEWRIGHT_MCP_TOOL_PROFILE": "essential"
+```bash
+npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz stonewright connect add \
+  --alias site-a --url https://site-a.example --username editor \
+  --mode plugin-only --client cursor --profile essential \
+  --plugin-enabled yes --wp-surface essential
 ```
 
-Example (plugin-oriented env block):
-
-```json
-{
-  "mcpServers": {
-    "stonewright": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "--package",
-        "https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz",
-        "stonewright-mcp"
-      ],
-      "env": {
-        "STONEWRIGHT_WP_URL": "https://your-site.example.com",
-        "STONEWRIGHT_WP_USERNAME": "your-wp-username",
-        "STONEWRIGHT_WP_APP_PASSWORD": "xxxx xxxx xxxx xxxx xxxx xxxx",
-        "STONEWRIGHT_MCP_TOOL_PROFILE": "essential"
-      }
-    }
-  }
-}
-```
+If the alias exists, run `stonewright connect repair site-a --client cursor
+--mode plugin-only`; it reuses the saved credential and updates only that named
+entry. Restart Cursor, then require `connect verify` to report the same alias
+and `active_mode=plugin`.
 
 Add `STONEWRIGHT_WP_ROOT` only when you want path-scoped WP-CLI / LocalWP
 discovery. Use the WordPress install folder that contains `wp-config.php`, not

--- a/docs/install-prompts.md
+++ b/docs/install-prompts.md
@@ -51,28 +51,39 @@ WordPress password.
 ```text
 Configure the Stonewright MCP server for my WordPress site in this AI client.
 
-Prefer the versioned `stonewright connect add` installer. Ask me for a unique
-site alias, environment, Plugin/Direct policy, WordPress mode, MCP tool surface,
-Elementor V4 choice, and target client. Ask once for a browser provider and ask
-separately before scanning client configuration or installing anything. Store
-those choices per site/client. Use a hidden password prompt or --password-env;
-never put a password on argv. After I restart the client, run
-`stonewright connect verify <alias> --client <client>` and require spawned task-start/status
-proof, not only a valid config file.
+Choose exactly one transport for this site. Do not combine local stdio and
+OAuth HTTP under the same server name.
 
-Connection values (I will provide secrets when asked):
-- WordPress URL: <https://example.com>
-- MCP server name: stonewright
-- Transport: command `npx`, args ["-y", "--package", "https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz", "stonewright-mcp"]
-- Env vars only (never inline secrets in args): STONEWRIGHT_WP_URL,
-  STONEWRIGHT_WP_USERNAME, STONEWRIGHT_WP_APP_PASSWORD,
-  STONEWRIGHT_MCP_TOOL_PROFILE=essential (normal bounded working profile; use
-  essential-static only for an unknown client with stale tool-list behavior,
-  or low-tools for a strict tool cap).
-- I will supply secrets only into private client config. Do not ask me to paste
-  real Application Passwords or OAuth tokens into chat.
+For local stdio, use the versioned installer with a unique alias, a
+collision-safe named server, and --mode plugin-only. Ask for the environment,
+WordPress mode, MCP surface, Elementor V4 choice, and target client. Let the
+installer request the Application Password through its hidden prompt, or use
+--password-env with a temporary variable; never put a password on argv.
+
+npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz stonewright connect add --alias <unique-alias> --url <your-wordpress-url> --username <your-wordpress-username> --env <environment> --mode plugin-only --client <client> --profile essential --plugin-enabled yes --wp-mode <development|staging|production-safe> --wp-surface essential --elementor-v4 <yes|no>
+
+I will replace private placeholders locally. Do not create or overwrite a
+generic server named stonewright. If the alias already exists, reuse its saved
+credential without asking for the password again:
+
+npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz stonewright connect repair <alias> --client <client> --mode plugin-only
+
+For remote OAuth HTTP instead, create a separately named connection to
+<your-wordpress-url>/wp-json/mcp/stonewright-oauth. That transport connects
+directly to the plugin and does not run the companion.
+
+Ask once for a browser provider and ask separately before scanning client
+configuration or installing anything. Store those choices per site/client.
+Never inspect or print private configuration. After I restart the client, run
+stonewright connect verify <alias> --client <client> for local stdio and require
+spawned runtime proof, not only a valid config file.
 
 After a client-specific restart / MCP reload (not only a chat refresh):
+- Verify stonewright-task-start is in the tool list; if missing, stop and tell me.
+- Call stonewright-task-start first with a non-empty task, surface, and intent.
+- Require the requested alias, configured_mode=plugin-only, active_mode=plugin,
+  and the expected companion version. If another site or Direct mode appears,
+  stop because the wrong named server is active.
 - Call stonewright-setup-profile and stonewright-wordpress-mcp-status.
 - Confirm companion_version matches VERSION, the WordPress MCP endpoint is
   authenticated, and refresh_required_tool_names is empty.
@@ -80,8 +91,6 @@ After a client-specific restart / MCP reload (not only a chat refresh):
 - If OAuth header delivery is in doubt, call the read-only
   `stonewright-oauth-header-diagnostic`; it returns booleans only and never
   returns a header or token fragment.
-- Verify stonewright-task-start is in the tool list; if missing, stop and tell me.
-- Start every WordPress task with stonewright-task-start.
 - Follow the returned skills, memory, expertise, and fast_path.tool_profile.
 - Task start returns a native rule digest, not the rule bodies. Read them once
   with stonewright-rules-get, cache them, and pass knownDigest on later calls so
@@ -149,23 +158,27 @@ before scanning and before installing/configuring a provider, save those
 choices for this site/client, and never infer consent. After restart, run
 `stonewright connect verify <alias> --client <client>`; require the spawned
 companion version, active alias, task-start, status, and required tool surface.
+For a non-local site, keep `STONEWRIGHT_DIRECT_WRITES=confirm` so every Direct
+mutation still needs the explicit per-call confirmation.
 
-Connection values (I will provide secrets when asked):
-- WordPress URL: <https://example.com>
-- MCP server name: stonewright
-- Transport: command `npx`, args ["-y", "--package", "https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz", "stonewright-mcp"]
-- Env vars only: STONEWRIGHT_WP_URL, STONEWRIGHT_WP_USERNAME,
-  STONEWRIGHT_WP_APP_PASSWORD, STONEWRIGHT_DIRECT_WRITES=confirm
-  (use `on` only where unconfirmed writes are acceptable; multi-site via ~/.stonewright/sites.json).
-  Optional: STONEWRIGHT_MODE=direct to force Direct mode.
+Use this versioned installer shape and let it create the alias-specific named
+entry. Do not build a second generic server entry:
+
+npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz stonewright connect add --alias <unique-alias> --url <your-wordpress-url> --username <your-wordpress-username> --env <environment> --mode direct-only --client <client>
+
+I will replace private placeholders locally. Use the hidden password prompt or
+--password-env, never a password on argv. If the alias already exists, run
+stonewright connect repair <alias> --client <client> --mode direct-only and
+reuse its saved credential.
 
 After reload:
+- Verify stonewright-task-start is in the tool list; if missing, stop and tell me.
+- Call stonewright-task-start first with a non-empty task, surface, and intent.
 - Call stonewright-setup-profile and stonewright-wordpress-mcp-status.
 - Confirm mode is Direct, companion_version matches VERSION, and capability
   gaps are reported honestly rather than silently falling back.
-- Verify stonewright-task-start is in the tool list; if missing, stop and tell me.
-- Start every WordPress task with stonewright-task-start — in Direct mode it
-  returns this site's locally stored skills and memory (or _global).
+- In Direct mode task-start returns this site's locally stored skills and
+  memory (or _global).
 - Task start returns a native rule digest. Read the rules once with
   stonewright-rules-get (on the Direct bootstrap surface), cache them, and pass
   knownDigest afterwards. Direct mode ships the same registry as the plugin, so

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -70,6 +70,9 @@ Set Application Password credentials and point at the site URL. With
 - HTTP 404 → Direct mode (100 tools in the current full surface)
 
 Force either path with `STONEWRIGHT_MODE=direct` or `STONEWRIGHT_MODE=plugin`.
+For an installed-plugin connection, prefer the alias-based installer with
+`--mode plugin-only`; `auto` is appropriate only when intentional Direct
+fallback is part of the connection policy.
 
 ```json
 {
@@ -106,7 +109,7 @@ npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/
   --username editor \
   --password-env STONEWRIGHT_TMP_APP_PASSWORD \
   --env staging \
-  --mode auto \
+  --mode plugin-only \
   --plugin-enabled yes \
   --wp-mode staging \
   --wp-surface essential \
@@ -121,7 +124,19 @@ Prefer interactive password entry or `--password-env VAR` (avoid `--password` on
 argv). Schema v2 stores only metadata and a `credential_ref` in
 `~/.stonewright/sites.json`; secrets live in the OS credential store (or
 `env://VAR`). Client config sets `STONEWRIGHT_SITE_ALIAS` only — the companion
-resolves URL and credentials for that alias at startup.
+resolves URL and credentials for that alias at startup. The alias is
+authoritative and replaces stale inherited `STONEWRIGHT_WP_*` values.
+
+If the alias already exists, reuse its saved credential and change the mode or
+client binding without creating a duplicate:
+
+```bash
+npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz stonewright connect repair site-a --client cursor --mode plugin-only
+```
+
+Secure v1 migration collapses repeated aliases for one canonical
+URL/environment before v2 is written. It keeps the configured default alias
+for that group, or the first stable alias when none is default.
 
 The WordPress Step 1 choices and browser consent are retained per site/client;
 `recommended` records Playwright as the external default without embedding it;
@@ -165,28 +180,18 @@ WordPress Application Password. The setup diagnostics panel blocks a green
 status when HTTPS, Application Passwords, the endpoint, or the 20-tool budget
 is missing.
 
-Fastest MCP-client setup uses `npx`, so Windows, macOS, and Linux do not need a
-shell wrapper, global install, or manual bridge:
+Fastest MCP-client setup uses the alias installer, so Windows, macOS, and Linux
+do not need a shell wrapper, global install, duplicate server block, or secret
+inside the client file:
 
-```json
-{
-  "mcpServers": {
-    "stonewright": {
-      "command": "npx",
-      "args": ["-y", "--package", "https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz", "stonewright-mcp"],
-      "env": {
-        "STONEWRIGHT_WP_URL": "http://mcp-test.local",
-        "STONEWRIGHT_WP_ROOT": "/absolute/path/to/wordpress",
-        "STONEWRIGHT_WP_APP_PASSWORD_AUTO": "local-only",
-        "STONEWRIGHT_MCP_TOOL_PROFILE": "essential"
-      }
-    }
-  }
-}
+```bash
+npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz stonewright connect add \
+  --alias local-site --url http://local-site.test --username editor \
+  --env local --mode direct-only --client cursor
 ```
 
 After adding the server, perform the **client-specific restart / MCP reload**,
-then call `stonewright-setup-profile`. It returns copy-paste MCP config,
+call `stonewright-task-start` first, then call `stonewright-setup-profile`. It returns copy-paste MCP config,
 platform checks, credential status, and notes for the current machine. Paste
 blocks stay credential-free; put real secrets only in private user-level client
 config. For local `.local` or `.test` sites, the companion can create one
@@ -219,8 +224,8 @@ For Antigravity 2.0, Antigravity IDE, and Antigravity CLI, use
 [Antigravity setup guide](getting-started/antigravity.md).
 For Codex CLI or the Codex IDE extension, use
 [`~/.codex/config.toml`](getting-started/codex.md) or a trusted project
-`.codex/config.toml`; Codex MCP entries use TOML tables named
-`[mcp_servers.stonewright]`, not JSON.
+`.codex/config.toml`; installer-managed Codex MCP entries use alias-specific
+TOML tables such as `[mcp_servers.stonewright-site-a]`, not JSON.
 
 Before the first WordPress task, verify the client tool list includes
 `stonewright-task-start` (canonical) or compatibility
@@ -285,24 +290,9 @@ npm install
 npm run build
 ```
 
-For MCP clients that use a local stdio server, configure:
-
-```json
-{
-  "mcpServers": {
-    "stonewright": {
-      "command": "npx",
-      "args": ["-y", "--package", "https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz", "stonewright-mcp"],
-      "env": {
-        "STONEWRIGHT_WP_URL": "https://your-site.example.com",
-        "STONEWRIGHT_WP_USERNAME": "your-wp-username",
-        "STONEWRIGHT_WP_APP_PASSWORD": "xxxx xxxx xxxx xxxx xxxx xxxx",
-        "STONEWRIGHT_MCP_TOOL_PROFILE": "essential"
-      }
-    }
-  }
-}
-```
+For MCP clients that use local stdio, use the versioned `stonewright connect
+add` flow above. It writes an alias-specific entry with the requested mode and
+tool profile; do not duplicate it with a generic manual block.
 
 `STONEWRIGHT_WP_ROOT` is optional. Add it only when the companion should run
 WP-CLI helper tools or discover LocalWP automatically. Use the absolute

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -14,8 +14,9 @@ edit WordPress sites through MCP.
   gates. Not available without the plugin: Elementor batch engines,
   DesignSpec rendering, php-execute, confirmation tokens, content-model
   registration, shared site memory.
-- The companion auto-detects the mode (`STONEWRIGHT_MODE=direct|plugin`
-  overrides; otherwise it probes the plugin MCP endpoint).
+- The companion can auto-detect the mode, but an installed-plugin connection
+  should be registered as `plugin-only`. This fails closed instead of silently
+  entering Direct mode when the wrong site entry or endpoint is selected.
 
 Copy-paste client setup for both modes lives in
 [install-prompts.md](install-prompts.md). Capability detail for Direct mode is
@@ -28,9 +29,13 @@ generated [ability-truth-matrix.md](ability-truth-matrix.md) (do not hand-edit).
 
 1. Install and activate the WordPress plugin.
 2. Start the companion when you need WP-CLI-assisted work or a stdio MCP server.
-3. Create a WordPress Application Password for the MCP client user.
-4. Add the Stonewright MCP server to your AI client (see
-   [install-prompts.md](install-prompts.md) Option A).
+3. Choose OAuth remote HTTP, or create a WordPress Application Password for a
+   local stdio connection. Use one transport per named connection.
+4. For stdio, run the versioned `stonewright connect add` installer with a
+   unique alias, `--mode plugin-only`, and the target client (see
+   [install-prompts.md](install-prompts.md) Option A). If the alias already
+   exists, use `connect repair <alias> --client <client> --mode plugin-only` so
+   the saved credential is reused instead of registering a duplicate.
 5. In wp-admin, open **Stonewright > Configuration**, enable Stonewright, and
    choose the operating mode (`development`, `staging`, or `production-safe`).
 6. Perform a **client-specific restart or MCP session reload** (not only a chat
@@ -40,6 +45,9 @@ generated [ability-truth-matrix.md](ability-truth-matrix.md) (do not hand-edit).
    still exposes that older entry. Prefer credential-free paste prompts from
    [install-prompts.md](install-prompts.md); keep real secrets in private
    user-level client config.
+8. Run `stonewright connect verify <alias> --client <client>` and require the
+   same alias, `configured_mode=plugin-only`, `active_mode=plugin`, the expected
+   companion, task-start/status, and an empty required-tool refresh list.
 
 ### Direct mode (no plugin)
 

--- a/docs/releases/1.0.0-beta.6.md
+++ b/docs/releases/1.0.0-beta.6.md
@@ -1,0 +1,71 @@
+# Stonewright 1.0.0-beta.6
+
+Released: 2026-08-12
+
+## Summary
+
+This hotfix makes installed-plugin connections deterministic and repairs the
+Setup save flow. A named site alias now controls the complete stdio runtime
+identity before Plugin/Direct selection, and an existing alias can be switched
+to `plugin-only` without re-entering its saved Application Password.
+
+## Fixed
+
+- **Setup Save Settings:** domain-lock recovery forms no longer sit inside the
+  Settings API form. Saving returns to Stonewright Setup instead of exposing
+  WordPress's internal `/wp-admin/options.php` handler.
+- **Wrong site or mode at startup:** `STONEWRIGHT_SITE_ALIAS` replaces inherited
+  WordPress URL, username, and password values before the companion probes or
+  selects a runtime. Credential resolution failure clears the selected password
+  and fails closed.
+- **Legacy duplicate aliases:** secure v1 migration keeps one stable record for
+  each canonical URL/environment pair and removes repeated aliases before
+  writing schema v2.
+- **Existing connection repair:** `stonewright connect repair <alias> --client
+  <client> --mode plugin-only` updates the mode, fallback policy, plugin
+  expectation, and named client entry while reusing the stored credential.
+- **Installed-plugin prompts:** Setup and public installation guidance now
+  choose exactly one transport, prefer an alias-specific `plugin-only` stdio
+  entry, and keep OAuth HTTP as a separately named alternative.
+- **Manual stdio snippets:** plugin-generated Application Password snippets set
+  `STONEWRIGHT_MODE=plugin` explicitly.
+
+## Upgrade and repair an existing stdio connection
+
+Update the WordPress plugin and companion to the same version. Then run the
+versioned repair command for the existing alias:
+
+```bash
+npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz stonewright connect repair <alias> --client <client> --mode plugin-only
+```
+
+Fully restart the MCP client, then verify:
+
+```bash
+npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz stonewright connect verify <alias> --client <client>
+```
+
+Success requires the requested alias, `configured_mode=plugin-only`,
+`active_mode=plugin`, the expected companion version, visible task-start and
+status tools, and no missing required tools. A parseable config file alone is
+not runtime proof.
+
+## Privacy-safe documentation image
+
+The main README now includes a synthetic Dashboard illustration derived from
+the product layout. It contains no customer site, credential, memory, audit,
+username, or production runtime data.
+
+## Compatibility and safety
+
+- WordPress plugin and companion: `1.0.0-beta.6`.
+- Plugin mode registers **360** abilities; Direct full exposes **100** tools.
+- WordPress: 6.7 or newer.
+- PHP: 8.1 or newer.
+- Node.js: 20 or newer for the companion.
+- No permission, confirmation, backup, validation, custom-code approval, or
+  Direct-mode write boundary was weakened.
+
+Release assets contain `stonewright-1.0.0-beta.6.zip`,
+`stonewright-companion-1.0.0-beta.6.tgz`, the Visual package, and
+`SHA256SUMS.txt`.

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -63,6 +63,18 @@ the linked SHA-256 manifest.
    `expected_companion_package` is current, and
    `refresh_required_tool_names` is empty.
 
+For alias-based stdio installs, prefer the versioned repair command over
+editing a generic MCP block:
+
+```bash
+npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz stonewright connect repair <alias> --client <client> --mode plugin-only
+```
+
+This reuses the existing credential reference, refreshes only the named client
+entry, and makes the alias authoritative over stale inherited WordPress
+environment values. Restart the client, then run `connect verify`; another
+alias or `active_mode=direct` is a failed plugin-mode update, not success.
+
 Direct mode keeps its private state under `~/.stonewright/`. Replacing the
 companion package does not reset its memory, user-created skills, site
 configuration, backups, or audit history.

--- a/e2e/tests/admin-ui.spec.ts
+++ b/e2e/tests/admin-ui.spec.ts
@@ -193,6 +193,33 @@ test.describe('Stonewright admin UI', () => {
 		await expect(page.getByRole('link', { name: 'Manage connected apps' }).first()).toBeVisible();
 	});
 
+	test('Setup Save Settings returns to Stonewright instead of exposing options.php', async ({
+		page,
+	}) => {
+		await page.goto('/wp-admin/admin.php?page=stonewright', {
+			waitUntil: 'domcontentloaded',
+		});
+
+		const settingsForm = page.locator('form.stonewright-settings-form');
+		await expect(settingsForm).toHaveCount(1);
+		await expect(settingsForm).toHaveAttribute('action', 'options.php');
+		const save = settingsForm.getByRole('button', { name: 'Save Settings' });
+		await expect(save).toBeVisible();
+		expect(await save.evaluate((button) => button.form?.classList.contains('stonewright-settings-form'))).toBe(true);
+		expect(await settingsForm.locator('form').count()).toBe(0);
+
+		await Promise.all([
+			page.waitForURL(/\/wp-admin\/admin\.php\?page=stonewright(?:&|$)/, {
+				timeout: 30_000,
+				waitUntil: 'domcontentloaded',
+			}),
+			save.click(),
+		]);
+
+		expect(page.url()).not.toContain('/wp-admin/options.php');
+		await expect(page.locator('form.stonewright-settings-form')).toBeVisible();
+	});
+
 	test('Application Password generation stays in-page, fills only private snippets, and revokes cleanly', async ({
 		page,
 	}, testInfo) => {

--- a/e2e/tests/connect.spec.ts
+++ b/e2e/tests/connect.spec.ts
@@ -96,10 +96,14 @@ test.describe('Connect wizard interactions', () => {
 		const prompt = page.locator('#stonewright-connect-prompt-full');
 		await expect(prompt).toBeAttached();
 		const fullPrompt = await prompt.getAttribute('data-stonewright-text-full');
-		expect(fullPrompt).toContain('STONEWRIGHT_WP_URL=<your-wordpress-url>');
+		expect(fullPrompt).toContain('stonewright connect add');
+		expect(fullPrompt).toContain('--mode plugin-only');
 		expect(fullPrompt).toContain(
-			'STONEWRIGHT_WP_APP_PASSWORD=<your-application-password>',
+			'stonewright connect repair <alias> --client <client> --mode plugin-only',
 		);
+		expect(fullPrompt).toContain('Choose exactly one transport');
+		expect(fullPrompt).toContain('/wp-json/mcp/stonewright-oauth');
+		expect(fullPrompt).not.toContain('MCP server name: stonewright');
 		expect(fullPrompt).not.toContain(WP_USER);
 		expect(fullPrompt).not.toContain(WP_BASE_URL);
 		// wp-env's login password is literally "password", so a raw substring

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+## [1.0.0-beta.6] - 2026-08-12
+
+### Changed
+
+- Make the credential-free installed-plugin prompt choose one transport and
+  route companion setup through an alias-specific `plugin-only` installer or
+  an existing-alias repair flow.
+- Mark every generated Application Password stdio snippet as explicit Plugin
+  mode so a temporary probe failure cannot silently select Direct mode.
+
+### Fixed
+
+- Render domain-lock status without nested action forms inside the Settings API
+  form, keeping **Save Settings** associated with the correct form and returning
+  the operator to Stonewright Setup after WordPress saves the options.
+
 ## [1.0.0-beta.5] - 2026-08-12
 
 ### Added
@@ -134,7 +150,11 @@
   inline category-action click handler, and correct setup code contrast and
   Visual Workspace focus outlines.
 
-## [1.0.0-beta.1] - 2026-07-30
+## Older releases
+
+See [1.0.0-beta.1](../docs/releases/1.0.0-beta.1.md) for the first public beta.
+
+### 1.0.0-beta.1 — 2026-07-30
 
 ### Added
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,6 +1,6 @@
 # Stonewright Plugin
 
-Version: 1.0.0-beta.5
+Version: 1.0.0-beta.6
 Requires WordPress: 6.7+
 Requires PHP: 8.1+
 License: AGPL-3.0-or-later
@@ -148,6 +148,14 @@ MCP surface, enablement/V4 selections, and per-client browser consent while
 keeping Application Passwords in the OS store. After restarting the client,
 `stonewright connect verify <alias> --client <id>` spawns the saved entry and
 requires task-start/status proof; parsing the client config is not sufficient.
+For a site where this plugin is installed, register `--mode plugin-only`. Use
+`connect repair <alias> --client <id> --mode plugin-only` to reuse an existing
+credential and repair the named entry without creating another alias.
+
+Setup keeps the Settings API form structurally separate from domain-lock
+recovery actions. **Save Settings** therefore returns to Stonewright Setup;
+`/wp-admin/options.php` is only the internal WordPress handler and is never the
+final admin page.
 
 ### Prompt library
 

--- a/plugin/includes/Admin/ConfigurationPage.php
+++ b/plugin/includes/Admin/ConfigurationPage.php
@@ -456,7 +456,7 @@ final class ConfigurationPage {
 								</p>
 							<?php endif; ?>
 						</div>
-						<?php self::render_domain_lock_status(); ?>
+						<?php self::render_domain_lock_status( false ); ?>
 						<div class="sw-field stonewright-field-row">
 							<label for="stonewright_mode"><?php esc_html_e( 'Mode', 'stonewright' ); ?></label>
 							<select name="stonewright_mode" id="stonewright_mode">
@@ -1494,7 +1494,7 @@ final class ConfigurationPage {
 		exit;
 	}
 
-	private static function render_domain_lock_status(): void {
+	private static function render_domain_lock_status( bool $include_actions = true ): void {
 		$locked_domain = DomainLock::locked_domain();
 		if ( '' === $locked_domain && DomainLock::check() ) {
 			return;
@@ -1503,7 +1503,7 @@ final class ConfigurationPage {
 		$status   = DomainLock::status();
 		$mismatch = ! DomainLock::check();
 		?>
-		<div class="stonewright-domain-lock-status" id="stonewright-domain-lock">
+		<div class="stonewright-domain-lock-status" id="<?php echo esc_attr( $include_actions ? 'stonewright-domain-lock' : 'stonewright-domain-lock-summary' ); ?>">
 			<span><?php esc_html_e( 'Domain lock:', 'stonewright' ); ?></span>
 			<?php if ( '' !== (string) $status['locked'] ) : ?>
 				<code><?php echo esc_html( (string) $status['locked'] ); ?></code>
@@ -1521,6 +1521,13 @@ final class ConfigurationPage {
 					<?php esc_html_e( 'Current origin:', 'stonewright' ); ?>
 					<code><?php echo esc_html( (string) $status['current'] ); ?></code>
 				</p>
+				<?php if ( ! $include_actions ) : ?>
+					<p class="description">
+						<?php esc_html_e( 'Domain lock recovery actions are available below the setup steps.', 'stonewright' ); ?>
+					</p>
+				<?php endif; ?>
+			<?php endif; ?>
+			<?php if ( $include_actions && $mismatch ) : ?>
 				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="stonewright-inline-form">
 					<input type="hidden" name="action" value="stonewright_rebind_domain_lock"/>
 					<?php wp_nonce_field( 'stonewright_rebind_domain_lock' ); ?>
@@ -1533,7 +1540,7 @@ final class ConfigurationPage {
 					</button>
 				</form>
 			<?php endif; ?>
-			<?php if ( DomainLock::can_rollback() ) : ?>
+			<?php if ( $include_actions && DomainLock::can_rollback() ) : ?>
 				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="stonewright-inline-form">
 					<input type="hidden" name="action" value="stonewright_rollback_domain_lock"/>
 					<?php wp_nonce_field( 'stonewright_rollback_domain_lock' ); ?>
@@ -1542,13 +1549,13 @@ final class ConfigurationPage {
 					</button>
 				</form>
 			<?php endif; ?>
-			<?php if ( DomainLock::can_clear() ) : ?>
+			<?php if ( $include_actions && DomainLock::can_clear() ) : ?>
 				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="stonewright-inline-form">
 					<input type="hidden" name="action" value="stonewright_reset_domain_lock"/>
 					<?php wp_nonce_field( 'stonewright_reset_domain_lock' ); ?>
 					<button type="submit" class="button button-small"><?php esc_html_e( 'Clear domain lock', 'stonewright' ); ?></button>
 				</form>
-			<?php elseif ( $mismatch ) : ?>
+			<?php elseif ( $include_actions && $mismatch ) : ?>
 				<p class="description">
 					<?php esc_html_e( 'Clear domain lock is disabled during a mismatch. Rebind this site or restore the prior binding instead.', 'stonewright' ); ?>
 				</p>

--- a/plugin/includes/Admin/ConnectClientConfig.php
+++ b/plugin/includes/Admin/ConnectClientConfig.php
@@ -65,12 +65,14 @@ final class ConnectClientConfig {
 	 */
 	public static function native_stdio_snippet( string $username = '', string $app_password = '', string $tool_profile = '' ): array {
 		$tool_profile = '' === trim( $tool_profile ) ? AbilityRegistry::mcp_surface() : $tool_profile;
+		$server_name  = self::mcp_server_name();
 		return [
 			'mcpServers' => [
-				'stonewright' => [
+				$server_name => [
 					'command' => 'npx',
 					'args'    => self::companion_mcp_args(),
 					'env'     => [
+						'STONEWRIGHT_MODE'            => 'plugin',
 						'STONEWRIGHT_WP_URL'          => self::site_url(),
 						'STONEWRIGHT_WP_USERNAME'     => $username ?: 'your-wp-username',
 						'STONEWRIGHT_WP_APP_PASSWORD'  => $app_password ?: '<your-application-password>',
@@ -90,9 +92,10 @@ final class ConnectClientConfig {
 	 */
 	public static function http_snippet( string $username = '', string $app_password = '' ): array {
 		$credentials = base64_encode( $username . ':' . ( $app_password ?: '<your-application-password>' ) );
+		$server_name = self::mcp_server_name();
 		return [
 			'mcpServers' => [
-				'stonewright' => [
+				$server_name => [
 					'url'     => self::mcp_endpoint_url(),
 					'headers' => [
 						'Authorization' => 'Basic ' . $credentials,
@@ -164,11 +167,13 @@ final class ConnectClientConfig {
 		}
 
 		if ( 'claude-code' === $client_slug ) {
+			$server_name = self::mcp_server_name();
 			if ( 'http' === $transport ) {
 				$credentials = base64_encode( $username . ':' . ( $app_password ?: '<your-application-password>' ) );
 				return [
 					'command' => sprintf(
-						'claude mcp add stonewright --transport http --url %s --header "Authorization: Basic %s"',
+						'claude mcp add %s --transport http --url %s --header "Authorization: Basic %s"',
+						escapeshellarg( $server_name ),
 						escapeshellarg( self::mcp_endpoint_url() ),
 						$credentials
 					),
@@ -177,7 +182,8 @@ final class ConnectClientConfig {
 			$tool_profile = self::profile_for_client( $client_slug );
 			return [
 				'command' => sprintf(
-					'claude mcp add stonewright --env STONEWRIGHT_WP_URL=%s --env STONEWRIGHT_WP_USERNAME=%s --env STONEWRIGHT_WP_APP_PASSWORD=%s --env STONEWRIGHT_MCP_TOOL_PROFILE=%s -- npx -y --package %s stonewright-mcp',
+					'claude mcp add %s --env STONEWRIGHT_MODE=plugin --env STONEWRIGHT_WP_URL=%s --env STONEWRIGHT_WP_USERNAME=%s --env STONEWRIGHT_WP_APP_PASSWORD=%s --env STONEWRIGHT_MCP_TOOL_PROFILE=%s -- npx -y --package %s stonewright-mcp',
+					escapeshellarg( $server_name ),
 					escapeshellarg( self::site_url() ),
 					escapeshellarg( $username ),
 					escapeshellarg( $app_password ?: '<your-application-password>' ),
@@ -234,14 +240,10 @@ final class ConnectClientConfig {
 	public static function paste_to_agent_prompt( string $username, string $app_password, string $client_slug = '' ): string {
 		unset( $username, $app_password );
 		$tool_profile = self::recommended_startup_profile( $client_slug );
-		$installer_intro = __(
-			"For local stdio, prefer the versioned `stonewright connect add` installer. Ask for a unique alias, environment, Direct/Plugin policy, WordPress mode, MCP surface, Elementor V4 choice, and client. Use a hidden password prompt or --password-env, never a password on argv. Persist these choices per site/client and generate a collision-safe named server entry. Keep secrets in the private client config, OS credential store, or an explicit env reference; ~/.stonewright/sites.json may contain a credential_ref but never plaintext. After saving, fully restart the MCP client and run stonewright connect verify <alias> --client <client>. Require the spawned companion version, active alias, task-start, status, and required tools; a parseable config file is not runtime proof.",
-			'stonewright'
-		);
-		$prompt = $installer_intro . "\n\n" . sprintf(
+		$prompt       = sprintf(
 			/* translators: 1: companion package URL, 2: selected MCP tool surface. */
 			__(
-				"Configure Stonewright MCP in the current AI client. Do not ask me to paste, reveal, print, or commit a site URL, username, Application Password, token, or private client config.\n\nBuild a private config with placeholders that I will replace locally:\n- MCP server name: stonewright\n- WordPress URL env: STONEWRIGHT_WP_URL=<your-wordpress-url>\n- Username env: STONEWRIGHT_WP_USERNAME=<your-wordpress-username>\n- Application Password env: STONEWRIGHT_WP_APP_PASSWORD=<your-application-password>\n- Tool surface env: STONEWRIGHT_MCP_TOOL_PROFILE=%2\$s\n- Local stdio command: npx\n- Local stdio args: [\"-y\", \"--package\", \"%1\$s\", \"stonewright-mcp\"]\n- Remote HTTP endpoint shape: <your-wordpress-url>/wp-json/mcp/stonewright\n\nConnection meaning:\n- Local stdio means this AI client starts the companion on this computer and communicates with it through standard input/output. The companion is required for local stdio, Direct mode, and local WP-CLI.\n- Remote HTTP connects directly to the WordPress plugin over HTTPS. It does not run or require a local companion.\n\nRules:\n- Prefer OAuth when this client supports Streamable HTTP; it keeps the Application Password out of copied config.\n- Keep credentials only in the private client config or ~/.stonewright/sites.json. Never put them in chat, repository files, memory, skills, audit examples, or commands saved in shell history.\n- For any custom PHP/CSS/JS/HTML write, run the approval-gated typed tool with dry_run first. Show me approval_url, exact path, byte counts, and a short summary, then stop. Never open the approval page, issue or retrieve a grant, or apply with custom_code_grant unless I explicitly ask you to perform that approval step.\n- Do not substitute a generic WordPress MCP adapter, inspect private client config, hand-roll JSON-RPC/REST runners, create scratch scripts, or run shell WP-CLI as a workaround.\n- Save the config and fully restart or reload the MCP session.\n\nVerify after reload:\n1. Confirm stonewright-task-start is visible. stonewright-context-bootstrap is compatibility fallback only.\n2. Call stonewright-task-start first with task, surface, and intent.\n3. Read fast_path.tool_profile; use stonewright-tool-profile only to switch or verify a profile.\n4. Run stonewright-setup-profile and stonewright-wordpress-mcp-status. Confirm companion_version matches expected_companion_package and refresh_required_tool_names is empty.\n5. If required tools are missing, stop. Reload the client or update the pinned companion package; do not bypass Stonewright.\n\nFor visual WordPress work, also confirm the user-approved browser provider is available before the first write.",
+				"Configure this installed Stonewright plugin in the current AI client. Choose exactly one transport for this site; do not combine a local stdio entry and an OAuth HTTP entry under the same server name. Do not ask me to paste, reveal, print, or commit a site URL, username, Application Password, token, or private client config.\n\nLOCAL STDIO WITH COMPANION (recommended when local WP-CLI or Direct fallback is needed)\nUse the versioned installer, a unique site alias, a collision-safe named server, and plugin-only mode:\n\nnpx -y --package %1\$s stonewright connect add --alias <unique-alias> --url <your-wordpress-url> --username <your-wordpress-username> --env <environment> --mode plugin-only --client <client> --profile %2\$s --plugin-enabled yes --wp-mode <development|staging|production-safe> --wp-surface %2\$s --elementor-v4 <yes|no>\n\nI will replace private placeholders locally. Let the installer request the Application Password through its hidden prompt, or use --password-env with a temporary environment variable. Never put a password on argv. Do not create or overwrite a generic server named `stonewright`; the installer must create or reuse the alias-specific named entry. ~/.stonewright/sites.json may contain credential_ref values, never plaintext credentials.\n\nIf the alias already exists and the saved credential must be reused, do not add another alias and do not ask for the password again. Run:\n\nnpx -y --package %1\$s stonewright connect repair <alias> --client <client> --mode plugin-only\n\nThen fully restart the MCP client and run:\n\nnpx -y --package %1\$s stonewright connect verify <alias> --client <client>\n\nREMOTE OAUTH HTTP (alternative, no companion)\nWhen the client supports Streamable HTTP OAuth, create a separately named remote connection to <your-wordpress-url>/wp-json/mcp/stonewright-oauth. Do not also install a local companion entry for that same connection. The Application Password route is <your-wordpress-url>/wp-json/mcp/stonewright and is a separate non-OAuth transport.\n\nConnection rules:\n- Local stdio means this AI client starts the companion and communicates through standard input/output. The alias is the routing authority; legacy STONEWRIGHT_WP_* values must never override it.\n- Remote HTTP connects directly to the WordPress plugin over HTTPS and does not run a local companion.\n- Keep credentials only in the OS credential store, an explicit environment reference, or the private client configuration. Never put them in chat, repository files, memory, skills, audit examples, or shell history.\n- For custom PHP/CSS/JS/HTML writes, run the approval-gated typed tool with dry_run first. Show me approval_url, exact path, byte counts, and a short summary, then stop. Never open the approval page, issue or retrieve a grant, or apply with custom_code_grant unless I explicitly ask you to perform that approval step.\n- Do not substitute a generic WordPress MCP adapter, inspect private client config, hand-roll JSON-RPC/REST runners, create scratch scripts, or run shell WP-CLI as a workaround.\n\nVerify after restart:\n1. The verifier must report the requested alias, configured_mode=plugin-only, active_mode=plugin, and the expected companion version. If it reports another site or Direct mode, stop: the wrong named server is active.\n2. Confirm stonewright-task-start is visible, then call it first with a non-empty task, surface, and intent. stonewright-context-bootstrap is compatibility fallback only.\n3. Read fast_path.tool_profile; use stonewright-tool-profile only to switch or verify a profile.\n4. Run stonewright-setup-profile and stonewright-wordpress-mcp-status. Confirm the target site, active alias, companion_version, expected_companion_package, and that refresh_required_tool_names is empty.\n5. If any required tool is missing or the target differs, fully reload the client; never bypass Stonewright.\n\nFor visual WordPress work, also confirm the user-approved browser provider is available before the first write.",
 				'stonewright'
 			),
 			self::companion_package_spec(),
@@ -256,7 +258,9 @@ final class ConnectClientConfig {
 
 	private static function codex_toml_snippet( string $username, string $app_password, string $tool_profile ): string {
 		$args = array_map( [ self::class, 'toml_string' ], self::companion_mcp_args() );
+		$server_name = self::mcp_server_name();
 		$env  = [
+			'STONEWRIGHT_MODE'            => 'plugin',
 			'STONEWRIGHT_WP_URL'          => self::site_url(),
 			'STONEWRIGHT_WP_USERNAME'     => $username ?: 'your-wp-username',
 			'STONEWRIGHT_WP_APP_PASSWORD'  => $app_password ?: '<your-application-password>',
@@ -264,11 +268,11 @@ final class ConnectClientConfig {
 		];
 
 		$lines = [
-			'[mcp_servers.stonewright]',
+			'[mcp_servers.' . $server_name . ']',
 			'command = "npx"',
 			'args = [' . implode( ', ', $args ) . ']',
 			'',
-			'[mcp_servers.stonewright.env]',
+			'[mcp_servers.' . $server_name . '.env]',
 		];
 
 		foreach ( $env as $key => $value ) {
@@ -306,5 +310,15 @@ final class ConnectClientConfig {
 	private static function normalise_tool_profile( string $tool_profile ): string {
 		$tool_profile = strtolower( trim( $tool_profile ) );
 		return '' === $tool_profile ? 'essential' : $tool_profile;
+	}
+
+	private static function mcp_server_name(): string {
+		$url      = self::site_url();
+		$host     = (string) parse_url( $url, PHP_URL_HOST );
+		$path     = trim( (string) parse_url( $url, PHP_URL_PATH ), '/' );
+		$identity = '' === $path ? $host : $host . '-' . $path;
+		$slug     = strtolower( (string) preg_replace( '/[^a-z0-9]+/i', '-', $identity ) );
+		$slug = trim( $slug, '-' );
+		return '' === $slug ? 'stonewright-site' : 'stonewright-' . $slug;
 	}
 }

--- a/plugin/stonewright.php
+++ b/plugin/stonewright.php
@@ -3,7 +3,7 @@
  * Plugin Name: Stonewright
  * Plugin URI: https://github.com/cosmincraciun97/stonewright-wp-mcp
  * Description: Guarded WordPress MCP tools for Elementor, Gutenberg/FSE, WooCommerce catalogs, content models, PHP runtime execution, and tokenized WP-CLI.
- * Version: 1.0.0-beta.5
+ * Version: 1.0.0-beta.6
  * Requires at least: 6.7
  * Requires PHP: 8.1
  * Author: Stonewright
@@ -33,7 +33,7 @@ if ( defined( 'STONEWRIGHT_FILE' ) ) {
 define( 'STONEWRIGHT_FILE', __FILE__ );
 define( 'STONEWRIGHT_DIR', plugin_dir_path( __FILE__ ) );
 define( 'STONEWRIGHT_URL', plugin_dir_url( __FILE__ ) );
-define( 'STONEWRIGHT_VERSION', '1.0.0-beta.5' );
+define( 'STONEWRIGHT_VERSION', '1.0.0-beta.6' );
 define( 'STONEWRIGHT_MIN_PHP', '8.1' );
 define( 'STONEWRIGHT_MIN_WP', '6.7' );
 

--- a/plugin/tests/Unit/Admin/AppPasswordRestTest.php
+++ b/plugin/tests/Unit/Admin/AppPasswordRestTest.php
@@ -105,7 +105,8 @@ final class AppPasswordRestTest extends TestCase {
 	public function test_paste_prompt_never_contains_real_password(): void {
 		$prompt = ConnectClientConfig::paste_to_agent_prompt( 'admin', 'super-secret-app-pass-xyz', 'cursor' );
 		self::assertStringNotContainsString( 'super-secret-app-pass-xyz', $prompt );
-		self::assertStringContainsString( '<your-application-password>', $prompt );
+		self::assertStringContainsString( 'hidden prompt', $prompt );
+		self::assertStringContainsString( '--password-env', $prompt );
 		self::assertDoesNotMatchRegularExpression( '/STONEWRIGHT_MCP_TOOL_PROFILE=full\b/', $prompt );
 	}
 

--- a/plugin/tests/Unit/Admin/ClientSnippetValidationTest.php
+++ b/plugin/tests/Unit/Admin/ClientSnippetValidationTest.php
@@ -17,6 +17,7 @@ use Stonewright\WpMcp\Admin\ConnectClientConfig;
  * @covers \Stonewright\WpMcp\Admin\ConnectClientConfig::snippet_for
  */
 final class ClientSnippetValidationTest extends TestCase {
+	private const SERVER_NAME = 'stonewright-example-test';
 
 	private const USER = 'fixture-admin';
 	private const PASS = 'xxxx xxxx xxxx xxxx xxxx xxxx';
@@ -58,7 +59,7 @@ final class ClientSnippetValidationTest extends TestCase {
 
 			if ( isset( $snippet['toml'] ) ) {
 				$toml = (string) $snippet['toml'];
-				self::assertStringContainsString( '[mcp_servers.stonewright]', $toml );
+					self::assertStringContainsString( '[mcp_servers.' . self::SERVER_NAME . ']', $toml );
 				self::assertStringContainsString( 'command = "npx"', $toml );
 				self::assertStringContainsString( 'STONEWRIGHT_WP_USERNAME', $toml );
 				self::assertStringContainsString( self::USER, $toml );
@@ -76,8 +77,8 @@ final class ClientSnippetValidationTest extends TestCase {
 
 			$servers = $decoded['mcpServers'] ?? $decoded['servers'] ?? $decoded['context_servers'] ?? null;
 			self::assertIsArray( $servers, "{$slug} missing server map" );
-			self::assertArrayHasKey( 'stonewright', $servers );
-			$entry = $servers['stonewright'];
+				self::assertArrayHasKey( self::SERVER_NAME, $servers );
+				$entry = $servers[ self::SERVER_NAME ];
 			self::assertIsArray( $entry );
 			if ( isset( $entry['command'] ) ) {
 				self::assertSame( 'npx', $entry['command'] );
@@ -97,7 +98,8 @@ final class ClientSnippetValidationTest extends TestCase {
 			self::assertIsArray( $decoded );
 			$servers = $decoded['mcpServers'] ?? $decoded['servers'] ?? $decoded['context_servers'] ?? null;
 			self::assertIsArray( $servers );
-			$entry = $servers['stonewright'];
+				self::assertArrayHasKey( self::SERVER_NAME, $servers );
+				$entry = $servers[ self::SERVER_NAME ];
 			self::assertArrayHasKey( 'url', $entry );
 			self::assertArrayHasKey( 'headers', $entry );
 			self::assertArrayHasKey( 'Authorization', $entry['headers'] );

--- a/plugin/tests/Unit/Admin/ConfigurationPageTest.php
+++ b/plugin/tests/Unit/Admin/ConfigurationPageTest.php
@@ -312,4 +312,34 @@ final class ConfigurationPageTest extends TestCase {
 		delete_option( 'stonewright_domain_lock_prior' );
 		unset( $GLOBALS['stonewright_test_home_url'] );
 	}
+
+	public function test_settings_form_never_contains_nested_domain_lock_forms(): void {
+		$GLOBALS['stonewright_test_options']['stonewright_enabled'] = true;
+		$GLOBALS['stonewright_test_home_url']                       = 'https://example.test/';
+		\Stonewright\WpMcp\Security\DomainLock::lock();
+		$GLOBALS['stonewright_test_home_url'] = 'https://cloned.example/';
+		\Stonewright\WpMcp\Security\DomainLock::record_mismatch();
+
+		ob_start();
+		ConfigurationPage::render();
+		$html = (string) ob_get_clean();
+
+		$form_start = strpos( $html, '<form method="post" action="options.php"' );
+		self::assertNotFalse( $form_start );
+		$form_end = strpos( $html, '</form>', (int) $form_start );
+		self::assertNotFalse( $form_end );
+		$settings_form = substr( $html, (int) $form_start, (int) $form_end - (int) $form_start );
+		self::assertSame( 1, substr_count( $settings_form, '<form' ) );
+		self::assertStringContainsString( 'stonewright-domain-lock-summary', $settings_form );
+		self::assertStringNotContainsString( 'stonewright_rebind_domain_lock', $settings_form );
+
+		$after_settings_form = substr( $html, (int) $form_end + strlen( '</form>' ) );
+		self::assertStringContainsString( 'stonewright_rebind_domain_lock', $after_settings_form );
+		self::assertSame( 1, substr_count( $html, 'id="stonewright-domain-lock"' ) );
+
+		delete_option( 'stonewright_locked_domain' );
+		delete_option( 'stonewright_domain_mismatch' );
+		delete_option( 'stonewright_domain_lock_prior' );
+		unset( $GLOBALS['stonewright_test_home_url'] );
+	}
 }

--- a/plugin/tests/Unit/ConnectClientConfigTest.php
+++ b/plugin/tests/Unit/ConnectClientConfigTest.php
@@ -10,6 +10,7 @@ use Stonewright\WpMcp\Admin\ConnectClientConfig;
  * @covers \Stonewright\WpMcp\Admin\ConnectClientConfig
  */
 final class ConnectClientConfigTest extends TestCase {
+	private const SERVER_NAME = 'stonewright-example-test';
 
 	protected function setUp(): void {
 		$GLOBALS['stonewright_test_options']['stonewright_mcp_surface'] = 'essential';
@@ -17,6 +18,7 @@ final class ConnectClientConfigTest extends TestCase {
 
 	protected function tearDown(): void {
 		$GLOBALS['stonewright_test_options'] = [];
+		unset( $GLOBALS['stonewright_test_site_url'] );
 	}
 
 	public function test_clients_catalogue_has_required_shape(): void {
@@ -78,9 +80,9 @@ final class ConnectClientConfigTest extends TestCase {
 	public function test_universal_snippet_structure(): void {
 		$snippet = ConnectClientConfig::universal_snippet( 'admin', 'abcd 1234 efgh 5678' );
 		$this->assertArrayHasKey( 'mcpServers', $snippet );
-		$this->assertArrayHasKey( 'stonewright', $snippet['mcpServers'] );
+		$this->assertArrayHasKey( self::SERVER_NAME, $snippet['mcpServers'] );
 
-		$server = $snippet['mcpServers']['stonewright'];
+		$server = $snippet['mcpServers'][ self::SERVER_NAME ];
 		$this->assertSame( 'npx', $server['command'] );
 		$this->assertSame(
 			[
@@ -92,16 +94,24 @@ final class ConnectClientConfigTest extends TestCase {
 			$server['args']
 		);
 		$this->assertNotContains( '@automattic/mcp-wordpress-remote@latest', $server['args'] );
+		$this->assertSame( 'plugin', $server['env']['STONEWRIGHT_MODE'] );
 		$this->assertSame( 'admin', $server['env']['STONEWRIGHT_WP_USERNAME'] );
 		$this->assertSame( 'abcd 1234 efgh 5678', $server['env']['STONEWRIGHT_WP_APP_PASSWORD'] );
 		$this->assertSame( 'essential', $server['env']['STONEWRIGHT_MCP_TOOL_PROFILE'] );
+	}
+
+	public function test_server_name_distinguishes_path_based_sites(): void {
+		$GLOBALS['stonewright_test_site_url'] = 'https://example.test/network/site-a/';
+		$snippet = ConnectClientConfig::universal_snippet( 'admin', 'pass' );
+
+		$this->assertArrayHasKey( 'stonewright-example-test-network-site-a', $snippet['mcpServers'] );
 	}
 
 	public function test_universal_snippet_password_placeholder_when_empty(): void {
 		$snippet = ConnectClientConfig::universal_snippet( 'admin', '' );
 		$this->assertSame(
 			'<your-application-password>',
-			$snippet['mcpServers']['stonewright']['env']['STONEWRIGHT_WP_APP_PASSWORD']
+			$snippet['mcpServers'][ self::SERVER_NAME ]['env']['STONEWRIGHT_WP_APP_PASSWORD']
 		);
 	}
 
@@ -115,10 +125,11 @@ final class ConnectClientConfigTest extends TestCase {
 		$result = ConnectClientConfig::snippet_for( 'claude-code', 'admin', 'pw' );
 		$this->assertIsArray( $result );
 		$this->assertArrayHasKey( 'command', $result );
-		$this->assertStringContainsString( 'claude mcp add stonewright', $result['command'] );
+		$this->assertStringContainsString( "claude mcp add 'stonewright-example-test'", $result['command'] );
 		$this->assertStringContainsString( 'stonewright-companion-0.0.0-test.tgz', $result['command'] );
 		$this->assertStringContainsString( '--package', $result['command'] );
 		$this->assertStringContainsString( 'stonewright-mcp', $result['command'] );
+		$this->assertStringContainsString( '--env STONEWRIGHT_MODE=plugin', $result['command'] );
 		$this->assertStringContainsString( '--env STONEWRIGHT_MCP_TOOL_PROFILE=essential', $result['command'] );
 		$this->assertStringNotContainsString( '@automattic/mcp-wordpress-remote', $result['command'] );
 	}
@@ -128,10 +139,11 @@ final class ConnectClientConfigTest extends TestCase {
 
 		$this->assertIsArray( $result );
 		$this->assertArrayHasKey( 'toml', $result );
-		$this->assertStringContainsString( '[mcp_servers.stonewright]', $result['toml'] );
+		$this->assertStringContainsString( '[mcp_servers.' . self::SERVER_NAME . ']', $result['toml'] );
 		$this->assertStringContainsString( 'command = "npx"', $result['toml'] );
 		$this->assertStringContainsString( 'stonewright-companion-0.0.0-test.tgz', $result['toml'] );
-		$this->assertStringContainsString( '[mcp_servers.stonewright.env]', $result['toml'] );
+		$this->assertStringContainsString( '[mcp_servers.' . self::SERVER_NAME . '.env]', $result['toml'] );
+		$this->assertStringContainsString( 'STONEWRIGHT_MODE = "plugin"', $result['toml'] );
 		$this->assertStringContainsString( 'STONEWRIGHT_WP_USERNAME = "admin"', $result['toml'] );
 		$this->assertStringContainsString( 'STONEWRIGHT_WP_APP_PASSWORD = "pw"', $result['toml'] );
 		$this->assertStringContainsString( 'STONEWRIGHT_MCP_TOOL_PROFILE = "essential"', $result['toml'] );
@@ -148,7 +160,7 @@ final class ConnectClientConfigTest extends TestCase {
 		$this->assertIsArray( $cursor );
 		$this->assertIsArray( $claude );
 		$this->assertStringContainsString( 'STONEWRIGHT_MCP_TOOL_PROFILE = "full"', $codex['toml'] );
-		$this->assertSame( 'full', $cursor['mcpServers']['stonewright']['env']['STONEWRIGHT_MCP_TOOL_PROFILE'] );
+		$this->assertSame( 'full', $cursor['mcpServers'][ self::SERVER_NAME ]['env']['STONEWRIGHT_MCP_TOOL_PROFILE'] );
 		$this->assertStringContainsString( '--env STONEWRIGHT_MCP_TOOL_PROFILE=full', $claude['command'] );
 	}
 
@@ -172,14 +184,14 @@ final class ConnectClientConfigTest extends TestCase {
 		$gemini = ConnectClientConfig::snippet_for( 'gemini-cli', 'admin', 'pw' );
 
 		$this->assertIsArray( $gemini );
-		$this->assertSame( 'low-tools', $gemini['mcpServers']['stonewright']['env']['STONEWRIGHT_MCP_TOOL_PROFILE'] );
+		$this->assertSame( 'low-tools', $gemini['mcpServers'][ self::SERVER_NAME ]['env']['STONEWRIGHT_MCP_TOOL_PROFILE'] );
 	}
 
 	public function test_snippet_for_known_client_returns_universal_block(): void {
 		$result = ConnectClientConfig::snippet_for( 'cursor', 'admin', 'pw' );
 		$this->assertIsArray( $result );
 		$this->assertArrayHasKey( 'mcpServers', $result );
-		$this->assertArrayHasKey( 'stonewright', $result['mcpServers'] );
+		$this->assertArrayHasKey( self::SERVER_NAME, $result['mcpServers'] );
 	}
 
 	public function test_strict_tool_cap_clients_use_low_tools_profile(): void {
@@ -188,8 +200,8 @@ final class ConnectClientConfigTest extends TestCase {
 
 		$this->assertIsArray( $antigravity );
 		$this->assertIsArray( $gemini );
-		$this->assertSame( 'low-tools', $antigravity['mcpServers']['stonewright']['env']['STONEWRIGHT_MCP_TOOL_PROFILE'] );
-		$this->assertSame( 'low-tools', $gemini['mcpServers']['stonewright']['env']['STONEWRIGHT_MCP_TOOL_PROFILE'] );
+		$this->assertSame( 'low-tools', $antigravity['mcpServers'][ self::SERVER_NAME ]['env']['STONEWRIGHT_MCP_TOOL_PROFILE'] );
+		$this->assertSame( 'low-tools', $gemini['mcpServers'][ self::SERVER_NAME ]['env']['STONEWRIGHT_MCP_TOOL_PROFILE'] );
 	}
 
 	public function test_snippet_for_vscode_copilot_uses_servers_key(): void {
@@ -197,7 +209,7 @@ final class ConnectClientConfigTest extends TestCase {
 		$this->assertIsArray( $result );
 		$this->assertArrayHasKey( 'servers', $result );
 		$this->assertArrayNotHasKey( 'mcpServers', $result );
-		$this->assertArrayHasKey( 'stonewright', $result['servers'] );
+		$this->assertArrayHasKey( self::SERVER_NAME, $result['servers'] );
 	}
 
 	public function test_snippet_for_github_copilot_uses_servers_key(): void {
@@ -210,7 +222,7 @@ final class ConnectClientConfigTest extends TestCase {
 		$result = ConnectClientConfig::snippet_for( 'zed', 'admin', 'pw' );
 		$this->assertIsArray( $result );
 		$this->assertArrayHasKey( 'context_servers', $result );
-		$this->assertArrayHasKey( 'stonewright', $result['context_servers'] );
+		$this->assertArrayHasKey( self::SERVER_NAME, $result['context_servers'] );
 	}
 
 	public function test_paste_to_agent_prompt_is_current_and_credential_free(): void {
@@ -220,26 +232,27 @@ final class ConnectClientConfigTest extends TestCase {
 		$this->assertStringNotContainsString( 'https://example.test', $prompt );
 		$this->assertStringContainsString( '<your-wordpress-url>', $prompt );
 		$this->assertStringContainsString( '<your-wordpress-username>', $prompt );
-		$this->assertStringContainsString( '<your-application-password>', $prompt );
 		$this->assertStringContainsString( 'mcp/stonewright', $prompt );
+		$this->assertStringContainsString( 'mcp/stonewright-oauth', $prompt );
 		$this->assertStringContainsString( 'stonewright-companion-0.0.0-test.tgz', $prompt );
-		$this->assertStringContainsString( '["-y", "--package"', $prompt );
-		$this->assertStringContainsString( 'stonewright-mcp', $prompt );
-		$this->assertStringContainsString( 'STONEWRIGHT_WP_APP_PASSWORD', $prompt );
-		$this->assertStringContainsString( 'STONEWRIGHT_MCP_TOOL_PROFILE', $prompt );
-		$this->assertStringContainsString( 'Prefer OAuth', $prompt );
-		$this->assertStringContainsString( 'communicates with it through standard input/output', $prompt );
-		$this->assertStringContainsString( 'required for local stdio, Direct mode, and local WP-CLI', $prompt );
-		$this->assertStringContainsString( 'It does not run or require a local companion', $prompt );
+		$this->assertStringContainsString( 'stonewright connect add', $prompt );
+		$this->assertStringContainsString( '--mode plugin-only', $prompt );
+		$this->assertStringContainsString( 'stonewright connect repair <alias> --client <client> --mode plugin-only', $prompt );
+		$this->assertStringContainsString( 'Choose exactly one transport', $prompt );
+		$this->assertStringNotContainsString( 'Build a private config', $prompt );
+		$this->assertStringNotContainsString( 'MCP server name: stonewright', $prompt );
+		$this->assertStringContainsString( 'communicates through standard input/output', $prompt );
+		$this->assertStringContainsString( 'does not run a local companion', $prompt );
 		$this->assertStringContainsString( 'Show me approval_url, exact path, byte counts, and a short summary, then stop', $prompt );
 		$this->assertStringContainsString( 'Never open the approval page', $prompt );
-		$this->assertStringContainsString( 'Keep credentials only in the private client config or ~/.stonewright/sites.json', $prompt );
-		$this->assertStringContainsString( 'prefer the versioned `stonewright connect add` installer', $prompt );
-		$this->assertStringContainsString( 'hidden password prompt or --password-env', $prompt );
-		$this->assertStringContainsString( '~/.stonewright/sites.json may contain a credential_ref but never plaintext', $prompt );
+		$this->assertStringContainsString( 'hidden prompt', $prompt );
+		$this->assertStringContainsString( '--password-env', $prompt );
+		$this->assertStringContainsString( '~/.stonewright/sites.json may contain credential_ref values, never plaintext credentials', $prompt );
 		$this->assertStringContainsString( 'stonewright connect verify <alias> --client <client>', $prompt );
-		$this->assertStringContainsString( 'a parseable config file is not runtime proof', $prompt );
-		$this->assertStringContainsString( 'fully restart or reload the MCP session', $prompt );
+		$this->assertStringContainsString( 'fully restart the MCP client', $prompt );
+		$this->assertStringContainsString( 'configured_mode=plugin-only', $prompt );
+		$this->assertStringContainsString( 'active_mode=plugin', $prompt );
+		$this->assertStringContainsString( 'wrong named server is active', $prompt );
 		$this->assertStringContainsString( 'stonewright-task-start', $prompt );
 		$this->assertLessThan(
 			strpos( $prompt, 'stonewright-context-bootstrap' ) ?: PHP_INT_MAX,
@@ -253,7 +266,7 @@ final class ConnectClientConfigTest extends TestCase {
 		$this->assertStringContainsString( 'companion_version', $prompt );
 		$this->assertStringContainsString( 'expected_companion_package', $prompt );
 		$this->assertStringContainsString( 'refresh_required_tool_names', $prompt );
-		$this->assertStringContainsString( 'do not bypass Stonewright', $prompt );
+		$this->assertStringContainsString( 'never bypass Stonewright', $prompt );
 		$this->assertStringContainsString( 'user-approved browser provider', $prompt );
 		$this->assertStringContainsString( 'Ask me once whether this site/client should use Playwright', $prompt );
 		$this->assertStringContainsString( 'Do not scan my private config or client tool surface without permission', $prompt );

--- a/plugin/tests/Unit/Support/ReleaseRetentionTest.php
+++ b/plugin/tests/Unit/Support/ReleaseRetentionTest.php
@@ -19,10 +19,10 @@ final class ReleaseRetentionTest extends TestCase {
 				$versioned[] = $name;
 			}
 		}
-		self::assertSame( [ '1.0.0-beta.1.md', '1.0.0-beta.2.md', '1.0.0-beta.3.md', '1.0.0-beta.4.md', '1.0.0-beta.5.md' ], $versioned );
+		self::assertSame( [ '1.0.0-beta.1.md', '1.0.0-beta.2.md', '1.0.0-beta.3.md', '1.0.0-beta.4.md', '1.0.0-beta.5.md', '1.0.0-beta.6.md' ], $versioned );
 	}
 
-	public function test_root_changelog_has_at_most_five_versions_plus_unreleased(): void {
+	public function test_root_changelog_keeps_latest_five_releases_and_links_older_history(): void {
 		$path = dirname( __DIR__, 4 ) . '/CHANGELOG.md';
 		$raw  = (string) file_get_contents( $path );
 		preg_match_all( '/^## \\[([^\\]]+)\\]/m', $raw, $m );
@@ -34,7 +34,8 @@ final class ReleaseRetentionTest extends TestCase {
 			)
 		);
 		self::assertContains( 'Unreleased', $headers );
-		self::assertSame( [ '1.0.0-beta.5', '1.0.0-beta.4', '1.0.0-beta.3', '1.0.0-beta.2', '1.0.0-beta.1' ], $versions );
-		self::assertStringContainsString( 'public changelog starts with the first beta', $raw );
+		self::assertSame( [ '1.0.0-beta.6', '1.0.0-beta.5', '1.0.0-beta.4', '1.0.0-beta.3', '1.0.0-beta.2' ], $versions );
+		self::assertStringContainsString( '## Older releases', $raw );
+		self::assertStringContainsString( 'docs/releases/1.0.0-beta.1.md', $raw );
 	}
 }


### PR DESCRIPTION
## Summary
- fix the Setup Save Settings redirect by keeping domain-lock actions outside the WordPress Settings API form
- make `STONEWRIGHT_SITE_ALIAS` authoritative and fail closed when its credential cannot be resolved
- securely collapse duplicate legacy aliases and add `connect repair --mode` for existing named client entries
- make installed-plugin prompts select one transport and explicit `plugin-only` mode
- ship 1.0.0-beta.6 documentation and a synthetic privacy-safe Dashboard illustration

## Ability and safety gates
- Changed abilities: none
- Backup gate: unchanged
- Confirmation-token gate: unchanged
- Permission gate: unchanged
- DesignSpec validation gate: unchanged
- Audit gate: unchanged
- Custom-code approval boundary: unchanged

## Validation
- Plugin: 6,818 tests / 36,117 assertions
- Public API contract: 5 tests / 7,576 assertions
- PHPStan, PHPCS, security audit, dependency audit, provenance, and token budgets: passed
- Companion: 456 tests; typecheck, lint, contract compatibility, token budgets, build, production dependency audit: passed
- Visual: 80 tests; typecheck and build passed
- Documentation freshness, public hygiene, release package verification, Jetpack manifests, and `git diff --check`: passed
- Playwright suite discovery: 175 tests; full wp-env execution is delegated to CI because Docker is unavailable locally

## Public docs changed
Root/plugin/companion READMEs and changelogs, installation prompts and client guides, architecture, onboarding, update guide, and the beta.6 release note were updated in the same change.
