### PR TITLE
fix: make release channels explicit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,9 +148,10 @@ jobs:
           version="${GITHUB_REF_NAME#v}"
           notes="docs/releases/${version}.md"
           if [ ! -f "$notes" ]; then
-            notes="docs/releases/checklist.md"
+            echo "Missing versioned release notes: $notes" >&2
+            exit 1
           fi
-          release_flag="$(node scripts/release-flags.mjs "$version")"
+          release_flag="$(node scripts/release-flags.mjs "$version" "$notes")"
           gh release create "$GITHUB_REF_NAME" \
             "dist/stonewright-${version}.zip" \
             dist/stonewright-companion-*.tgz \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,54 @@ npm run build
   compatibility, provenance, or migration. Copied and derived code must keep
   attribution in `docs/upstream-code-reuse.md` and SPDX file headers.
 
+## Release decision gate
+
+- Before changing a version, tag, release state, or release workflow, present a
+  release decision record containing: the user-visible change, affected
+  artifacts, one recommended release class, proposed SemVer, evidence and known
+  gaps, risk and rollback, and required documentation.
+- Recommend exactly one class: **no release**, **supported public beta**,
+  **preview prerelease**, or **stable release**. Do not manufacture a version
+  bump for documentation, tests, plans, comments, or internal automation that
+  does not change a user-consumed artifact.
+- A supported public beta is recommended for general installation. It keeps
+  prerelease SemVer, but is a normal GitHub release marked `Latest`.
+- A preview prerelease is opt-in and is not recommended for general
+  installation. It keeps prerelease SemVer, is marked `Pre-release`, and must
+  never be `Latest`.
+- A stable release uses stable SemVer and `Latest` only after every stable gate
+  below is satisfied.
+- Never publish a tag, release, channel conversion, or stable declaration
+  without explicit maintainer approval after presenting the decision record.
+- Release notes must declare exactly one channel: `supported`, `preview`, or
+  `stable`. Release automation must validate the declaration against SemVer and
+  fail closed for missing, unknown, or incompatible combinations.
+
+### Stable 1.0 gates
+
+Recommend against stable 1.0 while any required gate is missing:
+
+1. No unresolved P0 or P1 defect affects installation, authentication,
+   permissions, backups, writes, update discovery, or recovery.
+2. Plugin and Direct contracts are documented, versioned, and internally
+   consistent; intentional experimental abilities are explicitly marked.
+3. The supported client matrix has runtime evidence for installation,
+   `stonewright-task-start`, status, required tools, and an empty required-tool
+   refresh list after restart.
+4. Plugin, companion, and updater versions align in official release artifacts,
+   not merely in source code or saved configuration.
+5. Upgrade, reinstall, rollback, and private-state preservation are tested.
+6. Production-safe permission, confirmation, backup, custom-code approval,
+   validation, audit, and secret-scanning gates are green.
+7. The complete CI matrix, packaging workflow, checksums, and official archive
+   inspection are green.
+8. Maintained installation, update, architecture, capability, security, and
+   release documentation is current.
+9. A supported public beta has completed a maintainer-approved stabilization
+   period without an unresolved release-blocking regression. Record the beta,
+   observed feedback, resolved blockers, and remaining limitations; elapsed
+   time alone is not proof of stability.
+
 ## Public repository hygiene
 
 - Never commit customer or private-project names, domains, local site aliases,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ development builds were never stable releases.
 
 ## [Unreleased]
 
+### Changed
+
+- Require an explicit, SemVer-compatible release channel and expose the
+  supported public beta through one validated README download path.
+
 ## [1.0.0-beta.10] - 2026-08-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,6 +18,22 @@
   <img alt="wordpress" src="https://img.shields.io/badge/WordPress-%3E%3D6.7-21759b" />
 </p>
 
+<!-- supported-release:start -->
+<p align="center"><strong>Current release: 1.0.0-beta.10 — Public Beta</strong></p>
+<p align="center">
+  <a href="https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.10/stonewright-1.0.0-beta.10.zip">Download Plugin</a>
+  ·
+  <a href="docs/installation.md">Installation guide</a>
+  ·
+  <a href="https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.10/stonewright-companion-1.0.0-beta.10.tgz">Companion</a>
+  ·
+  <a href="https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.10/SHA256SUMS.txt">Checksums</a>
+  ·
+  <a href="https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/tag/v1.0.0-beta.10">Release notes</a>
+</p>
+<p align="center"><sub>Preview builds appear on the complete Releases page and are not recommended by default.</sub></p>
+<!-- supported-release:end -->
+
 Stonewright MCP presents a compact, task-aware surface backed by **361 Plugin abilities** and **101 Direct tools**. Elementor is a first-class Plugin surface; Gutenberg, WooCommerce, WordPress REST, and tokenized WP-CLI workflows use the same evidence-oriented operating model.
 
 Stonewright does not promise that automation cannot fail. It adds concrete controls around supported changes: permissions, operating modes, confirmation tokens, pre-write snapshots, validation, typed readback, audit evidence, and restore paths. Use staging and normal infrastructure backups for production work.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -220,18 +220,22 @@ legacy reconciliation stays retryable if any eligible memory update fails.
 
 ### Release-channel update discovery
 
-The native updater derives its channel from the installed semantic version.
-Stable builds inspect only complete, non-draft stable releases; prerelease
-builds inspect only complete, non-draft prereleases. Each channel has an
-isolated cache, and both the Plugin ZIP and companion package must use exact
-versioned filenames under the trusted GitHub release-download origin. Invalid
-metadata, missing assets, or a channel mismatch leave the installed version in
-place instead of falling back to another channel.
+The native updater derives compatibility from the installed semantic version.
+Stable builds inspect only complete, non-draft stable versions; prerelease
+builds inspect only complete, non-draft prerelease versions. GitHub presentation
+is a separate, explicit support decision: a supported public beta is a normal
+`Latest` release, a limited preview is a `Pre-release`, and a stable version is
+a normal `Latest` release. Each updater compatibility channel has an isolated
+cache, and both the Plugin ZIP and companion package must use exact versioned
+filenames under the trusted GitHub release-download origin. Invalid metadata,
+missing assets, or a SemVer mismatch leave the installed version in place
+instead of crossing compatibility channels.
 
 The Connect update status consumes that same selected release, so Plugin and
-companion recommendations cannot disagree. Future beta and release-candidate
-tags are created as GitHub prereleases; stable tags alone receive the latest
-release marker.
+companion recommendations cannot disagree. Versioned release notes declare
+`supported`, `preview`, or `stable`; release automation validates the declared
+support channel against SemVer before choosing GitHub's `Latest` or
+`Pre-release` state.
 
 ### External browser consent boundary
 

--- a/docs/documentation-maintenance.md
+++ b/docs/documentation-maintenance.md
@@ -41,6 +41,14 @@ imported reference snapshots with source metadata. Do not hand-edit either.
 
 ## Required review for releases and major changes
 
+Before any version, tag, channel, or release-workflow change, the agent presents
+the release decision record required by `AGENTS.md` and recommends exactly one
+release class. Publication or channel conversion waits for explicit maintainer
+approval. Every versioned `docs/releases/<version>.md` file used for a new
+publication declares exactly one `Release channel: <channel>` line, where the
+channel is `supported`, `preview`, or `stable`. Automation validates that
+declaration against SemVer and fails closed on disagreement.
+
 Review every affected item in the same PR:
 
 - `README.md`, `plugin/README.md`, and `companion/README.md`;
@@ -71,6 +79,7 @@ cd plugin
 composer docs:matrix
 ```
 
-The documentation check validates version agreement, current release notes,
-changelog heads, evergreen package URLs, required install-prompt contracts, and
-relative Markdown links. CI and the release workflow run it automatically.
+The documentation check validates version agreement, current release notes and
+their explicit channel, changelog heads, evergreen package URLs, the supported
+release block, required install-prompt contracts, and relative Markdown links.
+CI and the release workflow run it automatically.

--- a/docs/releases/1.0.0-beta.10.md
+++ b/docs/releases/1.0.0-beta.10.md
@@ -2,6 +2,8 @@
 
 Released: 2026-08-12
 
+Release channel: `supported`
+
 ## Summary
 
 This release makes Stonewright's learning loop evidence-based and easier to
@@ -37,8 +39,8 @@ crossing between them.
   throughout maintained documentation.
 - Select Plugin and companion updates from the installed SemVer channel using
   isolated caches and exact trusted assets without cross-channel fallback.
-- Publish future beta and release-candidate tags as GitHub prereleases; only a
-  stable tag can become the latest stable release.
+- Select the GitHub release channel explicitly: supported public betas are
+  recommended as `Latest`, while opt-in previews remain prereleases.
 
 ## Upgrade
 

--- a/docs/superpowers/plans/2026-08-12-release-channel-policy.md
+++ b/docs/superpowers/plans/2026-08-12-release-channel-policy.md
@@ -1,0 +1,374 @@
+# Release Channel Policy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Stonewright release channel selection explicit, fail-closed, easy for users to discover, and governed by a mandatory maintainer decision before publication.
+
+**Architecture:** A pure Node helper will read a channel declaration from the versioned release note and validate it against SemVer before returning the single GitHub CLI flag. `AGENTS.md` owns the maintainer/agent decision rules, documentation freshness owns the current-release README block, and the release workflow consumes the validated helper rather than inferring channel from the version suffix.
+
+**Tech Stack:** Node.js ESM and `node:test`, GitHub Actions YAML and GitHub CLI, Markdown, existing documentation-freshness/public-hygiene gates.
+
+## Global Constraints
+
+- Supported public beta means prerelease SemVer plus GitHub normal release and `Latest`.
+- Preview means prerelease SemVer plus GitHub `Pre-release`, never `Latest`.
+- Stable means stable SemVer plus GitHub normal release and `Latest`.
+- Missing, unknown, or incompatible version/channel combinations fail closed.
+- A tag, release publication, channel conversion, or stable declaration requires explicit maintainer approval after a release decision record.
+- Exact supported-release URLs may appear only in the README block validated against the canonical plugin version.
+- Existing beta.10 asset bytes and digests must not change during its metadata-only channel conversion.
+- No repository text, branch, commit, pull request, changelog, or release note may describe private application strategy or promotional optimization.
+- Git operations require author email `61551533+cosmincraciun97@users.noreply.github.com` and GitHub CLI account `cosmincraciun97`.
+
+---
+
+### Task 1: Explicit, fail-closed release channel helper
+
+**Files:**
+- Modify: `scripts/release-flags.mjs`
+- Modify: `scripts/tests/release-flags.test.mjs`
+- Modify: `.github/workflows/release.yml`
+- Modify: `docs/releases/1.0.0-beta.10.md`
+
+**Interfaces:**
+- Consumes: `releaseFlags(version: string, channel: string): string[]` and release-note Markdown containing `Release channel: \`supported\``.
+- Produces: CLI `node scripts/release-flags.mjs <version> <notes-path>` writing exactly `--latest` or `--prerelease`.
+
+- [ ] **Step 1: Write failing channel tests**
+
+Replace inference tests with exact assertions:
+
+```js
+assert.deepEqual(releaseFlags('1.0.0-beta.10', 'supported'), ['--latest']);
+assert.deepEqual(releaseFlags('1.0.0-beta.11', 'preview'), ['--prerelease']);
+assert.deepEqual(releaseFlags('1.0.0-rc.1', 'preview'), ['--prerelease']);
+assert.deepEqual(releaseFlags('1.0.0', 'stable'), ['--latest']);
+assert.throws(() => releaseFlags('1.0.0-beta.10', ''), /release channel/i);
+assert.throws(() => releaseFlags('1.0.0-beta.10', 'stable'), /incompatible/i);
+assert.throws(() => releaseFlags('1.0.0', 'preview'), /incompatible/i);
+assert.throws(() => releaseFlags('1.0.0', 'supported'), /incompatible/i);
+```
+
+Add release-note parser assertions:
+
+```js
+assert.equal(releaseChannelFromNotes('Release channel: `supported`\n'), 'supported');
+assert.throws(() => releaseChannelFromNotes('# Missing'), /release channel/i);
+assert.throws(() => releaseChannelFromNotes('Release channel: `other`'), /release channel/i);
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `node --test scripts/tests/release-flags.test.mjs`
+
+Expected: failure because `releaseFlags` still accepts one argument and `releaseChannelFromNotes` is absent.
+
+- [ ] **Step 3: Implement strict parsing and compatibility validation**
+
+Implement:
+
+```js
+const channels = new Set(['supported', 'preview', 'stable']);
+
+export function releaseChannelFromNotes(notes) {
+	const match = /^Release channel: `([^`]+)`$/m.exec(notes);
+	if (!match || !channels.has(match[1])) {
+		throw new Error('Release notes require one valid release channel.');
+	}
+	return match[1];
+}
+
+export function releaseFlags(version, channel) {
+	const match = semver.exec(version);
+	if (!match) throw new Error(/* existing semantic-version message */);
+	if (!channels.has(channel)) throw new Error('Expected release channel: supported, preview, or stable.');
+	const prerelease = Boolean(match[1]);
+	if (channel === 'stable' && prerelease) throw new Error('Release channel is incompatible with the semantic version.');
+	if (channel !== 'stable' && !prerelease) throw new Error('Release channel is incompatible with the semantic version.');
+	return [channel === 'preview' ? '--prerelease' : '--latest'];
+}
+```
+
+The CLI reads the UTF-8 notes path from `process.argv[3]`, parses its channel,
+and prints the validated flag. Missing files or declarations exit nonzero.
+
+- [ ] **Step 4: Wire workflow and current release note**
+
+Add directly after the release date:
+
+```markdown
+Release channel: `supported`
+```
+
+Change the workflow invocation to:
+
+```bash
+release_flag="$(node scripts/release-flags.mjs "$version" "$notes")"
+```
+
+Do not fall back to `docs/releases/checklist.md`; a missing versioned release
+note must block publication.
+
+- [ ] **Step 5: Run focused tests and workflow parse**
+
+Run:
+
+```bash
+node --test scripts/tests/release-flags.test.mjs
+node scripts/release-flags.mjs 1.0.0-beta.10 docs/releases/1.0.0-beta.10.md
+ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'workflow-yaml-ok'"
+```
+
+Expected: tests pass, CLI prints `--latest`, YAML prints `workflow-yaml-ok`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/release-flags.mjs scripts/tests/release-flags.test.mjs .github/workflows/release.yml docs/releases/1.0.0-beta.10.md
+git commit -m "fix: validate release channel selection"
+```
+
+### Task 2: Durable agent decision methodology
+
+**Files:**
+- Modify: `AGENTS.md`
+- Modify: `docs/documentation-maintenance.md`
+- Modify: `docs/architecture.md`
+
+**Interfaces:**
+- Consumes: release classes and stable gates from the approved design.
+- Produces: mandatory `Release decision gate` followed by agents before any version/tag/release operation.
+
+- [ ] **Step 1: Add the release decision gate to `AGENTS.md`**
+
+Add a section after `## Branching and changes` containing:
+
+```markdown
+## Release decision gate
+
+- Before changing a version, tag, release state, or release workflow, present a release decision record with: user-visible change, artifact impact, recommended class, SemVer, evidence and gaps, risk and rollback, and required documentation.
+- Recommend exactly one class: no release, supported public beta, preview prerelease, or stable release.
+- A supported public beta is recommended for general installation: prerelease SemVer, GitHub normal release, and `Latest`.
+- A preview prerelease is opt-in and not recommended generally: prerelease SemVer, GitHub `Pre-release`, never `Latest`.
+- A stable release uses stable SemVer and `Latest` only after every stable gate below is satisfied.
+- Never publish a tag, release, channel conversion, or stable declaration without explicit maintainer approval after the decision record.
+```
+
+Include all nine stable gates from the approved specification as concrete bullets.
+
+- [ ] **Step 2: Align maintained documentation**
+
+Update architecture to state that update selection follows installed SemVer
+compatibility while GitHub presentation follows the explicit support channel.
+Update documentation maintenance to require a channel declaration in every
+versioned release note and the release-decision review before tagging.
+
+- [ ] **Step 3: Verify documentation**
+
+Run:
+
+```bash
+node scripts/check-docs-freshness.mjs
+git diff --check
+```
+
+Expected: both exit zero.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add AGENTS.md docs/documentation-maintenance.md docs/architecture.md
+git commit -m "docs: codify release decision gates"
+```
+
+### Task 3: One obvious supported-download path
+
+**Files:**
+- Modify: `README.md`
+- Modify: `scripts/check-docs-freshness.mjs`
+- Modify: `CHANGELOG.md`
+- Test: `scripts/tests/release-flags.test.mjs`
+
+**Interfaces:**
+- Consumes: canonical version parsed from `plugin/stonewright.php`.
+- Produces: README block delimited by `<!-- supported-release:start -->` and `<!-- supported-release:end -->`, validated against that version.
+
+- [ ] **Step 1: Write failing README contract tests**
+
+Add assertions that README contains both markers, `Public Beta`, the canonical
+beta.10 tag URL, plugin ZIP URL, companion TGZ URL, checksum URL, and
+`docs/installation.md`. Assert the freshness script names the supported block.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `node --test scripts/tests/release-flags.test.mjs`
+
+Expected: failure because the supported-release block does not exist.
+
+- [ ] **Step 3: Add the compact README release card**
+
+Place it below the badge row and before the product description:
+
+```html
+<!-- supported-release:start -->
+<p align="center"><strong>Current release: 1.0.0-beta.10 — Public Beta</strong></p>
+<p align="center">
+  <a href=".../releases/download/v1.0.0-beta.10/stonewright-1.0.0-beta.10.zip">Download Plugin</a>
+  · <a href="docs/installation.md">Installation guide</a>
+  · <a href=".../releases/download/v1.0.0-beta.10/stonewright-companion-1.0.0-beta.10.tgz">Companion</a>
+  · <a href=".../releases/download/v1.0.0-beta.10/SHA256SUMS.txt">Checksums</a>
+</p>
+<p align="center"><sub>Preview builds appear on the complete Releases page and are not recommended by default.</sub></p>
+<!-- supported-release:end -->
+```
+
+- [ ] **Step 4: Make freshness own the exception**
+
+Extract exactly one supported-release block. Fail if markers are missing,
+duplicated, reversed, or if the block lacks the canonical version and all four
+expected URLs. Remove only this validated block before applying the existing
+evergreen exact-prerelease-pin rejection to README.
+
+Add an `Unreleased / Changed` root changelog item describing explicit channels
+and the supported-download path. Do not change plugin or companion versions.
+
+- [ ] **Step 5: Run focused and documentation tests**
+
+Run:
+
+```bash
+node --test scripts/tests/release-flags.test.mjs
+node scripts/check-docs-freshness.mjs
+node scripts/check-public-hygiene.mjs
+git diff --check
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add README.md scripts/check-docs-freshness.mjs scripts/tests/release-flags.test.mjs CHANGELOG.md
+git commit -m "docs: expose the supported release path"
+```
+
+### Task 4: Full verification, PR, merge, and channel conversion
+
+**Files:**
+- Verify all changed files; no new source file expected.
+- External metadata: GitHub release `v1.0.0-beta.10` only after merge.
+
+**Interfaces:**
+- Consumes: green branch, explicit user approval already recorded, immutable beta.10 assets.
+- Produces: merged policy and beta.10 as normal `Latest` without changed artifacts.
+
+- [ ] **Step 1: Record original asset digests**
+
+Run:
+
+```bash
+gh release view v1.0.0-beta.10 --json assets --jq '.assets[] | [.name,.digest] | @tsv'
+```
+
+Store the output only in the task evidence, never in a tracked scratch file.
+
+- [ ] **Step 2: Run complete local gates**
+
+Run:
+
+```bash
+node --test scripts/tests/release-flags.test.mjs
+node scripts/check-license-metadata.mjs
+node scripts/check-docs-freshness.mjs
+node scripts/check-public-hygiene.mjs
+ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); YAML.load_file('.github/workflows/release.yml')"
+git diff --check
+```
+
+Run the production packaging verification because release workflow behavior changed:
+
+```bash
+cd plugin
+composer package:verify-manifests
+cd ..
+node scripts/package-verify.mjs --require-visual-bundle --strict-vendor
+```
+
+- [ ] **Step 3: Identity gate, push, and PR**
+
+Verify the exact Git author email and GitHub account, push
+`release-channel-policy`, and open a PR titled:
+
+```text
+fix: make release channels explicit
+```
+
+The PR states that no ability, permission, backup, validation, token, approval,
+or audit behavior changed. It lists all public documentation changes.
+
+- [ ] **Step 4: Wait for all PR checks and merge normally**
+
+Do not merge while any check is pending or failed. Merge with a merge commit
+after all checks are green and re-run the identity gate immediately before the
+merge.
+
+- [ ] **Step 5: Wait for post-merge CI**
+
+Identify the CI run for the exact merge SHA and wait for `success`. Stop if the
+head SHA differs or any job fails.
+
+- [ ] **Step 6: Convert beta.10 metadata**
+
+Reconfirm that the release exists, is not a draft, points to the expected tag,
+and its asset digests match Step 1. Then run under the approved GitHub account:
+
+```bash
+gh release edit v1.0.0-beta.10 --prerelease=false --latest
+```
+
+Do not upload, replace, rename, or delete assets and do not move the tag.
+
+- [ ] **Step 7: Verify public result**
+
+Confirm:
+
+- beta.10 reports `isPrerelease=false`, `isLatest=true`, `isDraft=false`;
+- beta.9 reports `isLatest=false`;
+- tag target remains the beta.10 merge commit already released;
+- all four asset names and digests equal Step 1;
+- README links return the expected public assets;
+- `/releases/latest` resolves to beta.10.
+
+### Task 5: Prepare the maintainer application text outside the repository
+
+**Files:**
+- Do not create or modify repository files.
+- Deliver the reusable text only in the final task response.
+
+**Interfaces:**
+- Consumes: public repository facts verified during implementation.
+- Produces: three truthful form answers, each at most 500 characters.
+
+- [ ] **Step 1: Draft the maintainer-role answer**
+
+State that the applicant is the primary maintainer responsible for architecture,
+review, releases, security gates, documentation, and compatibility. Do not
+claim a team or adoption not supported by public evidence.
+
+- [ ] **Step 2: Draft the qualification answer**
+
+Explain ecosystem importance through the problem solved: guarded WordPress MCP
+automation, recoverable writes, evidence, Plugin/Direct modes, and maintained
+release infrastructure. Mention public tests/capability scope only when exact.
+
+- [ ] **Step 3: Draft the API-credit answer**
+
+Describe use for issue triage, regression-test generation, security review,
+compatibility validation, release verification, and documentation maintenance.
+Keep it concrete and under 500 characters.
+
+- [ ] **Step 4: Final truthfulness check**
+
+Verify every metric against the public repository. Omit stars, downloads,
+users, installations, or community adoption unless directly verified at the
+time of delivery.

--- a/docs/superpowers/specs/2026-08-12-release-channel-policy-design.md
+++ b/docs/superpowers/specs/2026-08-12-release-channel-policy-design.md
@@ -1,0 +1,187 @@
+# Release Channel Policy Design
+
+Date: 2026-08-12
+Status: Approved for implementation
+
+## Objective
+
+Make every Stonewright release decision predictable for maintainers, agents,
+updaters, and users. The version string and the GitHub release channel serve
+different purposes:
+
+- SemVer communicates API maturity.
+- GitHub's `Latest` marker identifies the version recommended for installation.
+- GitHub's `Pre-release` marker identifies an opt-in preview that is not the
+  recommended installation.
+
+Stonewright may therefore recommend a supported public beta as `Latest` while
+retaining its `1.0.0-beta.N` SemVer version.
+
+## Release classes
+
+### No release
+
+Use no release when a change affects only repository documentation, tests,
+plans, comments, or internal development automation and does not change any
+artifact consumed by users. Merge the change normally. Do not create an empty
+version bump merely to advertise repository activity.
+
+### Supported public beta
+
+Use a supported public beta when the product is still before the stable 1.0
+contract but the build is the version recommended to all new and existing
+users.
+
+- Version: `1.0.0-beta.N`.
+- GitHub state: normal release and `Latest`.
+- Updater state: selected by prerelease installations as their supported
+  channel.
+- Documentation: clearly label it `Public Beta` and state that APIs or
+  compatibility may still change before 1.0.
+- Distribution: publish the plugin ZIP, companion TGZ, Visual TGZ, release
+  notes, and checksums.
+
+### Preview prerelease
+
+Use a GitHub prerelease only when the build is intentionally not recommended
+for general installation. Typical reasons are incomplete compatibility,
+experimental contracts, a risky migration, a limited validation matrix, or an
+explicit request for early testing.
+
+- Version: an appropriate beta or release-candidate SemVer identifier.
+- GitHub state: `Pre-release`, never `Latest`.
+- Documentation: name the missing evidence and the intended tester audience.
+- Distribution: may contain the normal artifacts, but installation guidance
+  must not silently select it for general users.
+
+The existence of a prerelease suffix alone does not force this channel. The
+maintainer's support recommendation does.
+
+### Stable release
+
+Use a stable release only when the public contract is ready to carry normal
+SemVer compatibility expectations.
+
+- Version: `1.0.0` or a later stable SemVer version.
+- GitHub state: normal release and `Latest`.
+- Updater state: stable installations select only stable releases.
+- Documentation: remove public-beta warnings only when the stable gates below
+  are satisfied.
+
+## Stable 1.0 gates
+
+An agent must recommend against 1.0 while any required gate is missing:
+
+1. No unresolved P0 or P1 defect affecting installation, authentication,
+   permissions, backups, writes, update discovery, or recovery.
+2. Plugin and Direct contracts are documented, versioned, and internally
+   consistent; intentional experimental abilities are explicitly marked.
+3. The supported client matrix has runtime evidence for installation,
+   `stonewright-task-start`, status, required tools, and an empty required-tool
+   refresh list after restart.
+4. Plugin, companion, and updater version alignment is verified from official
+   release artifacts, not only from source or saved configuration.
+5. Upgrade, reinstall, rollback, and private-state preservation are tested.
+6. Production-safe permission, confirmation, backup, custom-code approval,
+   validation, audit, and secret-scanning gates are green.
+7. The complete CI matrix, release packaging workflow, checksum verification,
+   and official archive inspection are green.
+8. Maintained installation, update, architecture, capability, security, and
+   release documentation is current.
+9. A supported public beta has completed a maintainer-approved stabilization
+   period without an unresolved release-blocking regression.
+
+The stabilization period is evidence-based, not a fixed calendar promise. The
+maintainer records the beta used, observed feedback, resolved blockers, and
+remaining known limitations before approving 1.0.
+
+## Mandatory decision record
+
+Before changing versions, tags, GitHub release state, or release workflows, an
+agent must present a concise release decision record to the maintainer:
+
+1. **User-visible change:** what users gain or what blocking defect is fixed.
+2. **Artifact impact:** which plugin, companion, Visual, schema, updater, or
+   documentation artifacts changed.
+3. **Recommended action:** no release, supported public beta, preview
+   prerelease, or stable release.
+4. **Version:** proposed SemVer and why that increment is correct.
+5. **Evidence:** local tests, CI, compatibility/runtime proof, package checks,
+   and known gaps.
+6. **Risk and rollback:** likely failure modes and the exact recovery path.
+7. **Documentation:** files that must change with the release.
+
+The agent must make a recommendation rather than merely list possibilities. A
+tag, release publication, channel conversion, or stable 1.0 declaration always
+requires explicit maintainer approval after this record is shown.
+
+## Automation behavior
+
+The release workflow must accept an explicit release channel instead of
+inferring that every beta or release candidate is necessarily a GitHub
+prerelease.
+
+The implementation will provide a small validated channel input with these
+outcomes:
+
+- `supported` -> GitHub normal release with `--latest`.
+- `preview` -> GitHub release with `--prerelease`.
+- `stable` -> GitHub normal release with `--latest`, accepted only for a stable
+  SemVer version.
+
+Invalid combinations fail closed. In particular:
+
+- `stable` rejects beta and release-candidate versions.
+- `preview` rejects stable versions.
+- a missing or unknown channel blocks publication.
+
+Tests must cover supported beta, preview beta, preview release candidate,
+stable 1.0, malformed versions, missing channels, and invalid combinations.
+
+## Current release transition
+
+`1.0.0-beta.10` is the supported public beta and the recommended installation.
+Its existing assets and checksums remain immutable. The GitHub release metadata
+will be changed from `Pre-release` to a normal `Latest` release after the policy
+implementation is merged and all CI checks pass. No new version or artifact is
+created for this metadata-only correction.
+
+## User-facing discoverability
+
+The README header will expose one obvious supported-download path:
+
+- `Current release: 1.0.0-beta.10 - Public Beta`;
+- direct plugin ZIP download;
+- installation guide;
+- companion setup command or direct companion asset link;
+- checksum link;
+- a short statement that preview builds, when they exist, live on the complete
+  Releases page and are not recommended by default.
+
+Evergreen documentation continues to use `VERSION` placeholders. Exact beta.10
+links are allowed only in the current-release header while beta.10 is the
+supported release; the documentation-freshness contract must explicitly own
+and validate this exception so it cannot become a stale hidden pin.
+
+## Application text boundary
+
+Any maintainer application text is prepared outside tracked repository files.
+It must use truthful public evidence and must not invent usage, stars,
+downloads, security adoption, or community impact. Repository branches,
+commits, pull requests, changelogs, release notes, and code comments describe
+only product and maintenance changes.
+
+## Verification
+
+Implementation is complete only when:
+
+- the new `AGENTS.md` rules contain the release classes, decision record,
+  explicit-approval boundary, and stable gates;
+- release-channel tests pass and publication fails closed for invalid input;
+- README download links resolve to the supported beta.10 assets;
+- documentation freshness and public hygiene pass;
+- local package verification passes when workflow behavior changes;
+- all pull-request checks are green;
+- the change is merged normally into `main`;
+- beta.10 is a normal `Latest` release while all existing asset digests remain
+  unchanged.

--- a/scripts/check-docs-freshness.mjs
+++ b/scripts/check-docs-freshness.mjs
@@ -254,6 +254,7 @@ const historicalMarkdown = (relativePath) =>
 	relativePath === 'plugin/CHANGELOG.md' ||
 	relativePath.startsWith('docs/releases/') ||
 	relativePath.startsWith('docs/plans/') ||
+	relativePath.startsWith('docs/superpowers/') ||
 	relativePath.startsWith('research/') ||
 	[
 		'docs/premium-corrections-handoff-report.md',

--- a/scripts/check-docs-freshness.mjs
+++ b/scripts/check-docs-freshness.mjs
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { releaseChannelFromNotes, releaseFlags } from './release-flags.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const errors = [];
@@ -174,6 +175,48 @@ if (canonicalVersion && pluginReadmeVersion !== canonicalVersion) {
 
 if (canonicalVersion && !fs.existsSync(path.join(repoRoot, `docs/releases/${canonicalVersion}.md`))) {
 	fail(`Missing docs/releases/${canonicalVersion}.md.`);
+} else if (canonicalVersion) {
+	try {
+		const releaseChannel = releaseChannelFromNotes(read(`docs/releases/${canonicalVersion}.md`));
+		releaseFlags(canonicalVersion, releaseChannel);
+	} catch (error) {
+		fail(`docs/releases/${canonicalVersion}.md has an invalid release channel: ${error instanceof Error ? error.message : String(error)}`);
+	}
+}
+
+const rootReadme = read('README.md');
+const supportedReleaseStart = '<!-- supported-release:start -->';
+const supportedReleaseEnd = '<!-- supported-release:end -->';
+const supportedStartCount = rootReadme.split(supportedReleaseStart).length - 1;
+const supportedEndCount = rootReadme.split(supportedReleaseEnd).length - 1;
+let supportedReleaseBlock = '';
+if (supportedStartCount !== 1 || supportedEndCount !== 1) {
+	fail('README.md must contain exactly one supported-release marker pair.');
+} else {
+	const start = rootReadme.indexOf(supportedReleaseStart);
+	const end = rootReadme.indexOf(supportedReleaseEnd, start + supportedReleaseStart.length);
+	if (end < start) {
+		fail('README.md supported-release markers are reversed.');
+	} else {
+		supportedReleaseBlock = rootReadme.slice(start, end + supportedReleaseEnd.length);
+	}
+}
+if (canonicalVersion && supportedReleaseBlock) {
+	const releaseBase = `https://github.com/cosmincraciun97/stonewright-wp-mcp/releases`;
+	const releaseLabel = canonicalVersion.includes('-') ? 'Public Beta' : 'Stable';
+	const expectedSupportedMarkers = [
+		`Current release: ${canonicalVersion} — ${releaseLabel}`,
+		`${releaseBase}/tag/v${canonicalVersion}`,
+		`${releaseBase}/download/v${canonicalVersion}/stonewright-${canonicalVersion}.zip`,
+		`${releaseBase}/download/v${canonicalVersion}/stonewright-companion-${canonicalVersion}.tgz`,
+		`${releaseBase}/download/v${canonicalVersion}/SHA256SUMS.txt`,
+		'href="docs/installation.md"',
+	];
+	for (const marker of expectedSupportedMarkers) {
+		if (!supportedReleaseBlock.includes(marker)) {
+			fail(`README.md supported-release block is missing: ${marker}`);
+		}
+	}
 }
 
 const abilityCount = Number(read('docs/ability-truth-matrix.md').match(/Total abilities registered: \*\*(\d+)\*\*/)?.[1]);
@@ -314,8 +357,11 @@ const markdownFiles = allMarkdownFiles.filter((absolute) => {
 for (const absolute of markdownFiles) {
 	const relative = path.relative(repoRoot, absolute).split(path.sep).join('/');
 	const content = fs.readFileSync(absolute, 'utf8');
+	const evergreenContent = relative === 'README.md' && supportedReleaseBlock
+		? content.replace(supportedReleaseBlock, '')
+		: content;
 
-	if (!historicalMarkdown(relative) && /releases\/download\/v1\.0\.0-(?:beta|rc)\.\d+\//.test(content)) {
+	if (!historicalMarkdown(relative) && /releases\/download\/v1\.0\.0-(?:beta|rc)\.\d+\//.test(evergreenContent)) {
 		fail(`${relative} pins a release asset; use the VERSION placeholder.`);
 	}
 

--- a/scripts/release-flags.mjs
+++ b/scripts/release-flags.mjs
@@ -1,22 +1,44 @@
 #!/usr/bin/env node
 
 import process from 'node:process';
+import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 const semver = /^\d+\.\d+\.\d+(?:-([0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*))?(?:\+[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?$/;
+const channels = new Set(['supported', 'preview', 'stable']);
 
-export function releaseFlags(version) {
+export function releaseChannelFromNotes(notes) {
+	const match = /^Release channel: `([^`]+)`$/m.exec(notes);
+	if (!match || !channels.has(match[1])) {
+		throw new Error('Release notes require one valid release channel: supported, preview, or stable.');
+	}
+	return match[1];
+}
+
+export function releaseFlags(version, channel) {
 	const match = semver.exec(version);
 	if (!match) {
 		throw new Error(`Expected a semantic version without a v prefix; received "${version}".`);
 	}
-	return [match[1] ? '--prerelease' : '--latest'];
+	if (!channels.has(channel)) {
+		throw new Error('Expected release channel: supported, preview, or stable.');
+	}
+	const prerelease = Boolean(match[1]);
+	if ((channel === 'stable' && prerelease) || (channel !== 'stable' && !prerelease)) {
+		throw new Error(`Release channel "${channel}" is incompatible with semantic version "${version}".`);
+	}
+	return [channel === 'preview' ? '--prerelease' : '--latest'];
 }
 
 if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
 	try {
 		const version = process.argv[2] ?? '';
-		process.stdout.write(`${releaseFlags(version)[0]}\n`);
+		const notesPath = process.argv[3] ?? '';
+		if (!notesPath) {
+			throw new Error('Expected a versioned release notes path.');
+		}
+		const channel = releaseChannelFromNotes(readFileSync(notesPath, 'utf8'));
+		process.stdout.write(`${releaseFlags(version, channel)[0]}\n`);
 	} catch (error) {
 		process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
 		process.exitCode = 1;

--- a/scripts/tests/release-flags.test.mjs
+++ b/scripts/tests/release-flags.test.mjs
@@ -1,26 +1,43 @@
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
-import { releaseFlags } from '../release-flags.mjs';
+import { releaseChannelFromNotes, releaseFlags } from '../release-flags.mjs';
 
 const releaseWorkflow = readFileSync(
 	new URL('../../.github/workflows/release.yml', import.meta.url),
 	'utf8',
 );
 
-test('future beta and rc versions are prereleases', () => {
-	assert.deepEqual(releaseFlags('1.0.0-beta.10'), ['--prerelease']);
-	assert.deepEqual(releaseFlags('1.0.0-rc.1'), ['--prerelease']);
+test('supported public betas are latest releases', () => {
+	assert.deepEqual(releaseFlags('1.0.0-beta.10', 'supported'), ['--latest']);
 });
 
-test('stable versions are latest releases', () => {
-	assert.deepEqual(releaseFlags('1.0.0'), ['--latest']);
+test('preview beta and rc versions are prereleases', () => {
+	assert.deepEqual(releaseFlags('1.0.0-beta.11', 'preview'), ['--prerelease']);
+	assert.deepEqual(releaseFlags('1.0.0-rc.1', 'preview'), ['--prerelease']);
+});
+
+test('stable versions use the stable latest channel', () => {
+	assert.deepEqual(releaseFlags('1.0.0', 'stable'), ['--latest']);
+});
+
+test('release notes declare one recognized channel', () => {
+	assert.equal(releaseChannelFromNotes('Release channel: `supported`\n'), 'supported');
+	assert.throws(() => releaseChannelFromNotes('# Missing'), /release channel/i);
+	assert.throws(() => releaseChannelFromNotes('Release channel: `other`'), /release channel/i);
+});
+
+test('missing and incompatible release channels fail closed', () => {
+	assert.throws(() => releaseFlags('1.0.0-beta.10', ''), /release channel/i);
+	assert.throws(() => releaseFlags('1.0.0-beta.10', 'stable'), /incompatible/i);
+	assert.throws(() => releaseFlags('1.0.0', 'preview'), /incompatible/i);
+	assert.throws(() => releaseFlags('1.0.0', 'supported'), /incompatible/i);
 });
 
 test('malformed versions fail closed', () => {
-	assert.throws(() => releaseFlags('v1.0.0'), /semantic version/i);
-	assert.throws(() => releaseFlags('latest'), /semantic version/i);
-	assert.throws(() => releaseFlags('1.0'), /semantic version/i);
+	assert.throws(() => releaseFlags('v1.0.0', 'stable'), /semantic version/i);
+	assert.throws(() => releaseFlags('latest', 'stable'), /semantic version/i);
+	assert.throws(() => releaseFlags('1.0', 'stable'), /semantic version/i);
 });
 
 test('plugin release archive carries the canonical license', () => {

--- a/scripts/tests/release-flags.test.mjs
+++ b/scripts/tests/release-flags.test.mjs
@@ -7,6 +7,11 @@ const releaseWorkflow = readFileSync(
 	new URL('../../.github/workflows/release.yml', import.meta.url),
 	'utf8',
 );
+const readme = readFileSync(new URL('../../README.md', import.meta.url), 'utf8');
+const docsFreshness = readFileSync(
+	new URL('../check-docs-freshness.mjs', import.meta.url),
+	'utf8',
+);
 
 test('supported public betas are latest releases', () => {
 	assert.deepEqual(releaseFlags('1.0.0-beta.10', 'supported'), ['--latest']);
@@ -50,4 +55,16 @@ test('archive inspections remain reliable with pipefail enabled', () => {
 		releaseWorkflow,
 		/(?:tar -tzf|unzip -Z1)[^\n]*\|\s*grep\s+-[A-Za-z]*q/,
 	);
+});
+
+test('README exposes one validated supported public beta path', () => {
+	assert.match(readme, /<!-- supported-release:start -->/);
+	assert.match(readme, /<!-- supported-release:end -->/);
+	assert.match(readme, /Current release: 1\.0\.0-beta\.10 — Public Beta/);
+	assert.match(readme, /releases\/tag\/v1\.0\.0-beta\.10/);
+	assert.match(readme, /releases\/download\/v1\.0\.0-beta\.10\/stonewright-1\.0\.0-beta\.10\.zip/);
+	assert.match(readme, /releases\/download\/v1\.0\.0-beta\.10\/stonewright-companion-1\.0\.0-beta\.10\.tgz/);
+	assert.match(readme, /releases\/download\/v1\.0\.0-beta\.10\/SHA256SUMS\.txt/);
+	assert.match(readme, /docs\/installation\.md/);
+	assert.match(docsFreshness, /supported-release:start/);
 });


### PR DESCRIPTION
## Summary\n\n- require an explicit release channel in versioned release notes\n- validate supported, preview, and stable channels against SemVer\n- document the mandatory release decision record and stable 1.0 gates\n- expose the supported public beta through direct, freshness-checked README links\n\n## Ability and safety impact\n\nNo abilities changed. Permission, backup, validation, confirmation-token, custom-code approval, and audit behavior remain unchanged.\n\n## Documentation\n\nUpdated AGENTS.md, architecture, documentation maintenance, the root changelog, the current release note, README, and the approved design/implementation records.\n\n## Verification\n\n- release-channel Node tests\n- documentation freshness and public hygiene\n- license metadata and workflow YAML parsing\n- Jetpack manifest verification\n- strict production package verification\n- git diff whitespace checks