### PR TITLE
chore: prepare 1.0.0-beta.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ development builds were never stable releases.
 
 ## [Unreleased]
 
+## [1.0.0-beta.10] - 2026-08-12
+
 ### Added
 
 - Add a typed verified-repair recorder, canonical incident lifecycle metadata,
@@ -90,75 +92,9 @@ development builds were never stable releases.
   during secure v1 migration, and allow `connect repair --mode plugin-only` to
   update a named client entry without requesting the saved password again.
 
-## [1.0.0-beta.5] - 2026-08-12
-
-### Added
-
-- Add deterministic plugin/companion OAuth contract matrices, per-client
-  certification priorities and evidence receipts, and reusable acceptance and
-  release-report templates without treating a priority label as certification.
-- Add native Elementor row/container normalization, live-gated cover CTA and
-  testimonial carousel rendering, chip groups, schema-backed button icons, and
-  transactional kit/global design updates.
-- Add typed custom-code provider adapters for WPCode, Code Snippets,
-  Customizer CSS, and allowlisted theme files with dry-run approval handoff,
-  concurrency checks, snapshots, readback verification, and rollback guidance.
-- Add a versioned multi-site/environment registry, collision-safe site aliases,
-  per-client bindings, OS-backed credential references, transactional client
-  configuration, and a `stonewright connect` installer/verification workflow.
-- Persist each site's Plugin/Direct mode policy, WordPress Step 1 expectations,
-  Elementor V4 selection, tool surface, and per-client browser-consent choice.
-
-### Changed
-
-- Keep unresolved audit incidents out of active learning memory and promote a
-  durable repair only after exact verified evidence or an explicit correction.
-- Require a one-time browser-provider choice per site/client, separate consent
-  for tool/config scanning and installation, and keep every custom-code safety
-  boundary intact for browser-assisted Plugin and Direct workflows.
-- Aggregate terminal OAuth client failures over 24 hours while keeping 429/5xx
-  incidents on the short operational window.
-- Start fresh plugin installs on the bounded `essential` surface, use
-  the operator-selected surface in generated client profiles, retain bounded
-  overrides only for strict-cap clients, and reserve bootstrap for explicit
-  diagnostics.
-- Disable the Design Library wp-admin group and its page-specific browser tests
-  while preserving typed design engines, stored user data, and the
-  `figma-to-native-pixel` workflow.
-
-### Fixed
-
-- Reject catalog-only Elementor Pro widgets, allow operation-free kit rollback,
-  treat identical kit plans as verified no-ops, and restore snapshots whenever
-  kit write readback differs from the planned state; reject injectable icon
-  class payloads and non-HTTP SVG icon URLs, and emit only controls confirmed
-  by the live Button schema; require a compatible live repeater before choosing
-  a testimonial carousel widget.
-- Restrict snippet-plugin source reads to administrators, retain
-  `edit_theme_options` only for theme-owned providers, and confirmation-gate
-  custom-code apply and rollback in production-safe mode.
-- Paginate legacy audit-lesson reconciliation and leave it retryable whenever
-  an eligible memory update fails.
-- Keep the dependency audit fail-closed while documenting Composer 2.9.5's
-  false-positive boundary match for the already patched PHP_CodeSniffer 3.13.6.
-- Align Audit, Memory, Skills, and Sandbox controls with consistent card
-  padding, checkbox spacing, action gaps, and 32px control heights.
-- Resolve pre-login OAuth audit actors to registered client names in one batched
-  lookup, with explicit OAuth-client/System fallbacks instead of `(unknown)`.
-- Refresh the callable companion tool registry after task-start profile changes,
-  reuse tool and prompt handles during reconnect, and keep authentication and
-  WordPress reachability status evidence-based.
-- Preserve requested ability enablement across domain-lock mismatches and expose
-  explicit blocked, rebind, rollback, and audit state instead of silently
-  switching the plugin off.
-- Generate Application Passwords without a page refresh, fill private snippets
-  with the canonical placeholder, clear credentials from the tab lifecycle, and
-  remove plaintext transient persistence from the no-JavaScript fallback.
-- Apply every runtime-affecting Step 1 control immediately, bump one shared
-  surface revision, and expose the exact refresh contract to connected clients.
-
 ## Older releases
 
+- [1.0.0-beta.5](docs/releases/1.0.0-beta.5.md)
 - [1.0.0-beta.4](docs/releases/1.0.0-beta.4.md)
 - [1.0.0-beta.3](docs/releases/1.0.0-beta.3.md)
 - [1.0.0-beta.2](docs/releases/1.0.0-beta.2.md)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Stonewright does not promise that automation cannot fail. It adds concrete contr
 </p>
 
 <p align="center">
-  <img src="assets/screenshots/stonewright-dashboard-beta9.svg" alt="Stonewright dashboard showing a verified Plugin-mode connection" width="1200" />
+  <img src="assets/screenshots/stonewright-dashboard-beta10.svg" alt="Stonewright dashboard showing a verified Plugin-mode connection" width="1200" />
 </p>
 
 ## How it works

--- a/assets/screenshots/stonewright-dashboard-beta10.svg
+++ b/assets/screenshots/stonewright-dashboard-beta10.svg
@@ -36,7 +36,7 @@
   <text x="712.2" y="33" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif" font-size="12" font-weight="600" letter-spacing=".72" fill="#f8f9fa" fill-opacity=".45">SAFETY &amp; DIAGNOSTICS</text>
   <rect x="1205" y="14" width="107" height="28" rx="14" fill="#6366f1" fill-opacity=".35"/>
   <text x="1258.5" y="33" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif" font-size="12" font-weight="600" fill="#e0e7ff">development</text>
-  <text x="1422" y="33" text-anchor="end" font-family="ui-monospace,'SF Mono','Cascadia Code',Consolas,monospace" font-size="12" fill="#f8f9fa" fill-opacity=".45">1.0.0-beta.9</text>
+  <text x="1422" y="33" text-anchor="end" font-family="ui-monospace,'SF Mono','Cascadia Code',Consolas,monospace" font-size="12" fill="#f8f9fa" fill-opacity=".45">1.0.0-beta.10</text>
 
   <g transform="translate(150 108)">
     <text x="0" y="26" font-family="Inter,Arial,sans-serif" font-size="28" font-weight="750" fill="#202331">Dashboard</text>

--- a/companion/CHANGELOG.md
+++ b/companion/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+## [1.0.0-beta.10] - 2026-08-12
+
+### Added
+
+- Add a private per-site Direct incident store and
+  `stonewright-incident-repair-record` with strict correlated evidence,
+  readback verification, recurrence handling, and compact task-start actions.
+
+### Changed
+
+- Keep audit-derived learning guidance-only until a successful repair is
+  proven; stale a promoted lesson when the same failure recurs.
+
 ## [1.0.0-beta.9] - 2026-08-12
 
 ### Fixed

--- a/companion/package-lock.json
+++ b/companion/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@stonewright/companion",
-	"version": "1.0.0-beta.9",
+	"version": "1.0.0-beta.10",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@stonewright/companion",
-			"version": "1.0.0-beta.9",
+			"version": "1.0.0-beta.10",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/companion/package.json
+++ b/companion/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@stonewright/companion",
-	"version": "1.0.0-beta.9",
+	"version": "1.0.0-beta.10",
 	"description": "Node companion for the Stonewright WordPress MCP plugin: WP-CLI, health checks, and optional MCP HTTP proxy.",
 	"type": "module",
 	"license": "MIT",

--- a/companion/src/version.ts
+++ b/companion/src/version.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = '1.0.0-beta.9';
+export const APP_VERSION = '1.0.0-beta.10';
 
 export function companionPackageSpec(version: string = APP_VERSION): string {
 	return `https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v${version}/stonewright-companion-${version}.tgz`;

--- a/docs/releases/1.0.0-beta.10.md
+++ b/docs/releases/1.0.0-beta.10.md
@@ -1,0 +1,72 @@
+# Stonewright 1.0.0-beta.10
+
+Released: 2026-08-12
+
+## Summary
+
+This release makes Stonewright's learning loop evidence-based and easier to
+trust. Repeated failures become reusable guidance only after a correlated
+repair succeeds and its result is read back. Plugin and Direct mode now expose
+the same compact repair priorities at task start without shipping private site
+state.
+
+Setup documentation now leads with four steps and a runtime proof chain instead
+of treating saved configuration as a successful connection. Update discovery
+also follows the installed stable or prerelease channel without silently
+crossing between them.
+
+## Added
+
+- Add `stonewright/incident-repair-record` for strict repair receipts tied to
+  the original incident, repair audit event, and verification evidence.
+- Add ranked task-start repair actions, canonical incident lifecycle metadata,
+  stale-on-recurrence lessons, and readback-verified promotion.
+- Add an isolated per-site Direct incident store with atomic private writes,
+  bounded retention, corrupt-state preservation, and no raw arguments.
+- Add focused guides for verified learning, guarded workflows, practical use
+  cases, component licensing, and the Plugin/Direct capability boundary.
+
+## Changed
+
+- Keep generic successful audit events from resolving unrelated incidents or
+  promoting unverified lessons. Explicit user corrections remain immediately
+  recordable.
+- Lead Plugin onboarding with install, enable, connect, restart, and runtime
+  verification; keep advanced transports and profile controls secondary.
+- Expose the generated **361**-ability Plugin and **101**-tool Direct contracts
+  throughout maintained documentation.
+- Select Plugin and companion updates from the installed SemVer channel using
+  isolated caches and exact trusted assets without cross-channel fallback.
+- Publish future beta and release-candidate tags as GitHub prereleases; only a
+  stable tag can become the latest stable release.
+
+## Upgrade
+
+Update the plugin from its native WordPress updater or install the release ZIP.
+Update the companion package reference to the beta.10 asset, fully restart the
+MCP client, then run:
+
+```bash
+npx -y --package https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/vVERSION/stonewright-companion-VERSION.tgz stonewright connect verify <alias> --client <client>
+```
+
+Success requires the requested alias, expected companion version,
+`stonewright-task-start`, status availability, and an empty
+`refresh_required_tool_names` list.
+
+## Compatibility and safety
+
+- WordPress plugin and companion: `1.0.0-beta.10`.
+- Plugin mode registers **361** abilities; Direct full exposes **101** tools.
+- WordPress: 6.7 or newer.
+- PHP: 8.1 or newer.
+- Node.js: 20 or newer for the companion.
+- The repair recorder uses capability checks, audit evidence, and
+  production-safe confirmation tokens. Elementor backup, DesignSpec validation,
+  and custom-code approval boundaries remain unchanged.
+- Fresh installs start without user memory, user-created skills, incidents, or
+  audit history. Updates preserve existing private state.
+
+Release assets contain `stonewright-1.0.0-beta.10.zip`,
+`stonewright-companion-1.0.0-beta.10.tgz`, the Visual package, and
+`SHA256SUMS.txt`.

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.0.0-beta.10] - 2026-08-12
+
 ### Added
 
 - Add `stonewright/incident-repair-record` for persisted, correlated repair
@@ -63,66 +65,9 @@
   form, keeping **Save Settings** associated with the correct form and returning
   the operator to Stonewright Setup after WordPress saves the options.
 
-## [1.0.0-beta.5] - 2026-08-12
-
-### Added
-
-- Add deterministic OAuth discovery, PKCE, resource-binding, challenge,
-  refresh-rotation, replay, and terminal-reauthorization matrix coverage plus
-  distinct client support, certification-priority, and evidence metadata.
-- Add native row/container layout normalization, live-gated cover CTA and
-  testimonial carousel rendering, chip groups, schema-backed button icons, and
-  `stonewright/elementor-v3-kit-batch-mutate` for typed kit globals.
-- Add typed WPCode, Code Snippets, Customizer CSS, and theme-file providers
-  with approval-gated dry runs, concurrency checks, snapshots, verification,
-  and rollback guidance.
-
-### Changed
-
-- Separate unresolved audit incidents from active learning and promote durable
-  repair guidance only after exact verified evidence or user correction.
-- Make the paste-to-agent setup prompt prefer the versioned multi-site
-  installer, secret-free credential references, per-site/client choices, and
-  spawned runtime verification after restart.
-- Require explicit browser-provider, scan, and installation consent; Playwright
-  remains the recommended default without becoming a silent dependency.
-- Aggregate terminal OAuth client failures over 24 hours while retaining the
-  short visibility window for retryable and server-side failures.
-- Default fresh installs to the bounded `essential` MCP surface and make
-  generated client profiles follow the operator's explicit surface selection;
-  strict-cap clients retain their bounded override.
-- Disable the Design Library navigation, pages, page assets, and catalog
-  starters without deleting stored directions or removing typed MCP engines.
-
-### Fixed
-
-- Reject catalog-only Pro widget substitutions, accept rollback without dummy
-  operations, verify boolean snapshot restoration, treat identical kit plans as
-  no-ops, restore on kit readback mismatch, and reject unsafe icon classes or
-  SVG URL schemes while writing only live-supported Button icon controls and
-  selecting only carousel widgets with a compatible live repeater.
-- Restrict snippet-plugin source reads to `manage_options`, retain
-  `edit_theme_options` only for theme-owned providers, and require production
-  confirmation tokens for provider apply and rollback.
-- Reconcile every page of legacy audit lessons and keep failed migrations
-  retryable instead of marking them complete.
-- Document the exact Composer audit exception for PHP_CodeSniffer 3.13.6, the
-  patched boundary release that Composer 2.9.5 still misclassifies as affected.
-- Add deliberate spacing and consistent control heights across Audit incident
-  cards, Memory forms, Skills availability, and Sandbox action cells.
-- Display registered OAuth client names for pre-login audit events through one
-  batched lookup and replace ambiguous `(unknown)` labels with explicit source
-  fallbacks.
-- Preserve operator enablement intent during domain mismatch and require an
-  audited, reversible explicit rebind before abilities become effective.
-- Keep Application Password creation in the current Setup tab, update private
-  snippets and inventory in place, restore placeholders on clear/revoke, and
-  eliminate plaintext password transients from the no-JavaScript path.
-- Save all runtime Step 1 controls immediately and bump a shared surface
-  revision so active transports can re-list without unrelated form writes.
-
 ## Older releases
 
+- [1.0.0-beta.5](../docs/releases/1.0.0-beta.5.md)
 - [1.0.0-beta.4](../docs/releases/1.0.0-beta.4.md)
 - [1.0.0-beta.3](../docs/releases/1.0.0-beta.3.md)
 - [1.0.0-beta.2](../docs/releases/1.0.0-beta.2.md)

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,6 +1,6 @@
 # Stonewright Plugin
 
-Version: 1.0.0-beta.9
+Version: 1.0.0-beta.10
 Requires WordPress: 6.7+
 Requires PHP: 8.1+
 License: [AGPL-3.0-or-later](../LICENSE)

--- a/plugin/stonewright.php
+++ b/plugin/stonewright.php
@@ -3,7 +3,7 @@
  * Plugin Name: Stonewright
  * Plugin URI: https://github.com/cosmincraciun97/stonewright-wp-mcp
  * Description: Guarded WordPress MCP tools for Elementor, Gutenberg/FSE, WooCommerce catalogs, content models, PHP runtime execution, and tokenized WP-CLI.
- * Version: 1.0.0-beta.9
+ * Version: 1.0.0-beta.10
  * Requires at least: 6.7
  * Requires PHP: 8.1
  * Author: Stonewright
@@ -33,7 +33,7 @@ if ( defined( 'STONEWRIGHT_FILE' ) ) {
 define( 'STONEWRIGHT_FILE', __FILE__ );
 define( 'STONEWRIGHT_DIR', plugin_dir_path( __FILE__ ) );
 define( 'STONEWRIGHT_URL', plugin_dir_url( __FILE__ ) );
-define( 'STONEWRIGHT_VERSION', '1.0.0-beta.9' );
+define( 'STONEWRIGHT_VERSION', '1.0.0-beta.10' );
 define( 'STONEWRIGHT_MIN_PHP', '8.1' );
 define( 'STONEWRIGHT_MIN_WP', '6.7' );
 

--- a/plugin/tests/Unit/Support/ReleaseRetentionTest.php
+++ b/plugin/tests/Unit/Support/ReleaseRetentionTest.php
@@ -19,7 +19,7 @@ final class ReleaseRetentionTest extends TestCase {
 				$versioned[] = $name;
 			}
 		}
-		self::assertSame( [ '1.0.0-beta.1.md', '1.0.0-beta.2.md', '1.0.0-beta.3.md', '1.0.0-beta.4.md', '1.0.0-beta.5.md', '1.0.0-beta.6.md', '1.0.0-beta.7.md', '1.0.0-beta.8.md', '1.0.0-beta.9.md' ], $versioned );
+		self::assertSame( [ '1.0.0-beta.1.md', '1.0.0-beta.10.md', '1.0.0-beta.2.md', '1.0.0-beta.3.md', '1.0.0-beta.4.md', '1.0.0-beta.5.md', '1.0.0-beta.6.md', '1.0.0-beta.7.md', '1.0.0-beta.8.md', '1.0.0-beta.9.md' ], $versioned );
 	}
 
 	public function test_root_changelog_keeps_latest_five_releases_and_links_older_history(): void {
@@ -34,7 +34,7 @@ final class ReleaseRetentionTest extends TestCase {
 			)
 		);
 		self::assertContains( 'Unreleased', $headers );
-		self::assertSame( [ '1.0.0-beta.9', '1.0.0-beta.8', '1.0.0-beta.7', '1.0.0-beta.6', '1.0.0-beta.5' ], $versions );
+		self::assertSame( [ '1.0.0-beta.10', '1.0.0-beta.9', '1.0.0-beta.8', '1.0.0-beta.7', '1.0.0-beta.6' ], $versions );
 		self::assertStringContainsString( '## Older releases', $raw );
 		self::assertStringContainsString( 'docs/releases/1.0.0-beta.1.md', $raw );
 	}


### PR DESCRIPTION
## Summary\n\n- bump the plugin and companion to 1.0.0-beta.10\n- publish the verified incident-repair lifecycle already merged into main\n- update release notes, changelogs, retention coverage, and the README screenshot version\n- keep future beta and release-candidate tags on the GitHub prerelease channel\n\n## Ability and safety impact\n\n- Release-preparation changes add no new ability implementation.\n- The package includes the previously merged stonewright/incident-repair-record ability.\n- Permission, backup, validation, confirmation-token, approval, and audit gates are unchanged by this PR.\n\n## Documentation\n\nUpdated the root, plugin, and companion changelogs; plugin metadata; README screenshot reference; and the versioned beta.10 release notes.\n\n## Verification\n\n- Plugin: 6,868 tests / 36,360 assertions\n- Companion: 58 test files / 470 tests\n- Visual: 8 test files / 80 tests\n- PHPStan, PHPCS, security/dependency/provenance audits, contract checks, token budgets, and builds\n- documentation freshness, license metadata, public hygiene, workflow YAML, and release-flag tests\n- production dependency manifest verification and local release-package simulation with checksums