### PR TITLE
fix: keep client configuration receipts content-free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ development builds were never stable releases.
 
 ## [Unreleased]
 
+## [1.0.0-beta.7] - 2026-08-12
+
+### Fixed
+
+- Keep `connect add` and `connect repair` receipts content-free: client config
+  contents, unrelated local settings, absolute config paths, and backup paths
+  are withheld while the receipt retains the server name, change state, backup
+  state, support tier, and browser consent metadata.
+
 ## [1.0.0-beta.6] - 2026-08-12
 
 ### Changed
@@ -169,7 +178,12 @@ development builds were never stable releases.
 - Clarify escaped-layout PHP parsing and refuse ambiguous heredoc, nowdoc,
   script, style, and interpolation candidates instead of corrupting snippets.
 
-## [1.0.0-beta.2] - 2026-07-30
+## Older releases
+
+- [1.0.0-beta.2](docs/releases/1.0.0-beta.2.md)
+- [1.0.0-beta.1](docs/releases/1.0.0-beta.1.md)
+
+### 1.0.0-beta.2 — 2026-07-30
 
 ### Added
 
@@ -195,10 +209,6 @@ development builds were never stable releases.
 - Center the complete Domain Lock control group, keep Sandbox file-type badges
   readable, remove inline click handling from category actions, and correct
   low-contrast setup code blocks and focus rings.
-
-## Older releases
-
-See [1.0.0-beta.1](docs/releases/1.0.0-beta.1.md) for the first public beta.
 
 ### 1.0.0-beta.1 — 2026-07-30
 

--- a/companion/CHANGELOG.md
+++ b/companion/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [1.0.0-beta.7] - 2026-08-12
+
+### Fixed
+
+- Replace line-by-line client configuration diffs with content-free change
+  summaries and omit private config and backup paths from connect receipts.
+
 ## [1.0.0-beta.6] - 2026-08-12
 
 ### Changed

--- a/companion/package-lock.json
+++ b/companion/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@stonewright/companion",
-	"version": "1.0.0-beta.6",
+	"version": "1.0.0-beta.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@stonewright/companion",
-			"version": "1.0.0-beta.6",
+			"version": "1.0.0-beta.7",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/companion/package.json
+++ b/companion/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@stonewright/companion",
-	"version": "1.0.0-beta.6",
+	"version": "1.0.0-beta.7",
 	"description": "Node companion for the Stonewright WordPress MCP plugin: WP-CLI, health checks, and optional MCP HTTP proxy.",
 	"type": "module",
 	"license": "MIT",

--- a/companion/src/cli/clients/atomic-config.ts
+++ b/companion/src/cli/clients/atomic-config.ts
@@ -113,10 +113,9 @@ export function atomicWriteText(path: string, contents: string, mode = 0o600): v
 	}
 }
 
-export function redactedDiff(before: string | null, after: string, label: string): string {
+export function redactedDiff(before: string | null, after: string, _label: string): string {
 	const a = (before ?? '').split('\n');
 	const b = after.split('\n');
-	const lines: string[] = [`--- ${label} (before)`, `+++ ${label} (after)`];
 	const max = Math.max(a.length, b.length);
 	let changes = 0;
 	for (let i = 0; i < max; i++) {
@@ -124,28 +123,11 @@ export function redactedDiff(before: string | null, after: string, label: string
 		const right = b[i];
 		if (left === right) continue;
 		changes += 1;
-		if (left !== undefined) {
-			lines.push(`- ${redactLine(left)}`);
-		}
-		if (right !== undefined) {
-			lines.push(`+ ${redactLine(right)}`);
-		}
-		if (changes > 40) {
-			lines.push('… (diff truncated)');
-			break;
-		}
 	}
 	if (changes === 0) {
-		return `(no textual change in ${label})`;
+		return 'Client configuration unchanged; contents withheld.';
 	}
-	return lines.join('\n');
-}
-
-function redactLine(line: string): string {
-	return line
-		.replace(/(PASSWORD|TOKEN|SECRET|AUTHORIZATION)\s*[=:]\s*["']?[^"'\s]+/gi, '$1=***')
-		.replace(/Basic\s+[A-Za-z0-9+/=]+/gi, 'Basic ***')
-		.replace(/["'](?:[A-Za-z0-9]{4}\s+){5}[A-Za-z0-9]{4}["']/g, '"***"');
+	return `Client configuration updated (${changes} changed line positions); contents withheld.`;
 }
 
 /**
@@ -155,14 +137,16 @@ export function writeWithRollback(args: {
 	path: string;
 	nextContents: string;
 	validate: (path: string) => void;
-}): { backupPath: string | null; diff: string } {
+}): { backupPath: string | null; changed: boolean; diff: string } {
 	const before = readTextFile(args.path);
+	const changed = before !== args.nextContents;
 	const backupPath = backupFile(args.path);
 	try {
 		atomicWriteText(args.path, args.nextContents);
 		args.validate(args.path);
 		return {
 			backupPath,
+			changed,
 			diff: redactedDiff(before, args.nextContents, args.path),
 		};
 	} catch (err) {

--- a/companion/src/cli/clients/codex-toml.ts
+++ b/companion/src/cli/clients/codex-toml.ts
@@ -222,7 +222,7 @@ export function codexAdapter(): ClientAdapter {
 				parts.order.push(entry.serverName);
 			}
 			const next = rebuildToml(parts);
-			const { backupPath, diff } = writeWithRollback({
+			const { backupPath, changed, diff } = writeWithRollback({
 				path: configPath,
 				nextContents: next,
 				validate: validateTomlHasStructure,
@@ -230,6 +230,7 @@ export function codexAdapter(): ClientAdapter {
 			return {
 				configPath,
 				backupPath,
+				changed,
 				diff,
 				serverName: entry.serverName,
 				created,

--- a/companion/src/cli/clients/generic-json.ts
+++ b/companion/src/cli/clients/generic-json.ts
@@ -144,7 +144,7 @@ export function createGenericJsonAdapter(meta: {
 			bucket.map[entry.serverName] = entryToJson(entry);
 			setBucket(root, bucket.key, bucket.map);
 			const next = `${JSON.stringify(root, null, 2)}\n`;
-			const { backupPath, diff } = writeWithRollback({
+			const { backupPath, changed, diff } = writeWithRollback({
 				path: configPath,
 				nextContents: next,
 				validate: validateJsonFile,
@@ -152,6 +152,7 @@ export function createGenericJsonAdapter(meta: {
 			return {
 				configPath,
 				backupPath,
+				changed,
 				diff,
 				serverName: entry.serverName,
 				created,

--- a/companion/src/cli/clients/types.ts
+++ b/companion/src/cli/clients/types.ts
@@ -22,7 +22,8 @@ export interface ClientAdapterInfo {
 export interface ApplyResult {
 	configPath: string;
 	backupPath: string | null;
-	/** Redacted human-readable diff (no secrets). */
+	changed: boolean;
+	/** Content-free human-readable change summary. */
 	diff: string;
 	serverName: string;
 	created: boolean;

--- a/companion/src/cli/connect/commands.ts
+++ b/companion/src/cli/connect/commands.ts
@@ -776,16 +776,16 @@ function applyClientBinding(
 	const nextRegistry = upsertSite(registry, nextSite, { replace: true });
 	return {
 		registry: nextRegistry,
-			receipt: {
+		receipt: {
 			client: adapter.id,
 			server_name: serverName,
-			config_path: configPath,
-			backup_path: applied.backupPath,
+			config_changed: applied.changed,
+			backup_created: applied.backupPath !== null,
 			created: applied.created,
-			diff: applied.diff,
-				support_tier: adapter.supportTier,
-				browser: nextSite.clients[adapter.id]?.browser,
-			},
+			change_summary: applied.diff,
+			support_tier: adapter.supportTier,
+			browser: nextSite.clients[adapter.id]?.browser,
+		},
 		rollback: () => restoreFileSnapshot(configPath, before),
 	};
 }

--- a/companion/src/version.ts
+++ b/companion/src/version.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = '1.0.0-beta.6';
+export const APP_VERSION = '1.0.0-beta.7';
 
 export function companionPackageSpec(version: string = APP_VERSION): string {
 	return `https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v${version}/stonewright-companion-${version}.tgz`;

--- a/companion/tests/connect-cli.test.ts
+++ b/companion/tests/connect-cli.test.ts
@@ -16,7 +16,7 @@ import {
 import { runInit } from '../src/cli/init.js';
 import { codexAdapter, cursorAdapter } from '../src/cli/clients/index.js';
 import { ClientConfigError } from '../src/cli/clients/types.js';
-import { writeWithRollback } from '../src/cli/clients/atomic-config.js';
+import { redactedDiff, writeWithRollback } from '../src/cli/clients/atomic-config.js';
 
 describe('connect CLI acceptance matrix', () => {
 	const dirs: string[] = [];
@@ -240,6 +240,7 @@ describe('connect CLI acceptance matrix', () => {
 		const h = harness();
 		capture();
 		const codexCfg = join(h.dir, '.codex', 'config.toml');
+		writeFileSync(codexCfg, '[notice]\nprivate_marker = "do-not-print-local-context"\n', 'utf8');
 		writeFileSync(
 			h.sitesFile,
 			JSON.stringify({
@@ -286,6 +287,22 @@ describe('connect CLI acceptance matrix', () => {
 		expect(registry.sites[0].clients).toHaveProperty('codex');
 		expect(registryText).not.toContain('appPassword');
 		expect(readFileSync(codexCfg, 'utf8')).toMatch(/STONEWRIGHT_SITE_ALIAS\s*=\s*"site-primary"/);
+		expect(logs.join('')).toContain('change_summary');
+		expect(logs.join('')).not.toContain('do-not-print-local-context');
+		expect(logs.join('')).not.toContain(codexCfg);
+	});
+
+	it('client change summaries never include config content or paths', () => {
+		const summary = redactedDiff(
+			'[private]\npath = "/private/client/config"',
+			'[private]\npath = "/private/client/config"\nserver = "stonewright-site-a"',
+			'/private/client/config',
+		);
+
+		expect(summary).toMatch(/configuration updated/i);
+		expect(summary).toContain('contents withheld');
+		expect(summary).not.toContain('/private/client/config');
+		expect(summary).not.toContain('stonewright-site-a');
 	});
 
 	it('repair can change policy without a client binding or password prompt', async () => {
@@ -523,19 +540,22 @@ describe('connect CLI acceptance matrix', () => {
 			'utf8',
 		);
 		const adapter = codexAdapter();
-		adapter.upsert(path, {
+		const first = adapter.upsert(path, {
 			serverName: 'stonewright-site-a',
 			command: 'npx',
 			args: ['-y', 'stonewright-mcp'],
 			env: { STONEWRIGHT_MODE: 'auto', STONEWRIGHT_SITE_ALIAS: 'site-a' },
 		});
-		adapter.upsert(path, {
+		const second = adapter.upsert(path, {
 			serverName: 'stonewright-site-a',
 			command: 'npx',
 			args: ['-y', 'stonewright-mcp'],
 			env: { STONEWRIGHT_MODE: 'auto', STONEWRIGHT_SITE_ALIAS: 'site-a' },
 		});
 		const text = readFileSync(path, 'utf8');
+		expect(first.changed).toBe(true);
+		expect(second.changed).toBe(false);
+		expect(second.diff).toBe('Client configuration unchanged; contents withheld.');
 		expect(text).toContain('# keep this comment');
 		expect(text).toContain('model = "gpt-5"');
 		expect(text).toContain('[mcp_servers.other]');

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,6 +90,11 @@ spawns it through MCP stdio, lists tools, calls `stonewright-task-start` and
 status, and stores a version/tool-surface receipt. Structural config validation
 is reported separately and is never presented as live runtime proof.
 
+Client configuration receipts are content-free. They report the named server,
+change/backup state, support tier, and browser-consent metadata, but never emit
+the client configuration body, unrelated local settings, or absolute config and
+backup paths.
+
 Plugin mode owns the broad guarded write surface. Direct mode is not a fallback:
 it owns a documented pluginless surface, local task-start profiles, persistent
 private state, and read-only WooCommerce access. Capability differences are

--- a/docs/releases/1.0.0-beta.7.md
+++ b/docs/releases/1.0.0-beta.7.md
@@ -1,0 +1,54 @@
+# Stonewright 1.0.0-beta.7
+
+Released: 2026-08-12
+
+## Summary
+
+This privacy hotfix keeps installer and repair receipts useful without printing
+the surrounding private AI-client configuration. It supersedes beta.6; all
+deterministic Plugin-mode connection and Setup save fixes from beta.6 remain
+included.
+
+## Fixed
+
+- `stonewright connect add` and `stonewright connect repair` no longer return a
+  line-by-line client configuration diff.
+- Connect receipts no longer expose absolute client config or backup paths.
+- Receipts retain only the named server, whether configuration changed, whether
+  a backup was created, whether the server entry was created, the compatibility
+  tier, browser-consent metadata, and a content-free change count.
+- Regression coverage seeds unrelated private-looking client settings and
+  proves neither their values nor the config path reach stdout.
+
+## Upgrade
+
+Update the plugin and companion together. Repair an existing installed-plugin
+stdio alias without re-entering its saved Application Password:
+
+```bash
+npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz stonewright connect repair <alias> --client <client> --mode plugin-only
+```
+
+Fully restart the MCP client, then run:
+
+```bash
+npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz stonewright connect verify <alias> --client <client>
+```
+
+Success requires the requested alias, `configured_mode=plugin-only`,
+`active_mode=plugin`, the expected companion version, visible task-start and
+status tools, and no missing required tools.
+
+## Compatibility and safety
+
+- WordPress plugin and companion: `1.0.0-beta.7`.
+- Plugin mode registers **360** abilities; Direct full exposes **100** tools.
+- WordPress: 6.7 or newer.
+- PHP: 8.1 or newer.
+- Node.js: 20 or newer for the companion.
+- No permission, confirmation, backup, validation, custom-code approval, or
+  Direct-mode write boundary changed.
+
+Release assets contain `stonewright-1.0.0-beta.7.zip`,
+`stonewright-companion-1.0.0-beta.7.tgz`, the Visual package, and
+`SHA256SUMS.txt`.

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -74,6 +74,9 @@ This reuses the existing credential reference, refreshes only the named client
 entry, and makes the alias authoritative over stale inherited WordPress
 environment values. Restart the client, then run `connect verify`; another
 alias or `active_mode=direct` is a failed plugin-mode update, not success.
+The repair receipt is content-free: it confirms the server name, change/backup
+state, support tier, and browser consent without printing the surrounding
+private client configuration or absolute config/backup paths.
 
 Direct mode keeps its private state under `~/.stonewright/`. Replacing the
 companion package does not reset its memory, user-created skills, site

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [1.0.0-beta.7] - 2026-08-12
+
+### Changed
+
+- Align plugin metadata and generated companion package references with the
+  privacy hardening release. No plugin ability, permission, backup,
+  confirmation, validation, audit, or custom-code gate changed.
+
 ## [1.0.0-beta.6] - 2026-08-12
 
 ### Changed
@@ -127,7 +135,12 @@
 - Return exact batch-mutation repair hints, guarded escaped-layout decoding,
   and stable receipts for the new post-write closure.
 
-## [1.0.0-beta.2] - 2026-07-30
+## Older releases
+
+- [1.0.0-beta.2](../docs/releases/1.0.0-beta.2.md)
+- [1.0.0-beta.1](../docs/releases/1.0.0-beta.1.md)
+
+### 1.0.0-beta.2 — 2026-07-30
 
 ### Added
 
@@ -149,10 +162,6 @@
 - Center Domain Lock controls, restore Sandbox file-type contrast, remove an
   inline category-action click handler, and correct setup code contrast and
   Visual Workspace focus outlines.
-
-## Older releases
-
-See [1.0.0-beta.1](../docs/releases/1.0.0-beta.1.md) for the first public beta.
 
 ### 1.0.0-beta.1 — 2026-07-30
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,6 +1,6 @@
 # Stonewright Plugin
 
-Version: 1.0.0-beta.6
+Version: 1.0.0-beta.7
 Requires WordPress: 6.7+
 Requires PHP: 8.1+
 License: AGPL-3.0-or-later

--- a/plugin/stonewright.php
+++ b/plugin/stonewright.php
@@ -3,7 +3,7 @@
  * Plugin Name: Stonewright
  * Plugin URI: https://github.com/cosmincraciun97/stonewright-wp-mcp
  * Description: Guarded WordPress MCP tools for Elementor, Gutenberg/FSE, WooCommerce catalogs, content models, PHP runtime execution, and tokenized WP-CLI.
- * Version: 1.0.0-beta.6
+ * Version: 1.0.0-beta.7
  * Requires at least: 6.7
  * Requires PHP: 8.1
  * Author: Stonewright
@@ -33,7 +33,7 @@ if ( defined( 'STONEWRIGHT_FILE' ) ) {
 define( 'STONEWRIGHT_FILE', __FILE__ );
 define( 'STONEWRIGHT_DIR', plugin_dir_path( __FILE__ ) );
 define( 'STONEWRIGHT_URL', plugin_dir_url( __FILE__ ) );
-define( 'STONEWRIGHT_VERSION', '1.0.0-beta.6' );
+define( 'STONEWRIGHT_VERSION', '1.0.0-beta.7' );
 define( 'STONEWRIGHT_MIN_PHP', '8.1' );
 define( 'STONEWRIGHT_MIN_WP', '6.7' );
 

--- a/plugin/tests/Unit/Support/ReleaseRetentionTest.php
+++ b/plugin/tests/Unit/Support/ReleaseRetentionTest.php
@@ -19,7 +19,7 @@ final class ReleaseRetentionTest extends TestCase {
 				$versioned[] = $name;
 			}
 		}
-		self::assertSame( [ '1.0.0-beta.1.md', '1.0.0-beta.2.md', '1.0.0-beta.3.md', '1.0.0-beta.4.md', '1.0.0-beta.5.md', '1.0.0-beta.6.md' ], $versioned );
+		self::assertSame( [ '1.0.0-beta.1.md', '1.0.0-beta.2.md', '1.0.0-beta.3.md', '1.0.0-beta.4.md', '1.0.0-beta.5.md', '1.0.0-beta.6.md', '1.0.0-beta.7.md' ], $versioned );
 	}
 
 	public function test_root_changelog_keeps_latest_five_releases_and_links_older_history(): void {
@@ -34,7 +34,7 @@ final class ReleaseRetentionTest extends TestCase {
 			)
 		);
 		self::assertContains( 'Unreleased', $headers );
-		self::assertSame( [ '1.0.0-beta.6', '1.0.0-beta.5', '1.0.0-beta.4', '1.0.0-beta.3', '1.0.0-beta.2' ], $versions );
+		self::assertSame( [ '1.0.0-beta.7', '1.0.0-beta.6', '1.0.0-beta.5', '1.0.0-beta.4', '1.0.0-beta.3' ], $versions );
 		self::assertStringContainsString( '## Older releases', $raw );
 		self::assertStringContainsString( 'docs/releases/1.0.0-beta.1.md', $raw );
 	}


### PR DESCRIPTION
## Summary
- replace line-by-line client configuration diffs with content-free change summaries
- omit absolute client config and backup paths from connect receipts
- report accurate changed/unchanged state for idempotent updates
- align plugin and companion metadata, changelogs, release notes, architecture, and update docs for v1.0.0-beta.7

## Changed abilities
- None

## Safety gates
- Backup, confirmation-token, permission, validation, audit, and custom-code approval behavior are unchanged.
- Client config writes remain atomic, backed up, validated, and rolled back on failure. Only receipt exposure changes.

## Public documentation
- Root, plugin, and companion changelogs updated.
- Release notes, architecture, and update guidance updated.

## Validation
- companion typecheck, lint, compatibility contracts, 457 tests, token budgets, build, and dependency audit
- plugin 6,819 tests, compatibility contracts, PHPStan, PHPCS, security/dependency audits, provenance lint, and token budgets
- documentation freshness, public hygiene, and git diff checks