### PR TITLE
fix: align plugin surface and Elementor visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ development builds were never stable releases.
 
 ## [Unreleased]
 
+## [1.0.0-beta.9] - 2026-08-12
+
+### Fixed
+
+- Derive companion refresh diagnostics from the exact profile catalog resolved
+  by the connected plugin, eliminating false stale-surface failures when the
+  local fallback catalog is newer than the live profile.
+- Reject bare or cross-device Elementor responsive visibility values and accept
+  only each primary device's native switcher value or the empty off state.
+
+### Changed
+
+- Ship responsive visibility as a native global Elementor rule: prefer builder
+  controls over CSS/JavaScript, treat editor-canvas visibility as non-proof,
+  and require settings readback plus frontend-class verification.
+
 ## [1.0.0-beta.8] - 2026-08-12
 
 ### Fixed
@@ -119,35 +135,9 @@ development builds were never stable releases.
 - Apply every runtime-affecting Step 1 control immediately, bump one shared
   surface revision, and expose the exact refresh contract to connected clients.
 
-## [1.0.0-beta.4] - 2026-08-05
-
-### Added
-
-- Add versioned audit events and incident lifecycle storage with category-aware
-  thresholds, exact verified resolution, idempotent legacy reconciliation, and
-  redacted public diagnostics.
-- Add replay-safe OAuth refresh rotation, atomic token persistence, bounded
-  retry/circuit handling, trusted-proxy-aware rate limiting, transactional
-  Elementor/Gutenberg receipts, patch validation, design manifests, visual
-  comparison, and read-only delivery/capability diagnostics.
-- Add count-only, hash-bound runtime-history purge with production confirmation,
-  reviewed deletion watermarks, concurrent-row preservation, and one retained
-  cleanup receipt.
-
-### Fixed
-
-- Require successful OAuth refreshes to rotate the refresh token; omitted or
-  replayed refresh credentials now clear durable state and require reauthorization.
-- Bind OAuth authorization and refresh requests to the canonical MCP resource,
-  advertise only the minimal `mcp` resource scope, and revoke an entire refresh
-  family plus its access tokens when a rotated credential is replayed.
-- Update companion transitive dependencies to patched releases and restore a
-  zero-advisory production dependency audit.
-- Neutralize spreadsheet formulas in redacted audit CSV exports and include
-  both value and timeout OAuth audit transients in purge state fingerprints.
-
 ## Older releases
 
+- [1.0.0-beta.4](docs/releases/1.0.0-beta.4.md)
 - [1.0.0-beta.3](docs/releases/1.0.0-beta.3.md)
 - [1.0.0-beta.2](docs/releases/1.0.0-beta.2.md)
 - [1.0.0-beta.1](docs/releases/1.0.0-beta.1.md)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Stonewright is a WordPress MCP stack for AI coding agents. **Elementor** is a fi
 </p>
 
 <p align="center">
-  <img src="assets/screenshots/stonewright-dashboard-beta8.svg" alt="Stonewright dashboard showing a verified Plugin-mode connection" width="1200" />
+  <img src="assets/screenshots/stonewright-dashboard-beta9.svg" alt="Stonewright dashboard showing a verified Plugin-mode connection" width="1200" />
 </p>
 
 ## Capabilities

--- a/assets/screenshots/stonewright-dashboard-beta9.svg
+++ b/assets/screenshots/stonewright-dashboard-beta9.svg
@@ -36,7 +36,7 @@
   <text x="712.2" y="33" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif" font-size="12" font-weight="600" letter-spacing=".72" fill="#f8f9fa" fill-opacity=".45">SAFETY &amp; DIAGNOSTICS</text>
   <rect x="1205" y="14" width="107" height="28" rx="14" fill="#6366f1" fill-opacity=".35"/>
   <text x="1258.5" y="33" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif" font-size="12" font-weight="600" fill="#e0e7ff">development</text>
-  <text x="1422" y="33" text-anchor="end" font-family="ui-monospace,'SF Mono','Cascadia Code',Consolas,monospace" font-size="12" fill="#f8f9fa" fill-opacity=".45">1.0.0-beta.8</text>
+  <text x="1422" y="33" text-anchor="end" font-family="ui-monospace,'SF Mono','Cascadia Code',Consolas,monospace" font-size="12" fill="#f8f9fa" fill-opacity=".45">1.0.0-beta.9</text>
 
   <g transform="translate(150 108)">
     <text x="0" y="26" font-family="Inter,Arial,sans-serif" font-size="28" font-weight="750" fill="#202331">Dashboard</text>

--- a/companion/CHANGELOG.md
+++ b/companion/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [1.0.0-beta.9] - 2026-08-12
+
+### Fixed
+
+- Use the plugin-resolved profile catalog for expected counts, missing-tool
+  diagnostics, and `refresh_required_tool_names` instead of comparing a live
+  connection with a potentially newer companion fallback list.
+
 ## [1.0.0-beta.8] - 2026-08-12
 
 ### Fixed

--- a/companion/data/global-rules.json
+++ b/companion/data/global-rules.json
@@ -154,6 +154,17 @@
 		}
 	},
 	{
+		"id": "elementor-native-responsive-visibility",
+		"severity": "strong",
+		"scope": "elementor",
+		"rule": "Hide Elementor elements with native Responsive controls only. Use hidden-desktop, hidden-laptop, hidden-tablet, or hidden-mobile for the matching hide setting; never use bare hidden or CSS/JavaScript as a substitute. The editor canvas may still show hidden elements. After writing, read back the settings and verify the frontend classes at the requested devices.",
+		"why": "Wrong switcher return values leave the editor toggle out of sync with saved metadata and do not produce reliable frontend visibility classes.",
+		"enforcement": {
+			"kind": "instruction",
+			"guard": ""
+		}
+	},
+	{
 		"id": "no-schema-guessing",
 		"severity": "strong",
 		"scope": "all",

--- a/companion/package-lock.json
+++ b/companion/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@stonewright/companion",
-	"version": "1.0.0-beta.8",
+	"version": "1.0.0-beta.9",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@stonewright/companion",
-			"version": "1.0.0-beta.8",
+			"version": "1.0.0-beta.9",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/companion/package.json
+++ b/companion/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@stonewright/companion",
-	"version": "1.0.0-beta.8",
+	"version": "1.0.0-beta.9",
 	"description": "Node companion for the Stonewright WordPress MCP plugin: WP-CLI, health checks, and optional MCP HTTP proxy.",
 	"type": "module",
 	"license": "MIT",

--- a/companion/src/connection/runtime.ts
+++ b/companion/src/connection/runtime.ts
@@ -171,7 +171,8 @@ export function createConnectionRuntime(args: {
 				PERMANENT_GATEWAY_TOOL_NAME_SET.has(n) || n.startsWith('stonewright-wp-cli-') || n.startsWith('companion_'),
 			).length;
 			const remoteCount = runtime.status.remote_tool_count;
-			const requested = proxyToolNamesForProfile(runtime.profile);
+			const requested = runtime.status.live?.requestedToolNames
+				?? proxyToolNamesForProfile(runtime.profile);
 			const refresh = computeRefreshRequiredToolNames(requested, registered);
 			const base = buildConnectionStatusV2({
 				siteAlias: (runtime.env['STONEWRIGHT_SITE_ALIAS'] ?? '').trim() || null,
@@ -238,7 +239,8 @@ export function createConnectionRuntime(args: {
 			runtime.status.local_tool_names = names.filter((n) =>
 				PERMANENT_GATEWAY_TOOL_NAME_SET.has(n) || n.startsWith('stonewright-wp-cli-') || n.startsWith('companion_'),
 			);
-			const requested = proxyToolNamesForProfile(runtime.profile);
+			const requested = runtime.status.live?.requestedToolNames
+				?? proxyToolNamesForProfile(runtime.profile);
 			runtime.status.refresh_required_tool_names = computeRefreshRequiredToolNames(requested, names);
 			runtime.syncLegacyStatus();
 		},

--- a/companion/src/mcp-server.ts
+++ b/companion/src/mcp-server.ts
@@ -28,7 +28,6 @@ import {
 	emitToolListChanged,
 	mergeServerInstructions,
 	proxyToolProfileFromEnv,
-	proxyToolNamesForProfile,
 	registerWordPressMcpPrompts,
 	registerWordPressMcpTools,
 	resolveWordPressMcpConfig,
@@ -247,7 +246,7 @@ async function bootstrapConnection(
 			...registration.registeredTools.map((tool) => tool.name),
 		]);
 		wpMcpStatus.startup_ready = wpMcpStatus.startup_missing_tool_names.length === 0;
-		const profileExpectedToolNames = proxyToolNamesForProfile(registration.profile);
+		const profileExpectedToolNames = registration.requestedToolNames;
 		const localToolNames = localToolNamesForProfile(registration.profile);
 		wpMcpStatus.profile_expected_tool_count = profileExpectedToolNames.length;
 		wpMcpStatus.client_visible_expected_tool_count = profileExpectedToolNames.length + localToolNames.length;

--- a/companion/src/version.ts
+++ b/companion/src/version.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = '1.0.0-beta.8';
+export const APP_VERSION = '1.0.0-beta.9';
 
 export function companionPackageSpec(version: string = APP_VERSION): string {
 	return `https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v${version}/stonewright-companion-${version}.tgz`;

--- a/companion/src/wordpress-mcp.ts
+++ b/companion/src/wordpress-mcp.ts
@@ -55,6 +55,8 @@ export interface WordPressMcpRegistrationResult {
 	profile: ProxyToolProfile;
 	remoteTools: RemoteTool[];
 	registeredTools: RemoteTool[];
+	/** Exact profile catalog resolved by the plugin for this connection. */
+	requestedToolNames: string[];
 	profileFilteredToolNames: string[];
 	filteredToolCount: number;
 	/** Plugin MCP initialize.instructions captured during proxy handshake. */
@@ -765,12 +767,21 @@ export async function registerWordPressMcpTools(
 	const liveState: WordPressProxyLiveState = {
 		profile: activeProfile,
 		surfaceRevision: lastSeenSurfaceRevision,
+		requestedToolNames: [],
 		enabledToolNames: [],
 		registeredToolCount: 0,
 		lastRefreshAt: null,
 		lastRefresh: null,
 	};
 	const allowedOrder = resolved.tools;
+	const requestedToolNames = activeProfile === 'full' && allowedOrder.length === 0
+		? tools
+			.map((tool) => tool.name)
+			.filter((name) => Boolean(name)
+				&& !name.startsWith('companion_')
+				&& !COMPANION_OWNED_TOOL_NAMES.has(name))
+		: [...allowedOrder];
+	liveState.requestedToolNames = requestedToolNames;
 	const allowedSet = activeProfile === 'full' && allowedOrder.length === 0
 		? null
 		: new Set(allowedOrder.length > 0 ? allowedOrder : proxyToolNamesForProfile(activeProfile));
@@ -924,6 +935,7 @@ export async function registerWordPressMcpTools(
 		profile: activeProfile,
 		remoteTools: tools,
 		registeredTools,
+		requestedToolNames,
 		profileFilteredToolNames: profileFilteredToolNames.slice(0, 12),
 		filteredToolCount: profileFilteredToolNames.length,
 		remoteInstructions: client.remoteInstructions,
@@ -1167,11 +1179,13 @@ export interface ToolsChangedRefreshResult {
 	removed: string[];
 	profile: ProxyToolProfile;
 	desiredCount: number;
+	desiredToolNames: string[];
 }
 
 export interface WordPressProxyLiveState {
 	profile: ProxyToolProfile;
 	surfaceRevision: number | null;
+	requestedToolNames: string[];
 	enabledToolNames: string[];
 	registeredToolCount: number;
 	lastRefreshAt: string | null;
@@ -1185,6 +1199,9 @@ export function applyRefreshToLiveState(
 	registered: Map<string, { handle: { enabled: boolean }; tool: { name: string } }>,
 ): void {
 	liveState.profile = refresh.profile;
+	if (refresh.refreshed) {
+		liveState.requestedToolNames = refresh.desiredToolNames;
+	}
 	liveState.registeredToolCount = registered.size;
 	liveState.enabledToolNames = [...registered.entries()]
 		.filter(([, entry]) => entry.handle.enabled)
@@ -1307,6 +1324,7 @@ export async function handleToolsChangedResponse(options: {
 			removed,
 			profile: activeProfile,
 			desiredCount: desiredSet.size,
+			desiredToolNames: [...desiredSet],
 		};
 	} catch {
 		// Still notify so clients re-list; companion process may keep the prior set
@@ -1319,6 +1337,7 @@ export async function handleToolsChangedResponse(options: {
 			removed: [],
 			profile: activeProfile,
 			desiredCount: 0,
+			desiredToolNames: [],
 		};
 	}
 }

--- a/companion/tests/mcp-server.test.ts
+++ b/companion/tests/mcp-server.test.ts
@@ -580,6 +580,60 @@ describe('createMcpServer', () => {
 		expect(response.structuredContent?.recovery).toContain('If startup_ready is false, update/enable the missing startup tools in the WordPress Stonewright plugin, then restart the MCP session.');
 	});
 
+	it('uses the plugin-resolved profile catalog for refresh diagnostics', async () => {
+		const resolvedTools = [
+			'stonewright-context-bootstrap',
+			'stonewright-skills-get',
+			'stonewright-php-execute',
+		];
+		const fallback = stonewrightMcpFetch(resolvedTools.map((name) => ({ name })));
+		const fetchImpl: typeof fetch = async (url, init) => {
+			const body = JSON.parse(String(init?.body ?? '{}')) as {
+				method?: string;
+				params?: { name?: string };
+			};
+			if (body.method === 'tools/call' && body.params?.name === 'stonewright-tool-profile') {
+				const structuredContent = {
+					ok: true,
+					tools: resolvedTools,
+					mcp_surface: 'essential',
+					surface_revision: 7,
+				};
+				return new Response(JSON.stringify({
+					jsonrpc: '2.0',
+					id: 3,
+					result: {
+						structuredContent,
+						content: [{ type: 'text', text: JSON.stringify(structuredContent) }],
+					},
+				}), { headers: { 'content-type': 'application/json' } });
+			}
+			return fallback(url, init);
+		};
+
+		const server = await createMcpServer({
+			env: {
+				STONEWRIGHT_MCP_URL: 'https://example.com/wp-json/mcp/stonewright',
+				WP_API_USERNAME: 'admin',
+				WP_API_PASSWORD: 'pw',
+				STONEWRIGHT_MCP_TOOL_PROFILE: 'essential',
+			},
+			fetchImpl,
+		});
+		const tools = (server as { _registeredTools?: Record<string, { handler?: (input: unknown) => Promise<unknown> }> })._registeredTools ?? {};
+		const response = await tools['stonewright-wordpress-mcp-status']?.handler?.({}) as {
+			structuredContent?: {
+				profile_expected_tool_count?: number;
+				profile_missing_tool_names?: string[];
+				refresh_required_tool_names?: string[];
+			};
+		};
+
+		expect(response.structuredContent?.profile_expected_tool_count).toBe(resolvedTools.length);
+		expect(response.structuredContent?.profile_missing_tool_names).toEqual([]);
+		expect(response.structuredContent?.refresh_required_tool_names).toEqual([]);
+	});
+
 	it('wordpress-mcp-status reports the last seen surface_revision', async () => {
 		const remoteTools = [
 			{ name: 'stonewright-context-bootstrap' },

--- a/companion/tests/tools-changed.test.ts
+++ b/companion/tests/tools-changed.test.ts
@@ -126,6 +126,7 @@ describe('handleToolsChangedResponse', () => {
 		const liveState = {
 			profile: 'bootstrap' as const,
 			surfaceRevision: null as number | null,
+			requestedToolNames: ['stonewright-context-bootstrap'],
 			enabledToolNames: [] as string[],
 			registeredToolCount: 0,
 			lastRefreshAt: null as string | null,
@@ -138,11 +139,13 @@ describe('handleToolsChangedResponse', () => {
 			removed: ['stonewright-elementor-page-digest'],
 			profile: 'essential',
 			desiredCount: 1,
+			desiredToolNames: ['stonewright-tool-profile'],
 		};
 
 		applyRefreshToLiveState(liveState, refresh, registered);
 
 		expect(liveState.profile).toBe('essential');
+		expect(liveState.requestedToolNames).toEqual(['stonewright-tool-profile']);
 		expect(liveState.enabledToolNames).toEqual(['stonewright-tool-profile']);
 		expect(liveState.registeredToolCount).toBe(2);
 		expect(liveState.lastRefreshAt).toBeTruthy();

--- a/docs/elementor-write-verification.md
+++ b/docs/elementor-write-verification.md
@@ -76,7 +76,10 @@ The live Elementor schema is authoritative. Before the write:
 - request the exact responsive control keys and value domains;
 - preserve activator controls required by dependent settings;
 - use `_position` only when the live container schema exposes it;
-- use device-specific hide values exposed by the current runtime;
+- for the primary Elementor visibility switches, use only the matching native
+  values: `hide_desktop=hidden-desktop`, `hide_laptop=hidden-laptop`,
+  `hide_tablet=hidden-tablet`, and `hide_mobile=hidden-mobile`; never use bare
+  `hidden`;
 - keep unknown settings unchanged.
 
 A dry-run error can return `schema_requests`. Read each requested schema once,
@@ -106,6 +109,9 @@ The default verification viewports are the source desktop/mobile frames plus
 the site's tablet breakpoint. A page is complete only when the requested
 tolerances pass, there is no unintended horizontal overflow, visibility
 matches the contract, and screenshots show the expected rendered state.
+The Elementor editor canvas can still display a widget hidden for the frontend;
+that is expected. Read back the saved switcher value and verify the rendered
+frontend class and computed display at each requested device.
 
 ## Direct mode boundary
 

--- a/docs/releases/1.0.0-beta.9.md
+++ b/docs/releases/1.0.0-beta.9.md
@@ -1,0 +1,62 @@
+# Stonewright 1.0.0-beta.9
+
+Released: 2026-08-12
+
+## Summary
+
+This release removes a false Plugin-mode verification failure and hardens
+Elementor responsive visibility writes. Companion diagnostics now follow the
+profile catalog resolved by the connected plugin, while Elementor writes reject
+values that leave the editor switcher out of sync with frontend classes.
+
+## Fixed
+
+- `stonewright connect verify <alias> --client <client>` no longer reports a
+  refresh requirement merely because the companion fallback profile contains a
+  tool that the connected plugin did not select for its current profile.
+- Expected profile counts and missing-tool diagnostics use the same exact
+  plugin-resolved catalog as registration.
+- `hide_desktop`, `hide_laptop`, `hide_tablet`, and `hide_mobile` reject bare
+  `hidden`, cross-device values, and other non-native switcher values before an
+  Elementor document write.
+- The matching native values are `hidden-desktop`, `hidden-laptop`,
+  `hidden-tablet`, and `hidden-mobile`; an empty value keeps the switch off.
+
+## Operating rule
+
+Use Elementor Responsive visibility controls instead of CSS or JavaScript.
+The editor canvas may still show a frontend-hidden element. Completion requires
+settings readback and frontend class/display verification at the requested
+devices.
+
+## Upgrade
+
+Repair an existing alias without re-entering its saved credential:
+
+```bash
+npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz stonewright connect repair <alias> --client <client> --mode plugin-only --browser-provider playwright
+```
+
+Fully restart the MCP client, then verify:
+
+```bash
+npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz stonewright connect verify <alias> --client <client>
+```
+
+Success requires the requested alias, Plugin mode, the expected companion
+version, task-start/status availability, and an empty
+`refresh_required_tool_names` list.
+
+## Compatibility and safety
+
+- WordPress plugin and companion: `1.0.0-beta.9`.
+- Plugin mode registers **360** abilities; Direct full exposes **100** tools.
+- WordPress: 6.7 or newer.
+- PHP: 8.1 or newer.
+- Node.js: 20 or newer for the companion.
+- Permission, confirmation, backup, custom-code approval, and Direct-mode write
+  boundaries are unchanged.
+
+Release assets contain `stonewright-1.0.0-beta.9.zip`,
+`stonewright-companion-1.0.0-beta.9.tgz`, the Visual package, and
+`SHA256SUMS.txt`.

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+## [1.0.0-beta.9] - 2026-08-12
+
+### Added
+
+- Add a site-independent Elementor responsive-visibility rule to the packaged
+  native rule registry used by Plugin and Direct sessions.
+
+### Fixed
+
+- Reject bare `hidden` and cross-device values for the primary Elementor
+  `hide_*` switches; accept only the matching native device value or an empty
+  off state before any document write.
+
 ## [1.0.0-beta.8] - 2026-08-12
 
 ### Changed
@@ -92,28 +105,9 @@
 - Save all runtime Step 1 controls immediately and bump a shared surface
   revision so active transports can re-list without unrelated form writes.
 
-## [1.0.0-beta.4] - 2026-08-05
-
-### Added
-
-- Add the permanent audit/incident taxonomy, OAuth server rate-limit contract,
-  Elementor transaction receipts and evidence-preserving patch validation,
-  Gutenberg block batches, design manifests/comparison, and read-only form and
-  capability diagnostics.
-- Add a count-only, hash-bound runtime-history purge with production
-  confirmation, reviewed watermarks, concurrent-row preservation, and one
-  retained cleanup receipt.
-
-### Fixed
-
-- Bind OAuth tokens to the canonical MCP resource, publish the minimal `mcp`
-  resource scope, and revoke all descendant refresh and access tokens when a
-  rotated refresh token is replayed.
-- Neutralize spreadsheet formulas in redacted audit CSV exports and include
-  both OAuth audit transient families in purge hashes and counts.
-
 ## Older releases
 
+- [1.0.0-beta.4](../docs/releases/1.0.0-beta.4.md)
 - [1.0.0-beta.3](../docs/releases/1.0.0-beta.3.md)
 - [1.0.0-beta.2](../docs/releases/1.0.0-beta.2.md)
 - [1.0.0-beta.1](../docs/releases/1.0.0-beta.1.md)

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,6 +1,6 @@
 # Stonewright Plugin
 
-Version: 1.0.0-beta.8
+Version: 1.0.0-beta.9
 Requires WordPress: 6.7+
 Requires PHP: 8.1+
 License: AGPL-3.0-or-later

--- a/plugin/data/global-rules.json
+++ b/plugin/data/global-rules.json
@@ -154,6 +154,17 @@
 		}
 	},
 	{
+		"id": "elementor-native-responsive-visibility",
+		"severity": "strong",
+		"scope": "elementor",
+		"rule": "Hide Elementor elements with native Responsive controls only. Use hidden-desktop, hidden-laptop, hidden-tablet, or hidden-mobile for the matching hide setting; never use bare hidden or CSS/JavaScript as a substitute. The editor canvas may still show hidden elements. After writing, read back the settings and verify the frontend classes at the requested devices.",
+		"why": "Wrong switcher return values leave the editor toggle out of sync with saved metadata and do not produce reliable frontend visibility classes.",
+		"enforcement": {
+			"kind": "instruction",
+			"guard": ""
+		}
+	},
+	{
 		"id": "no-schema-guessing",
 		"severity": "strong",
 		"scope": "all",

--- a/plugin/includes/Elementor/Schema/ContainerSchemaRepository.php
+++ b/plugin/includes/Elementor/Schema/ContainerSchemaRepository.php
@@ -139,6 +139,7 @@ final class ContainerSchemaRepository {
 			'sticky_on'             => [ 'type' => 'select2', 'multiple' => true ],
 			'sticky_offset'         => [ 'type' => 'number', 'responsive' => true ],
 			'hide_desktop'          => [ 'type' => 'switcher' ],
+			'hide_laptop'           => [ 'type' => 'switcher' ],
 			'hide_tablet'           => [ 'type' => 'switcher' ],
 			'hide_mobile'           => [ 'type' => 'switcher' ],
 		];

--- a/plugin/includes/Elementor/Schema/ResponsiveScope.php
+++ b/plugin/includes/Elementor/Schema/ResponsiveScope.php
@@ -84,6 +84,29 @@ final class ResponsiveScope {
 	}
 
 	/**
+	 * Exact native switcher return values for Elementor's primary devices.
+	 *
+	 * @return array<string, string>
+	 */
+	public static function native_visibility_values(): array {
+		return [
+			'hide_desktop' => 'hidden-desktop',
+			'hide_laptop'  => 'hidden-laptop',
+			'hide_tablet'  => 'hidden-tablet',
+			'hide_mobile'  => 'hidden-mobile',
+		];
+	}
+
+	public static function expected_visibility_value( string $key ): ?string {
+		return self::native_visibility_values()[ $key ] ?? null;
+	}
+
+	public static function visibility_value_is_valid( string $key, mixed $value ): bool {
+		$expected = self::expected_visibility_value( $key );
+		return null === $expected || '' === $value || $expected === $value;
+	}
+
+	/**
 	 * Decide whether a control accepts breakpoint-suffixed keys.
 	 *
 	 * Elementor's add_responsive_control() records the breakpoint bounds as an
@@ -189,6 +212,38 @@ final class ResponsiveScope {
 	 * @return bool|\WP_Error True when valid.
 	 */
 	public static function assert_settings_in_scope( array $settings, array $allowed_breakpoints, array $controls = [], string $widget_type = '' ): bool|\WP_Error {
+		foreach ( $settings as $key => $value ) {
+			$key      = (string) $key;
+			$expected = self::expected_visibility_value( $key );
+			if ( null === $expected || self::visibility_value_is_valid( $key, $value ) ) {
+				continue;
+			}
+			return new \WP_Error(
+				'stonewright_elementor_settings_invalid',
+				sprintf(
+					/* translators: 1: setting key, 2: exact native value */
+					__( 'Elementor visibility setting %1$s must be empty or use its native value %2$s.', 'stonewright' ),
+					$key,
+					$expected
+				),
+				[
+					'status'      => 400,
+					'widget_type' => $widget_type,
+					'violations'  => [
+						[
+							'path'        => 'settings.' . $key,
+							'code'        => 'invalid_responsive_visibility_value',
+							'expected'    => 'an empty value or ' . $expected,
+							'got_type'    => get_debug_type( $value ),
+							'suggestions' => [ '', $expected ],
+						],
+					],
+					'retryable'   => true,
+					'repair'      => 'Use the native Elementor Responsive switcher value for this device, then read back settings and verify frontend classes.',
+				]
+			);
+		}
+
 		$allowed = array_values(
 			array_unique(
 				array_map(

--- a/plugin/includes/Elementor/Schema/SettingsValidator.php
+++ b/plugin/includes/Elementor/Schema/SettingsValidator.php
@@ -58,6 +58,18 @@ final class SettingsValidator {
 				continue;
 			}
 
+			$expected_visibility = ResponsiveScope::expected_visibility_value( $key );
+			if ( null !== $expected_visibility && ! ResponsiveScope::visibility_value_is_valid( $key, $value ) ) {
+				$violations[] = self::violation(
+					'settings.' . $key,
+					'invalid_responsive_visibility_value',
+					'an empty value or ' . $expected_visibility,
+					$value,
+					[ '', $expected_visibility ]
+				);
+				continue;
+			}
+
 			$control_key = self::control_key( $key, $controls );
 			if ( null === $control_key ) {
 				// P0 integrity: never strip unknown settings to "pass" validation.

--- a/plugin/stonewright.php
+++ b/plugin/stonewright.php
@@ -3,7 +3,7 @@
  * Plugin Name: Stonewright
  * Plugin URI: https://github.com/cosmincraciun97/stonewright-wp-mcp
  * Description: Guarded WordPress MCP tools for Elementor, Gutenberg/FSE, WooCommerce catalogs, content models, PHP runtime execution, and tokenized WP-CLI.
- * Version: 1.0.0-beta.8
+ * Version: 1.0.0-beta.9
  * Requires at least: 6.7
  * Requires PHP: 8.1
  * Author: Stonewright
@@ -33,7 +33,7 @@ if ( defined( 'STONEWRIGHT_FILE' ) ) {
 define( 'STONEWRIGHT_FILE', __FILE__ );
 define( 'STONEWRIGHT_DIR', plugin_dir_path( __FILE__ ) );
 define( 'STONEWRIGHT_URL', plugin_dir_url( __FILE__ ) );
-define( 'STONEWRIGHT_VERSION', '1.0.0-beta.8' );
+define( 'STONEWRIGHT_VERSION', '1.0.0-beta.9' );
 define( 'STONEWRIGHT_MIN_PHP', '8.1' );
 define( 'STONEWRIGHT_MIN_WP', '6.7' );
 

--- a/plugin/tests/Unit/Elementor/ResponsiveScopeTest.php
+++ b/plugin/tests/Unit/Elementor/ResponsiveScopeTest.php
@@ -155,8 +155,8 @@ final class ResponsiveScopeTest extends TestCase {
 		$result = ResponsiveScope::assert_settings_in_scope(
 			[
 				'title_mobile' => 'Hi mobile',
-				'hide_desktop' => 'hidden',
-				'hide_tablet'  => 'hidden',
+				'hide_desktop' => 'hidden-desktop',
+				'hide_tablet'  => 'hidden-tablet',
 			],
 			[ 'mobile' ],
 			[
@@ -165,6 +165,44 @@ final class ResponsiveScopeTest extends TestCase {
 				'hide_tablet'  => [ 'type' => 'switcher' ],
 			],
 			'heading'
+		);
+
+		self::assertTrue( $result );
+	}
+
+	public function test_visibility_switchers_reject_bare_or_cross_device_hidden_values(): void {
+		foreach (
+			[
+				'hide_desktop' => 'hidden',
+				'hide_laptop'  => 'hidden-mobile',
+				'hide_tablet'  => 'hidden-desktop',
+				'hide_mobile'  => 'yes',
+			] as $key => $value
+		) {
+			$result = ResponsiveScope::assert_settings_in_scope(
+				[ $key => $value ],
+				[ 'desktop', 'laptop', 'tablet', 'mobile' ],
+				[ $key => [ 'type' => 'switcher' ] ],
+				'container'
+			);
+
+			self::assertInstanceOf( \WP_Error::class, $result, $key );
+			self::assertSame( 'stonewright_elementor_settings_invalid', $result->get_error_code(), $key );
+			self::assertSame( 'invalid_responsive_visibility_value', $result->get_error_data()['violations'][0]['code'], $key );
+		}
+	}
+
+	public function test_visibility_switchers_accept_empty_or_matching_device_values(): void {
+		$result = ResponsiveScope::assert_settings_in_scope(
+			[
+				'hide_desktop' => 'hidden-desktop',
+				'hide_laptop'  => 'hidden-laptop',
+				'hide_tablet'  => '',
+				'hide_mobile'  => 'hidden-mobile',
+			],
+			[ 'desktop', 'laptop', 'tablet', 'mobile' ],
+			[],
+			'container'
 		);
 
 		self::assertTrue( $result );

--- a/plugin/tests/Unit/Elementor/Schema/WidgetSchemaRepositoryTest.php
+++ b/plugin/tests/Unit/Elementor/Schema/WidgetSchemaRepositoryTest.php
@@ -122,6 +122,39 @@ final class WidgetSchemaRepositoryTest extends TestCase {
 		self::assertSame( 'unknown_setting', $invalid->get_error_data()['violations'][0]['code'] );
 	}
 
+	public function test_container_schema_enforces_native_responsive_visibility_values(): void {
+		$invalid = SettingsValidator::validate_container( [ 'hide_desktop' => 'hidden' ] );
+		self::assertInstanceOf( \WP_Error::class, $invalid );
+		self::assertSame( 'stonewright_elementor_settings_invalid', $invalid->get_error_code() );
+		self::assertSame( 'invalid_responsive_visibility_value', $invalid->get_error_data()['violations'][0]['code'] );
+
+		$valid = SettingsValidator::validate_container(
+			[
+				'hide_desktop' => 'hidden-desktop',
+				'hide_laptop'  => 'hidden-laptop',
+				'hide_tablet'  => '',
+				'hide_mobile'  => 'hidden-mobile',
+			]
+		);
+		self::assertIsArray( $valid );
+	}
+
+	public function test_offline_container_schema_exposes_every_primary_visibility_switch(): void {
+		\Elementor\Plugin::$instance = (object) [
+			'elements_manager' => new class() {
+				public function get_element_types( string $name ): ?object {
+					return null;
+				}
+			},
+		];
+
+		$schema = ContainerSchemaRepository::get();
+		self::assertIsArray( $schema );
+		foreach ( [ 'hide_desktop', 'hide_laptop', 'hide_tablet', 'hide_mobile' ] as $key ) {
+			self::assertArrayHasKey( $key, $schema['controls'] );
+		}
+	}
+
 	public function test_responsive_url_and_recursive_repeater_shapes_are_validated(): void {
 		$valid = SettingsValidator::validate(
 			'third-party-card',
@@ -423,6 +456,10 @@ final class LiveContainerElement {
 			// layout controls even though breakpoint-suffixed values are native.
 			'flex_direction'     => [ 'type' => 'select' ],
 			'plugin_layout_token' => [ 'type' => 'select', 'responsive' => true, 'options' => [ 'wide' => 'Wide' ] ],
+			'hide_desktop'       => [ 'type' => 'switcher' ],
+			'hide_laptop'        => [ 'type' => 'switcher' ],
+			'hide_tablet'        => [ 'type' => 'switcher' ],
+			'hide_mobile'        => [ 'type' => 'switcher' ],
 		];
 	}
 }

--- a/plugin/tests/Unit/Security/GlobalRulesTest.php
+++ b/plugin/tests/Unit/Security/GlobalRulesTest.php
@@ -41,6 +41,7 @@ final class GlobalRulesTest extends TestCase {
 		'dynamic-architecture-preservation',
 		'native-controls-rendered-proof',
 		'custom-code-human-handoff',
+		'elementor-native-responsive-visibility',
 	];
 
 	public function test_generalized_operating_repairs_live_in_the_digest_registry(): void {

--- a/plugin/tests/Unit/Support/ReleaseRetentionTest.php
+++ b/plugin/tests/Unit/Support/ReleaseRetentionTest.php
@@ -19,7 +19,7 @@ final class ReleaseRetentionTest extends TestCase {
 				$versioned[] = $name;
 			}
 		}
-		self::assertSame( [ '1.0.0-beta.1.md', '1.0.0-beta.2.md', '1.0.0-beta.3.md', '1.0.0-beta.4.md', '1.0.0-beta.5.md', '1.0.0-beta.6.md', '1.0.0-beta.7.md', '1.0.0-beta.8.md' ], $versioned );
+		self::assertSame( [ '1.0.0-beta.1.md', '1.0.0-beta.2.md', '1.0.0-beta.3.md', '1.0.0-beta.4.md', '1.0.0-beta.5.md', '1.0.0-beta.6.md', '1.0.0-beta.7.md', '1.0.0-beta.8.md', '1.0.0-beta.9.md' ], $versioned );
 	}
 
 	public function test_root_changelog_keeps_latest_five_releases_and_links_older_history(): void {
@@ -34,7 +34,7 @@ final class ReleaseRetentionTest extends TestCase {
 			)
 		);
 		self::assertContains( 'Unreleased', $headers );
-		self::assertSame( [ '1.0.0-beta.8', '1.0.0-beta.7', '1.0.0-beta.6', '1.0.0-beta.5', '1.0.0-beta.4' ], $versions );
+		self::assertSame( [ '1.0.0-beta.9', '1.0.0-beta.8', '1.0.0-beta.7', '1.0.0-beta.6', '1.0.0-beta.5' ], $versions );
 		self::assertStringContainsString( '## Older releases', $raw );
 		self::assertStringContainsString( 'docs/releases/1.0.0-beta.1.md', $raw );
 	}


### PR DESCRIPTION
## What changed

- derive expected and refresh-required tools from the exact plugin-resolved profile catalog
- reject bare and cross-device Elementor responsive visibility values before writes
- ship the generalized native visibility rule in Plugin and Direct rule registries
- update beta.9 metadata, changelogs, release notes, docs, and README dashboard asset

## Root causes

The companion recomputed expected tools from its local fallback profile after registration, so a newer fallback could falsely mark a healthy older plugin profile stale. Elementor switcher schema validation checked only the generic switcher shape, allowing values that do not match native per-device return values.

## Ability and safety impact

- Changed Elementor settings validation used by typed V3 mutations and final tree validation.
- No ability added or removed; Plugin remains 360 abilities and Direct remains 100 tools.
- Permission, backup, confirmation-token, audit, custom-code approval, and DesignSpec validation gates are unchanged.
- Native responsive visibility validation runs before Elementor persistence.

## Public docs

Updated root/plugin/companion changelogs, plugin README/version, Elementor write verification, beta.9 release notes, release-retention coverage, and README dashboard asset.

## Validation

- Plugin: 6,822 tests / 36,158 assertions; contract suite; PHPStan; PHPCS; security audit; dependency audit; provenance; token budgets
- Companion: 460 tests; typecheck; lint; contract compatibility; token budgets; build; production dependency audit
- Visual: 80 tests; typecheck; build; production dependency audit
- Documentation freshness and public hygiene
- Exact local plugin ZIP, companion TGZ, and Visual TGZ packaging with manifest, hygiene, runtime-state, and archive-layout checks