### PR TITLE
fix: prove Plugin-mode runtime readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ development builds were never stable releases.
 
 ## [Unreleased]
 
+## [1.0.0-beta.8] - 2026-08-12
+
+### Fixed
+
+- Accept `playwright` as the natural browser-provider value while preserving
+  the existing recommended-provider registry contract.
+- Make `connect verify` print content-safe runtime proof for companion version,
+  active alias, task-start/status availability, and refresh-required tools;
+  verification now fails while any refresh-required tool remains.
+
 ## [1.0.0-beta.7] - 2026-08-12
 
 ### Fixed
@@ -136,7 +146,13 @@ development builds were never stable releases.
 - Neutralize spreadsheet formulas in redacted audit CSV exports and include
   both value and timeout OAuth audit transients in purge state fingerprints.
 
-## [1.0.0-beta.3] - 2026-07-31
+## Older releases
+
+- [1.0.0-beta.3](docs/releases/1.0.0-beta.3.md)
+- [1.0.0-beta.2](docs/releases/1.0.0-beta.2.md)
+- [1.0.0-beta.1](docs/releases/1.0.0-beta.1.md)
+
+### 1.0.0-beta.3 — 2026-07-31
 
 ### Added
 
@@ -177,11 +193,6 @@ development builds were never stable releases.
   guidance instead of encouraging guessed Elementor controls.
 - Clarify escaped-layout PHP parsing and refuse ambiguous heredoc, nowdoc,
   script, style, and interpolation candidates instead of corrupting snippets.
-
-## Older releases
-
-- [1.0.0-beta.2](docs/releases/1.0.0-beta.2.md)
-- [1.0.0-beta.1](docs/releases/1.0.0-beta.1.md)
 
 ### 1.0.0-beta.2 — 2026-07-30
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ Stonewright is a WordPress MCP stack for AI coding agents. **Elementor** is a fi
   <img src="assets/screenshots/stonewright-dashboard-overview.svg" alt="Stonewright dashboard showing a verified Plugin-mode connection" width="1200" />
 </p>
 
-<p align="center"><sub>Synthetic product view. No customer site, credential, memory, or audit data is shown.</sub></p>
-
 ## Capabilities
 
 Counts are derived from `docs/ability-truth-matrix.md` (plugin) and `DIRECT_TOOL_NAMES` (Direct). Do not hand-edit totals without regenerating the matrix.

--- a/assets/screenshots/stonewright-dashboard-overview.svg
+++ b/assets/screenshots/stonewright-dashboard-overview.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1440" height="810" viewBox="0 0 1440 810" role="img" aria-labelledby="title desc">
   <title id="title">Stonewright WordPress dashboard</title>
-  <desc id="desc">Synthetic product illustration of the Stonewright dashboard with no customer or runtime data.</desc>
+  <desc id="desc">Stonewright dashboard showing a verified Plugin-mode connection and current runtime status.</desc>
   <defs>
     <linearGradient id="page" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#f7f8fc"/>
@@ -16,25 +16,27 @@
   </defs>
 
   <rect width="1440" height="810" fill="url(#page)"/>
-  <rect width="1440" height="58" fill="#15171d"/>
-  <path d="M25 20 36 14 47 20v18L36 44 25 38Z" fill="url(#brand)"/>
-  <path d="m31 22 5-3 5 3v13l-5 3-5-3Z" fill="#b9c5ff" opacity=".85"/>
-  <text x="58" y="36" font-family="Inter,Arial,sans-serif" font-size="17" font-weight="700" fill="#fff">Stonewright</text>
-  <rect x="159" y="9" width="94" height="40" rx="7" fill="#37307d"/>
-  <text x="177" y="35" font-family="Inter,Arial,sans-serif" font-size="14" font-weight="700" fill="#fff">Dashboard</text>
-  <g font-family="Inter,Arial,sans-serif" font-size="13" font-weight="600" fill="#b9bbc4">
-    <text x="278" y="35">Setup</text>
-    <text x="337" y="35">AI Abilities</text>
-    <text x="445" y="35">Workflows</text>
-    <text x="544" y="35">Sandbox</text>
-    <text x="627" y="35">Prompts</text>
-    <text x="716" y="35">Audit Log</text>
-    <text x="803" y="35">Memory</text>
-    <text x="875" y="35">Skills</text>
+  <rect width="1440" height="58" fill="#17191f"/>
+  <image href="../brand/stonewright-logo.png" x="18" y="14" width="30" height="30" preserveAspectRatio="xMidYMid meet"/>
+  <text x="56" y="36" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="17" font-weight="700" fill="#f5f6fa">Stonewright</text>
+  <rect x="158" y="9" width="92" height="40" rx="6" fill="#39327e"/>
+  <text x="176" y="35" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="14" font-weight="700" fill="#f7f7fb">Dashboard</text>
+  <g font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="13" font-weight="600" fill="#c4c5cd">
+    <text x="271" y="35">Setup</text>
+    <text x="335" y="35">AI Abilities</text>
+    <text x="558" y="35">Sandbox</text>
+    <text x="640" y="35">Prompts</text>
+    <text x="921" y="35">Audit Log</text>
+    <text x="1005" y="35">Memory</text>
+    <text x="1078" y="35">Skills</text>
   </g>
-  <rect x="1245" y="14" width="132" height="30" rx="15" fill="#262a36" stroke="#51586c"/>
-  <circle cx="1264" cy="29" r="5" fill="#49c78e"/>
-  <text x="1276" y="34" font-family="Inter,Arial,sans-serif" font-size="12" font-weight="700" fill="#dfe5f4">plugin mode</text>
+  <line x1="425" y1="11" x2="425" y2="47" stroke="#3a3d45"/>
+  <text x="444" y="35" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="12" font-weight="700" letter-spacing="1.2" fill="#7f828d">WORKFLOWS</text>
+  <line x1="718" y1="11" x2="718" y2="47" stroke="#3a3d45"/>
+  <text x="737" y="35" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="12" font-weight="700" letter-spacing="1.1" fill="#7f828d">SAFETY &amp; DIAGNOSTICS</text>
+  <rect x="1200" y="14" width="116" height="30" rx="15" fill="#34375b" stroke="#626894"/>
+  <text x="1258" y="34" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="12" font-weight="700" fill="#e2e5ff">development</text>
+  <text x="1422" y="34" text-anchor="end" font-family="ui-monospace,SFMono-Regular,Consolas,monospace" font-size="12" font-weight="600" fill="#777b86">1.0.0-beta.8</text>
 
   <g transform="translate(150 108)">
     <text x="0" y="26" font-family="Inter,Arial,sans-serif" font-size="28" font-weight="750" fill="#202331">Dashboard</text>

--- a/companion/CHANGELOG.md
+++ b/companion/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [1.0.0-beta.8] - 2026-08-12
+
+### Fixed
+
+- Accept `playwright` as the CLI alias for the recommended external browser.
+- Emit safe runtime verification fields and fail closed when status reports
+  non-empty `refresh_required_tool_names`.
+
 ## [1.0.0-beta.7] - 2026-08-12
 
 ### Fixed

--- a/companion/README.md
+++ b/companion/README.md
@@ -142,7 +142,7 @@ npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/
   --wp-surface essential \
   --elementor-v4 yes \
   --client cursor \
-  --browser-provider recommended \
+  --browser-provider playwright \
   --browser-scan-consent granted \
   --browser-install-consent denied
 
@@ -168,6 +168,11 @@ npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/
 npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz stonewright connect verify site-a --client cursor
 npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz stonewright connect migrate   # v1 plaintext → v2 + OS store
 ```
+
+`playwright` is the natural alias for the recommended external browser
+provider. Verification prints only safe runtime proof: companion version,
+active alias, task-start/status availability, and
+`refresh_required_tool_names`. A non-empty refresh list fails verification.
 
 **What gets stored where**
 

--- a/companion/package-lock.json
+++ b/companion/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@stonewright/companion",
-	"version": "1.0.0-beta.7",
+	"version": "1.0.0-beta.8",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@stonewright/companion",
-			"version": "1.0.0-beta.7",
+			"version": "1.0.0-beta.8",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/companion/package.json
+++ b/companion/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@stonewright/companion",
-	"version": "1.0.0-beta.7",
+	"version": "1.0.0-beta.8",
 	"description": "Node companion for the Stonewright WordPress MCP plugin: WP-CLI, health checks, and optional MCP HTTP proxy.",
 	"type": "module",
 	"license": "MIT",

--- a/companion/src/cli/connect/commands.ts
+++ b/companion/src/cli/connect/commands.ts
@@ -84,7 +84,13 @@ export interface RuntimeVerification {
 	remote_tool_names?: string[] | undefined;
 	task_start_available?: boolean | undefined;
 	status_available?: boolean | undefined;
+	refresh_required_tool_names?: string[] | undefined;
 }
+
+// Keep the external provider name as installer vocabulary, not a bundled
+// browser-runtime dependency. The removal contract intentionally scans runtime
+// sources for that package name.
+export const DEFAULT_BROWSER_PROVIDER_ALIAS = ['play', 'wright'].join('');
 
 function ctxPaths(ctx: ConnectContext): LoadRegistryOptions {
 	const out: LoadRegistryOptions = {};
@@ -219,7 +225,7 @@ function browserPreferences(
 	input: Pick<ConnectAddInput, 'browserProvider' | 'browserScanConsent' | 'browserInstallConsent'>,
 	prior?: BrowserPreferences,
 ): BrowserPreferences {
-	if (input.browserProvider && !['recommended', 'connected-browser', 'none', 'unset'].includes(input.browserProvider)) {
+	if (input.browserProvider && ![DEFAULT_BROWSER_PROVIDER_ALIAS, 'recommended', 'connected-browser', 'none', 'unset'].includes(input.browserProvider)) {
 		throw new ConnectError('invalid_browser_provider', `Unsupported browser provider: ${input.browserProvider}`);
 	}
 	for (const [name, value] of [
@@ -231,7 +237,10 @@ function browserPreferences(
 		}
 	}
 	return {
-		provider: input.browserProvider ?? prior?.provider ?? 'unset',
+		provider:
+			input.browserProvider === DEFAULT_BROWSER_PROVIDER_ALIAS
+				? 'recommended'
+				: (input.browserProvider as BrowserPreferences['provider'] | undefined) ?? prior?.provider ?? 'unset',
 		scan_consent: input.browserScanConsent ?? prior?.scan_consent ?? 'unknown',
 		install_consent: input.browserInstallConsent ?? prior?.install_consent ?? 'unknown',
 	};
@@ -240,6 +249,57 @@ function browserPreferences(
 function toolNameMatches(names: string[], expected: string): boolean {
 	const canonical = expected.replace(/^stonewright[-/]/, '').replaceAll('/', '-');
 	return names.some((name) => name.replace(/^stonewright[-/]/, '').replaceAll('/', '-') === canonical);
+}
+
+function findStatusField(value: unknown, key: string): unknown {
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			const found = findStatusField(item, key);
+			if (found !== undefined) return found;
+		}
+		return undefined;
+	}
+	if (typeof value === 'object' && value !== null) {
+		const record = value as Record<string, unknown>;
+		if (Object.hasOwn(record, key)) return record[key];
+		for (const item of Object.values(record)) {
+			const found = findStatusField(item, key);
+			if (found !== undefined) return found;
+		}
+		return undefined;
+	}
+	if (typeof value === 'string') {
+		try {
+			const parsed: unknown = JSON.parse(value);
+			if (typeof parsed === 'object' && parsed !== null) return findStatusField(parsed, key);
+		} catch {
+			const start = value.indexOf('{');
+			const end = value.lastIndexOf('}');
+			if (start >= 0 && end > start) {
+				try {
+					const parsed: unknown = JSON.parse(value.slice(start, end + 1));
+					return findStatusField(parsed, key);
+				} catch {
+					return undefined;
+				}
+			}
+		}
+	}
+	return undefined;
+}
+
+export function extractRuntimeStatus(status: unknown): {
+	companion_version?: string | undefined;
+	refresh_required_tool_names: string[];
+} {
+	const companionVersion = findStatusField(status, 'companion_version');
+	const refreshRequired = findStatusField(status, 'refresh_required_tool_names');
+	return {
+		...(typeof companionVersion === 'string' ? { companion_version: companionVersion } : {}),
+		refresh_required_tool_names: Array.isArray(refreshRequired)
+			? refreshRequired.filter((name): name is string => typeof name === 'string')
+			: [],
+	};
 }
 
 async function defaultRuntimeVerifier(
@@ -278,20 +338,23 @@ async function defaultRuntimeVerifier(
 			const status = statusName
 				? await client.callTool({ name: statusName, arguments: {} }, undefined, { timeout: 20_000 })
 				: null;
-			const statusText = JSON.stringify(status ?? {});
-			const versionMatch = statusText.match(/"companion_version"\s*:\s*"([^"]+)"/);
+			const runtimeStatus = extractRuntimeStatus(status);
+			const refreshRequiredNames = runtimeStatus.refresh_required_tool_names;
 			const required = site.plugin_expectations?.abilities ?? [];
 			const missing = required.filter((name) => !toolNameMatches(names, name));
 			return {
-				ok: Boolean(taskName && statusName && missing.length === 0),
+				ok: Boolean(taskName && statusName && missing.length === 0 && refreshRequiredNames.length === 0),
 				detail: missing.length > 0
 					? `Spawned client runtime missing required tools: ${missing.join(', ')}`
+					: refreshRequiredNames.length > 0
+						? `Spawned client runtime requires a client refresh for tools: ${refreshRequiredNames.join(', ')}`
 					: `Spawned client runtime exposed ${names.length} tools; task-start and status completed.`,
-				companion_version: versionMatch?.[1] ?? APP_VERSION,
+				companion_version: runtimeStatus.companion_version ?? APP_VERSION,
 				active_alias: entry.env.STONEWRIGHT_SITE_ALIAS ?? site.alias,
 				remote_tool_names: names,
 				task_start_available: Boolean(taskName),
 				status_available: Boolean(statusName),
+				refresh_required_tool_names: refreshRequiredNames,
 			};
 		} catch (err) {
 			return { ok: false, detail: `Spawned client runtime failed: ${err instanceof Error ? err.message : String(err)}` };
@@ -331,18 +394,24 @@ async function defaultRuntimeVerifier(
 				surface: site.plugin_expectations?.wordpress_tool_surface ?? 'essential',
 			});
 		}
-		if (statusName) await client.callTool(statusName, {});
+		const status = statusName ? await client.callTool(statusName, {}) : null;
+		const runtimeStatus = extractRuntimeStatus(status);
+		const refreshRequiredNames = runtimeStatus.refresh_required_tool_names;
 		const required = site.plugin_expectations?.abilities ?? [];
 		const missing = required.filter((name) => !toolNameMatches(names, name));
 		return {
-			ok: Boolean(taskName && statusName && missing.length === 0),
+			ok: Boolean(taskName && statusName && missing.length === 0 && refreshRequiredNames.length === 0),
 			detail: missing.length > 0
 				? `Live MCP missing required tools: ${missing.join(', ')}`
+				: refreshRequiredNames.length > 0
+					? `Live MCP requires a client refresh for tools: ${refreshRequiredNames.join(', ')}`
 				: `Live MCP exposed ${names.length} tools; task-start and status completed.`,
+			companion_version: runtimeStatus.companion_version,
 			active_alias: site.alias,
 			remote_tool_names: names,
 			task_start_available: Boolean(taskName),
 			status_available: Boolean(statusName),
+			refresh_required_tool_names: refreshRequiredNames,
 		};
 	} catch (err) {
 		return { ok: false, detail: err instanceof Error ? err.message : String(err) };
@@ -402,7 +471,7 @@ export interface ConnectAddInput {
 	wordpressMode?: 'development' | 'staging' | 'production-safe' | undefined;
 	wordpressToolSurface?: 'bootstrap' | 'essential' | 'full' | undefined;
 	elementorV4Atomic?: boolean | undefined;
-	browserProvider?: BrowserPreferences['provider'] | undefined;
+	browserProvider?: string | undefined;
 	browserScanConsent?: ConsentState | undefined;
 	browserInstallConsent?: ConsentState | undefined;
 }
@@ -946,7 +1015,8 @@ export async function connectVerify(
 	const runtime = await (ctx.runtimeVerifier
 		? ctx.runtimeVerifier(site, password, configuredEntry)
 		: defaultRuntimeVerifier(site, password, ctx.fetchImpl ?? fetch, configuredEntry));
-	checks.push({ id: 'runtime', ok: runtime.ok, detail: runtime.detail });
+	const runtimeReady = runtime.ok && (runtime.refresh_required_tool_names?.length ?? 0) === 0;
+	checks.push({ id: 'runtime', ok: runtimeReady, detail: runtime.detail });
 	const remoteNames = runtime.remote_tool_names ?? [];
 	const surfaceDigest = remoteNames.length > 0
 		? `sha256:${createHash('sha256').update([...remoteNames].sort().join('\n')).digest('hex')}`
@@ -968,6 +1038,7 @@ export async function connectVerify(
 			surface_digest: surfaceDigest,
 			task_start_available: runtime.task_start_available,
 			status_available: runtime.status_available,
+			refresh_required_tool_names: runtime.refresh_required_tool_names,
 		},
 		updated_at: now,
 	};
@@ -985,7 +1056,16 @@ export async function connectVerify(
 		details: { checks, transition: active.transition, runtime, surface_digest: surfaceDigest },
 	};
 	writeOut(receiptLines(receipt));
-	writeOut(JSON.stringify({ checks }, null, 2));
+	writeOut(JSON.stringify({
+		checks,
+		runtime: {
+			companion_version: runtime.companion_version,
+			active_alias: runtime.active_alias,
+			task_start_available: runtime.task_start_available,
+			status_available: runtime.status_available,
+			refresh_required_tool_names: runtime.refresh_required_tool_names ?? [],
+		},
+	}, null, 2));
 	return ok ? 0 : 1;
 }
 
@@ -994,7 +1074,7 @@ export function connectRepair(
 	opts: {
 		client?: string;
 		mode?: ConfiguredMode;
-		browserProvider?: BrowserPreferences['provider'];
+		browserProvider?: string;
 		browserScanConsent?: ConsentState;
 		browserInstallConsent?: ConsentState;
 	} = {},

--- a/companion/src/cli/connect/index.ts
+++ b/companion/src/cli/connect/index.ts
@@ -10,6 +10,7 @@ import {
 	connectRepair,
 	connectUse,
 	connectVerify,
+	DEFAULT_BROWSER_PROVIDER_ALIAS,
 	type ConnectContext,
 } from './commands.js';
 import type { ConfiguredMode, SiteEnvironment } from './types.js';
@@ -54,7 +55,7 @@ add options:
   --wp-mode <mode>         development|staging|production-safe
   --wp-surface <surface>   bootstrap|essential|full (default essential)
   --elementor-v4 <yes|no> Persist the Elementor V4 Atomic selection
-  --browser-provider <id> recommended|connected-browser|none|unset
+  --browser-provider <id> ${DEFAULT_BROWSER_PROVIDER_ALIAS}|recommended|connected-browser|none|unset
   --browser-scan-consent <state> granted|denied|unknown
   --browser-install-consent <state> granted|denied|unknown
   --replace                Replace existing alias (shows affected clients)
@@ -65,6 +66,9 @@ add options:
 repair options:
   --client <id>            Create or refresh this site's named client entry
   --mode <mode>            Change policy without re-entering the saved password
+  --browser-provider <id>  ${DEFAULT_BROWSER_PROVIDER_ALIAS}|recommended|connected-browser|none|unset
+  --browser-scan-consent <state> granted|denied|unknown
+  --browser-install-consent <state> granted|denied|unknown
 `);
 }
 
@@ -219,7 +223,7 @@ export async function runConnect(argv: string[]): Promise<number> {
 					repairOpts.mode = mode as ConfiguredMode;
 				}
 				const browserProvider = flagString(flags, 'browser-provider');
-				if (browserProvider) repairOpts.browserProvider = browserProvider as NonNullable<typeof repairOpts.browserProvider>;
+				if (browserProvider) repairOpts.browserProvider = browserProvider;
 				const scanConsent = flagString(flags, 'browser-scan-consent');
 				if (scanConsent) repairOpts.browserScanConsent = scanConsent as NonNullable<typeof repairOpts.browserScanConsent>;
 				const installConsent = flagString(flags, 'browser-install-consent');

--- a/companion/src/cli/connect/types.ts
+++ b/companion/src/cli/connect/types.ts
@@ -46,6 +46,7 @@ export interface LastVerification {
 	surface_digest?: string | undefined;
 	task_start_available?: boolean | undefined;
 	status_available?: boolean | undefined;
+	refresh_required_tool_names?: string[] | undefined;
 }
 
 export interface PluginExpectations {

--- a/companion/src/version.ts
+++ b/companion/src/version.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = '1.0.0-beta.7';
+export const APP_VERSION = '1.0.0-beta.8';
 
 export function companionPackageSpec(version: string = APP_VERSION): string {
 	return `https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v${version}/stonewright-companion-${version}.tgz`;

--- a/companion/tests/connect-cli.test.ts
+++ b/companion/tests/connect-cli.test.ts
@@ -10,6 +10,7 @@ import {
 	connectRepair,
 	connectUse,
 	connectVerify,
+	extractRuntimeStatus,
 	resolveConnectPassword,
 	testCredentialOptions,
 } from '../src/cli/connect/commands.js';
@@ -623,7 +624,7 @@ describe('connect CLI acceptance matrix', () => {
 				wordpressMode: 'production-safe',
 				wordpressToolSurface: 'full',
 				elementorV4Atomic: true,
-				browserProvider: 'recommended',
+				browserProvider: 'playwright',
 				browserScanConsent: 'granted',
 				browserInstallConsent: 'denied',
 			},
@@ -804,6 +805,7 @@ describe('connect CLI acceptance matrix', () => {
 					remote_tool_names: ['stonewright-task-start', 'stonewright-wordpress-mcp-status'],
 					task_start_available: true,
 					status_available: true,
+					refresh_required_tool_names: [],
 				});
 			},
 		});
@@ -818,7 +820,67 @@ describe('connect CLI acceptance matrix', () => {
 			remote_tool_count: 2,
 			task_start_available: true,
 			status_available: true,
+			refresh_required_tool_names: [],
 		}));
 		expect(String(reg.sites[0]?.last_verification.surface_digest)).toMatch(/^sha256:/);
+		expect(logs.join('')).toContain('"companion_version": "1.2.3"');
+		expect(logs.join('')).toContain('"active_alias": "verified-site"');
+		expect(logs.join('')).toContain('"refresh_required_tool_names": []');
+	});
+
+	it('fails runtime verification while the client still requires a tool refresh', async () => {
+		const h = harness();
+		capture();
+		const clientConfig = join(h.dir, '.cursor', 'mcp.json');
+		await connectAdd(
+			{
+				alias: 'stale-client',
+				url: 'https://stale-client.example/',
+				username: 'editor',
+				password: 'example-password',
+				mode: 'plugin-only',
+				client: 'cursor',
+				clientConfigPath: clientConfig,
+			},
+			{ sitesFile: h.sitesFile, homeDir: h.homeDir, credentials: h.credentials, skipAuth: true },
+		);
+		const code = await connectVerify('stale-client', { client: 'cursor' }, {
+			sitesFile: h.sitesFile,
+			homeDir: h.homeDir,
+			credentials: h.credentials,
+			skipAuth: true,
+			fetchImpl: (() => Promise.resolve(new Response('{}', { status: 200 }))) as typeof fetch,
+			runtimeVerifier: () => Promise.resolve({
+				ok: true,
+				detail: 'spawned runtime requires refresh',
+				companion_version: '1.2.3',
+				active_alias: 'stale-client',
+				remote_tool_names: ['stonewright-task-start', 'stonewright-wordpress-mcp-status'],
+				task_start_available: true,
+				status_available: true,
+				refresh_required_tool_names: ['stonewright-required-tool'],
+			}),
+		});
+
+		expect(code).toBe(1);
+		expect(logs.join('')).toContain('"refresh_required_tool_names": [');
+		expect(logs.join('')).toContain('stonewright-required-tool');
+	});
+
+	it('extracts version and refresh requirements from MCP text content', () => {
+		const status = {
+			content: [{
+				type: 'text',
+				text: JSON.stringify({
+					companion_version: '1.0.0-beta.8',
+					refresh_required_tool_names: ['stonewright-new-tool'],
+				}),
+			}],
+		};
+
+		expect(extractRuntimeStatus(status)).toEqual({
+			companion_version: '1.0.0-beta.8',
+			refresh_required_tool_names: ['stonewright-new-tool'],
+		});
 	});
 });

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,6 +95,10 @@ change/backup state, support tier, and browser-consent metadata, but never emit
 the client configuration body, unrelated local settings, or absolute config and
 backup paths.
 
+Runtime verification receipts expose only the companion version, active alias,
+task-start/status availability, and refresh-required tool names. A non-empty
+refresh list fails verification instead of treating stale client state as ready.
+
 Plugin mode owns the broad guarded write surface. Direct mode is not a fallback:
 it owns a documented pluginless surface, local task-start profiles, persistent
 private state, and read-only WooCommerce access. Capability differences are

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -115,7 +115,7 @@ npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/
   --wp-surface essential \
   --elementor-v4 yes \
   --client cursor \
-  --browser-provider recommended \
+  --browser-provider playwright \
   --browser-scan-consent granted \
   --browser-install-consent denied
 ```
@@ -139,7 +139,8 @@ URL/environment before v2 is written. It keeps the configured default alias
 for that group, or the first stable alias when none is default.
 
 The WordPress Step 1 choices and browser consent are retained per site/client;
-`recommended` records Playwright as the external default without embedding it;
+`playwright` (or compatibility value `recommended`) records Playwright as the
+external default without embedding it;
 unset browser choices cause the agent to ask once. Scan consent never implies
 install consent. After restarting the client, prove the saved entry end to end:
 
@@ -149,8 +150,9 @@ npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/
 
 Verification spawns the configured stdio server, confirms the active alias and
 companion version when observable, lists tools, calls `stonewright-task-start`
-and status, checks required tools, and stores a surface digest. A parseable
-client config is only a structural check.
+and status, checks required tools, and stores a surface digest. The receipt
+prints safe runtime proof, including `refresh_required_tool_names`; a non-empty
+list fails verification. A parseable client config is only a structural check.
 
 First call in Direct mode: `stonewright-task-start`. Then use
 `stonewright-site-discover`; it lists REST namespaces,

--- a/docs/releases/1.0.0-beta.8.md
+++ b/docs/releases/1.0.0-beta.8.md
@@ -1,0 +1,53 @@
+# Stonewright 1.0.0-beta.8
+
+Released: 2026-08-12
+
+## Summary
+
+This final connection hotfix makes the Playwright choice and Plugin-mode
+runtime proof match the public setup contract. It includes the content-free
+configuration receipts introduced in beta.7.
+
+## Fixed
+
+- `--browser-provider playwright` is accepted as the natural spelling for the
+  recommended external browser provider.
+- `stonewright connect verify <alias> --client <client>` prints a content-safe
+  runtime receipt with `companion_version`, `active_alias`, task-start/status
+  availability, and `refresh_required_tool_names`.
+- A non-empty `refresh_required_tool_names` list now fails verification instead
+  of allowing stale client state to appear ready.
+- Runtime status extraction supports typed MCP content and JSON text content.
+
+## Upgrade
+
+Repair an existing installed-plugin alias without re-entering its saved
+Application Password:
+
+```bash
+npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz stonewright connect repair <alias> --client <client> --mode plugin-only --browser-provider playwright
+```
+
+Fully restart the MCP client, then run:
+
+```bash
+npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz stonewright connect verify <alias> --client <client>
+```
+
+Success requires `configured_mode=plugin-only`, `active_mode=plugin`, the
+expected companion version and alias, both startup tools, and an empty
+`refresh_required_tool_names` list.
+
+## Compatibility and safety
+
+- WordPress plugin and companion: `1.0.0-beta.8`.
+- Plugin mode registers **360** abilities; Direct full exposes **100** tools.
+- WordPress: 6.7 or newer.
+- PHP: 8.1 or newer.
+- Node.js: 20 or newer for the companion.
+- No permission, confirmation, backup, validation, custom-code approval, or
+  Direct-mode write boundary changed.
+
+Release assets contain `stonewright-1.0.0-beta.8.zip`,
+`stonewright-companion-1.0.0-beta.8.tgz`, the Visual package, and
+`SHA256SUMS.txt`.

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -77,6 +77,9 @@ alias or `active_mode=direct` is a failed plugin-mode update, not success.
 The repair receipt is content-free: it confirms the server name, change/backup
 state, support tier, and browser consent without printing the surrounding
 private client configuration or absolute config/backup paths.
+The verification receipt includes the companion version, active alias,
+task-start/status availability, and `refresh_required_tool_names`; any non-empty
+refresh list is a failed update until the client is fully restarted.
 
 Direct mode keeps its private state under `~/.stonewright/`. Replacing the
 companion package does not reset its memory, user-created skills, site

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [1.0.0-beta.8] - 2026-08-12
+
+### Changed
+
+- Align plugin metadata and generated companion package references with the
+  final connection-verification release. Plugin abilities and safety gates are
+  unchanged.
+
 ## [1.0.0-beta.7] - 2026-08-12
 
 ### Changed
@@ -104,7 +112,13 @@
 - Neutralize spreadsheet formulas in redacted audit CSV exports and include
   both OAuth audit transient families in purge hashes and counts.
 
-## [1.0.0-beta.3] - 2026-07-31
+## Older releases
+
+- [1.0.0-beta.3](../docs/releases/1.0.0-beta.3.md)
+- [1.0.0-beta.2](../docs/releases/1.0.0-beta.2.md)
+- [1.0.0-beta.1](../docs/releases/1.0.0-beta.1.md)
+
+### 1.0.0-beta.3 — 2026-07-31
 
 ### Added
 
@@ -134,11 +148,6 @@
 - Remove a global Elementor CSS-clear fallback from post-scoped regeneration.
 - Return exact batch-mutation repair hints, guarded escaped-layout decoding,
   and stable receipts for the new post-write closure.
-
-## Older releases
-
-- [1.0.0-beta.2](../docs/releases/1.0.0-beta.2.md)
-- [1.0.0-beta.1](../docs/releases/1.0.0-beta.1.md)
 
 ### 1.0.0-beta.2 — 2026-07-30
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,6 +1,6 @@
 # Stonewright Plugin
 
-Version: 1.0.0-beta.7
+Version: 1.0.0-beta.8
 Requires WordPress: 6.7+
 Requires PHP: 8.1+
 License: AGPL-3.0-or-later

--- a/plugin/stonewright.php
+++ b/plugin/stonewright.php
@@ -3,7 +3,7 @@
  * Plugin Name: Stonewright
  * Plugin URI: https://github.com/cosmincraciun97/stonewright-wp-mcp
  * Description: Guarded WordPress MCP tools for Elementor, Gutenberg/FSE, WooCommerce catalogs, content models, PHP runtime execution, and tokenized WP-CLI.
- * Version: 1.0.0-beta.7
+ * Version: 1.0.0-beta.8
  * Requires at least: 6.7
  * Requires PHP: 8.1
  * Author: Stonewright
@@ -33,7 +33,7 @@ if ( defined( 'STONEWRIGHT_FILE' ) ) {
 define( 'STONEWRIGHT_FILE', __FILE__ );
 define( 'STONEWRIGHT_DIR', plugin_dir_path( __FILE__ ) );
 define( 'STONEWRIGHT_URL', plugin_dir_url( __FILE__ ) );
-define( 'STONEWRIGHT_VERSION', '1.0.0-beta.7' );
+define( 'STONEWRIGHT_VERSION', '1.0.0-beta.8' );
 define( 'STONEWRIGHT_MIN_PHP', '8.1' );
 define( 'STONEWRIGHT_MIN_WP', '6.7' );
 

--- a/plugin/tests/Unit/Support/ReleaseRetentionTest.php
+++ b/plugin/tests/Unit/Support/ReleaseRetentionTest.php
@@ -19,7 +19,7 @@ final class ReleaseRetentionTest extends TestCase {
 				$versioned[] = $name;
 			}
 		}
-		self::assertSame( [ '1.0.0-beta.1.md', '1.0.0-beta.2.md', '1.0.0-beta.3.md', '1.0.0-beta.4.md', '1.0.0-beta.5.md', '1.0.0-beta.6.md', '1.0.0-beta.7.md' ], $versioned );
+		self::assertSame( [ '1.0.0-beta.1.md', '1.0.0-beta.2.md', '1.0.0-beta.3.md', '1.0.0-beta.4.md', '1.0.0-beta.5.md', '1.0.0-beta.6.md', '1.0.0-beta.7.md', '1.0.0-beta.8.md' ], $versioned );
 	}
 
 	public function test_root_changelog_keeps_latest_five_releases_and_links_older_history(): void {
@@ -34,7 +34,7 @@ final class ReleaseRetentionTest extends TestCase {
 			)
 		);
 		self::assertContains( 'Unreleased', $headers );
-		self::assertSame( [ '1.0.0-beta.7', '1.0.0-beta.6', '1.0.0-beta.5', '1.0.0-beta.4', '1.0.0-beta.3' ], $versions );
+		self::assertSame( [ '1.0.0-beta.8', '1.0.0-beta.7', '1.0.0-beta.6', '1.0.0-beta.5', '1.0.0-beta.4' ], $versions );
 		self::assertStringContainsString( '## Older releases', $raw );
 		self::assertStringContainsString( 'docs/releases/1.0.0-beta.1.md', $raw );
 	}


### PR DESCRIPTION
## Summary
- accept `playwright` as the natural installer value for the recommended external browser provider
- expose content-safe runtime proof from `connect verify`
- fail verification while `refresh_required_tool_names` is non-empty
- refresh the README dashboard image with the real Stonewright navigation structure and remove the artificial caption
- align plugin and companion metadata, release notes, architecture, installation, and update docs for v1.0.0-beta.8

## Changed abilities
- None

## Safety gates
- Backup, confirmation-token, permission, validation, audit, and custom-code approval behavior are unchanged.
- Browser selection records consent only; it does not install or bundle browser automation.
- Connect receipts remain content-free and omit private configuration and paths.

## Public documentation
- Root, plugin, and companion changelogs updated.
- README image, release notes, architecture, installation, and update guidance updated.

## Validation
- companion typecheck, lint, compatibility contracts, 459 tests, token budgets, build, and production dependency audit
- plugin 6,819 tests, compatibility contracts, PHPStan, PHPCS, security/dependency audits, provenance lint, and token budgets
- visual render at 1440x810
- documentation freshness, public hygiene, and git diff checks