### PR TITLE
Release updater bridge 1.0.0-beta.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ development builds were never stable releases.
 
 ## [Unreleased]
 
+## [1.0.0-beta.11.1] - 2026-08-24
+
+### Fixed
+
+- Add a preview migration bridge so the native plugin updater validates
+  declared supported, preview, and stable release channels before selecting an
+  eligible update.
+
 ## [1.0.0-beta.11] - 2026-08-22
 
 ### Added
@@ -250,15 +258,6 @@ development builds were never stable releases.
 - Make `connect verify` print content-safe runtime proof for companion version,
   active alias, task-start/status availability, and refresh-required tools;
   verification now fails while any refresh-required tool remains.
-
-## [1.0.0-beta.7] - 2026-08-12
-
-### Fixed
-
-- Keep `connect add` and `connect repair` receipts content-free: client config
-  contents, unrelated local settings, absolute config paths, and backup paths
-  are withheld while the receipt retains the server name, change state, backup
-  state, support tier, and browser consent metadata.
 
 ## Older releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -261,6 +261,7 @@ development builds were never stable releases.
 
 ## Older releases
 
+- [1.0.0-beta.7](docs/releases/1.0.0-beta.7.md)
 - [1.0.0-beta.6](docs/releases/1.0.0-beta.6.md)
 - [1.0.0-beta.5](docs/releases/1.0.0-beta.5.md)
 - [1.0.0-beta.4](docs/releases/1.0.0-beta.4.md)

--- a/companion/CHANGELOG.md
+++ b/companion/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [1.0.0-beta.11.1] - 2026-08-24
+
+### Changed
+
+- Align release-consumed package metadata with the beta.11.1 updater migration
+  bridge; companion behavior is unchanged.
+
 ## [1.0.0-beta.11] - 2026-08-22
 
 ### Added

--- a/companion/package-lock.json
+++ b/companion/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@stonewright/companion",
-	"version": "1.0.0-beta.11",
+	"version": "1.0.0-beta.11.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@stonewright/companion",
-			"version": "1.0.0-beta.11",
+			"version": "1.0.0-beta.11.1",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/companion/package.json
+++ b/companion/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@stonewright/companion",
-	"version": "1.0.0-beta.11",
+	"version": "1.0.0-beta.11.1",
 	"description": "Node companion for the Stonewright WordPress MCP plugin: WP-CLI, health checks, and optional MCP HTTP proxy.",
 	"type": "module",
 	"license": "MIT",

--- a/companion/src/version.ts
+++ b/companion/src/version.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = '1.0.0-beta.11';
+export const APP_VERSION = '1.0.0-beta.11.1';
 
 export function companionPackageSpec(version: string = APP_VERSION): string {
 	return `https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v${version}/stonewright-companion-${version}.tgz`;

--- a/docs/releases/1.0.0-beta.11.1.md
+++ b/docs/releases/1.0.0-beta.11.1.md
@@ -1,0 +1,31 @@
+# Stonewright 1.0.0-beta.11.1
+
+Released: 2026-08-24
+
+Release channel: `preview`
+
+## Summary
+
+This is a temporary migration bridge for beta.11 installations whose native
+WordPress updater could not recognize supported public beta releases published
+as GitHub Latest. Normal users should move to the next supported public beta
+when it is available.
+
+## Fixed
+
+- Validate the declared release channel together with SemVer and the GitHub
+  prerelease flag before the plugin updater selects an update.
+- Accept supported public beta releases as GitHub Latest, retain preview-only
+  prereleases, and retain stable-only stable releases.
+- Reject missing, malformed, unknown, incompatible, or incomplete release
+  metadata with deterministic updater rejection reasons.
+
+## Compatibility and safety
+
+- WordPress plugin and companion: `1.0.0-beta.11.1`.
+- Plugin mode registers **387** abilities; Direct full exposes **101** tools.
+- WordPress: 6.7 or newer.
+- PHP: 8.1 or newer.
+- Node.js: 20 or newer for the companion.
+- This bridge adds no beta.12 reliability behavior and does not package or
+  publish release artifacts.

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [1.0.0-beta.11.1] - 2026-08-24
+
+### Fixed
+
+- Restore the native updater path for supported public betas published as
+  GitHub Latest, while rejecting incompatible release metadata.
+
 ## [1.0.0-beta.11] - 2026-08-22
 
 ### Added
@@ -226,14 +233,6 @@
 - Align plugin metadata and generated companion package references with the
   final connection-verification release. Plugin abilities and safety gates are
   unchanged.
-
-## [1.0.0-beta.7] - 2026-08-12
-
-### Changed
-
-- Align plugin metadata and generated companion package references with the
-  privacy hardening release. No plugin ability, permission, backup,
-  confirmation, validation, audit, or custom-code gate changed.
 
 ## Older releases
 

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -236,6 +236,7 @@
 
 ## Older releases
 
+- [1.0.0-beta.7](../docs/releases/1.0.0-beta.7.md)
 - [1.0.0-beta.6](../docs/releases/1.0.0-beta.6.md)
 - [1.0.0-beta.5](../docs/releases/1.0.0-beta.5.md)
 - [1.0.0-beta.4](../docs/releases/1.0.0-beta.4.md)

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,6 +1,6 @@
 # Stonewright Plugin
 
-Version: 1.0.0-beta.11
+Version: 1.0.0-beta.11.1
 Requires WordPress: 6.7+
 Requires PHP: 8.1+
 License: [AGPL-3.0-or-later](../LICENSE)

--- a/plugin/includes/Core/GitHubUpdater.php
+++ b/plugin/includes/Core/GitHubUpdater.php
@@ -13,6 +13,7 @@ namespace Stonewright\WpMcp\Core;
 final class GitHubUpdater {
 
 	public const CACHE_KEY = 'stonewright_github_release';
+	public const CACHE_SCHEMA_VERSION = 2;
 	public const CACHE_TTL = 12 * HOUR_IN_SECONDS;
 	public const REPO      = 'cosmincraciun97/stonewright-wp-mcp';
 	public const API_URL   = 'https://api.github.com/repos/cosmincraciun97/stonewright-wp-mcp/releases?per_page=50';
@@ -30,9 +31,7 @@ final class GitHubUpdater {
 	}
 
 	public static function installed_channel( string $version ): string {
-		return 1 === preg_match( '/^\d+\.\d+\.\d+-[0-9A-Za-z.-]+(?:\+[0-9A-Za-z.-]+)?$/', $version )
-			? 'beta'
-			: 'stable';
+		return self::is_prerelease_version( $version ) ? 'beta' : 'stable';
 	}
 
 	public static function installed_version(): string {
@@ -65,7 +64,7 @@ final class GitHubUpdater {
 		}
 
 		$release_channel = $channel_metadata['channel'];
-		$is_prerelease   = str_contains( $version, '-' );
+		$is_prerelease   = self::is_prerelease_version( $version );
 		if (
 			( 'stable' === $release_channel && $is_prerelease ) ||
 			( in_array( $release_channel, [ 'supported', 'preview' ], true ) && ! $is_prerelease )
@@ -226,6 +225,7 @@ final class GitHubUpdater {
 			$cached = get_transient( $cache_key );
 			if (
 				is_array( $cached ) &&
+				self::CACHE_SCHEMA_VERSION === ( $cached['schema_version'] ?? null ) &&
 				$channel === ( $cached['channel'] ?? null ) &&
 				is_array( $cached['release'] ?? null ) &&
 				isset( $cached['release']['version'], $cached['release']['package'], $cached['release']['companion_package'], $cached['release']['url'] )
@@ -234,7 +234,12 @@ final class GitHubUpdater {
 				$release = $cached['release'];
 				return $release;
 			}
-			if ( is_array( $cached ) && $channel === ( $cached['channel'] ?? null ) && true === ( $cached['error'] ?? false ) ) {
+			if (
+				is_array( $cached ) &&
+				self::CACHE_SCHEMA_VERSION === ( $cached['schema_version'] ?? null ) &&
+				$channel === ( $cached['channel'] ?? null ) &&
+				true === ( $cached['error'] ?? false )
+			) {
 				return null;
 			}
 		}
@@ -251,24 +256,24 @@ final class GitHubUpdater {
 		);
 
 		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			set_transient( $cache_key, [ 'channel' => $channel, 'error' => true ], HOUR_IN_SECONDS );
+			set_transient( $cache_key, [ 'schema_version' => self::CACHE_SCHEMA_VERSION, 'channel' => $channel, 'error' => true ], HOUR_IN_SECONDS );
 			return null;
 		}
 
 		$body = wp_remote_retrieve_body( $response );
 		$data = json_decode( $body, true );
 		if ( ! is_array( $data ) ) {
-			set_transient( $cache_key, [ 'channel' => $channel, 'error' => true ], HOUR_IN_SECONDS );
+			set_transient( $cache_key, [ 'schema_version' => self::CACHE_SCHEMA_VERSION, 'channel' => $channel, 'error' => true ], HOUR_IN_SECONDS );
 			return null;
 		}
 
 		$parsed = self::select_release( array_values( $data ), $channel );
 		if ( null === $parsed ) {
-			set_transient( $cache_key, [ 'channel' => $channel, 'error' => true ], HOUR_IN_SECONDS );
+			set_transient( $cache_key, [ 'schema_version' => self::CACHE_SCHEMA_VERSION, 'channel' => $channel, 'error' => true ], HOUR_IN_SECONDS );
 			return null;
 		}
 
-		set_transient( $cache_key, [ 'channel' => $channel, 'release' => $parsed ], self::CACHE_TTL );
+		set_transient( $cache_key, [ 'schema_version' => self::CACHE_SCHEMA_VERSION, 'channel' => $channel, 'release' => $parsed ], self::CACHE_TTL );
 		return $parsed;
 	}
 
@@ -369,5 +374,14 @@ final class GitHubUpdater {
 		$tag     = isset( $release['tag_name'] ) ? (string) $release['tag_name'] : '';
 		$version = ( str_starts_with( $tag, 'v' ) || str_starts_with( $tag, 'V' ) ) ? substr( $tag, 1 ) : $tag;
 		return 1 === preg_match( self::SEMVER_PATTERN, $version ) ? $version : null;
+	}
+
+	private static function is_prerelease_version( string $version ): bool {
+		if ( 1 !== preg_match( self::SEMVER_PATTERN, $version ) ) {
+			return false;
+		}
+
+		$precedence_version = explode( '+', $version, 2 )[0];
+		return str_contains( $precedence_version, '-' );
 	}
 }

--- a/plugin/includes/Core/GitHubUpdater.php
+++ b/plugin/includes/Core/GitHubUpdater.php
@@ -17,6 +17,7 @@ final class GitHubUpdater {
 	public const REPO      = 'cosmincraciun97/stonewright-wp-mcp';
 	public const API_URL   = 'https://api.github.com/repos/cosmincraciun97/stonewright-wp-mcp/releases?per_page=50';
 	public const SLUG      = 'stonewright';
+	private const RELEASE_CHANNELS = [ 'supported', 'preview', 'stable' ];
 
 	public static function register(): void {
 		add_filter( 'site_transient_update_plugins', [ self::class, 'inject_update' ] );
@@ -39,6 +40,54 @@ final class GitHubUpdater {
 	}
 
 	/**
+	 * Return a stable reason code when release metadata is ineligible.
+	 *
+	 * @param array<string, mixed> $release Decoded GitHub release JSON.
+	 */
+	public static function release_rejection_reason( array $release, string $channel ): ?string {
+		if ( ! in_array( $channel, [ 'stable', 'beta' ], true ) ) {
+			return 'invalid_installed_channel';
+		}
+
+		if ( false !== ( $release['draft'] ?? null ) ) {
+			return 'draft_release';
+		}
+
+		$version = self::release_version( $release );
+		if ( null === $version ) {
+			return 'invalid_semantic_version';
+		}
+
+		$channel_metadata = self::release_channel_metadata( $release );
+		if ( null !== $channel_metadata['reason'] ) {
+			return $channel_metadata['reason'];
+		}
+
+		$release_channel = $channel_metadata['channel'];
+		$is_prerelease   = str_contains( $version, '-' );
+		if (
+			( 'stable' === $release_channel && $is_prerelease ) ||
+			( in_array( $release_channel, [ 'supported', 'preview' ], true ) && ! $is_prerelease )
+		) {
+			return 'release_channel_version_incompatible';
+		}
+
+		$expected_prerelease = 'preview' === $release_channel;
+		if ( $expected_prerelease !== ( $release['prerelease'] ?? null ) ) {
+			return 'github_prerelease_incompatible';
+		}
+
+		if (
+			( 'stable' === $channel && 'stable' !== $release_channel ) ||
+			( 'beta' === $channel && ! in_array( $release_channel, [ 'supported', 'preview' ], true ) )
+		) {
+			return 'installed_channel_incompatible';
+		}
+
+		return null === self::parse_release( $release ) ? 'missing_required_assets' : null;
+	}
+
+	/**
 	 * @param array<int, mixed> $releases Decoded GitHub release list.
 	 * @return array{version: string, package: string, companion_package: string, checksums: string, url: string, body?: string, tested?: string, requires?: string, requires_php?: string}|null
 	 */
@@ -49,17 +98,7 @@ final class GitHubUpdater {
 
 		$selected = null;
 		foreach ( $releases as $release ) {
-			if ( ! is_array( $release ) || false !== ( $release['draft'] ?? null ) ) {
-				continue;
-			}
-			$tag     = isset( $release['tag_name'] ) ? (string) $release['tag_name'] : '';
-			$version = ltrim( $tag, 'vV' );
-			$is_beta = 1 === preg_match( '/^\d+\.\d+\.\d+-[0-9A-Za-z.-]+(?:\+[0-9A-Za-z.-]+)?$/', $version );
-			$flag    = $release['prerelease'] ?? null;
-			if (
-				( 'stable' === $channel && ( false !== $flag || $is_beta ) ) ||
-				( 'beta' === $channel && ( true !== $flag || ! $is_beta ) )
-			) {
+			if ( ! is_array( $release ) || null !== self::release_rejection_reason( $release, $channel ) ) {
 				continue;
 			}
 			$parsed = self::parse_release( $release );
@@ -237,13 +276,9 @@ final class GitHubUpdater {
 	 * @return array{version: string, package: string, companion_package: string, checksums: string, url: string, body?: string, tested?: string, requires?: string, requires_php?: string}|null
 	 */
 	public static function parse_release( array $release ): ?array {
-		$tag = isset( $release['tag_name'] ) ? (string) $release['tag_name'] : '';
-		if ( '' === $tag ) {
-			return null;
-		}
-
-		$version = ltrim( $tag, "vV" );
-		if ( 1 !== preg_match( '/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/', $version ) ) {
+		$tag     = isset( $release['tag_name'] ) ? (string) $release['tag_name'] : '';
+		$version = self::release_version( $release );
+		if ( null === $version ) {
 			return null;
 		}
 
@@ -297,5 +332,41 @@ final class GitHubUpdater {
 		}
 
 		return $parsed;
+	}
+
+	/**
+	 * @param array<string, mixed> $release Decoded GitHub release JSON.
+	 * @return array{channel: string, reason: string|null}
+	 */
+	private static function release_channel_metadata( array $release ): array {
+		$body = $release['body'] ?? null;
+		if ( ! is_string( $body ) || '' === trim( $body ) ) {
+			return [ 'channel' => '', 'reason' => 'missing_release_channel' ];
+		}
+
+		preg_match_all( '/^Release channel: `([^`]+)`$/m', $body, $matches );
+		$channels = $matches[1];
+		if ( 0 === count( $channels ) ) {
+			return [ 'channel' => '', 'reason' => str_contains( $body, 'Release channel:' ) ? 'malformed_release_channel' : 'missing_release_channel' ];
+		}
+		if ( 1 !== count( $channels ) ) {
+			return [ 'channel' => '', 'reason' => 'malformed_release_channel' ];
+		}
+
+		$channel = $channels[0];
+		if ( ! in_array( $channel, self::RELEASE_CHANNELS, true ) ) {
+			return [ 'channel' => '', 'reason' => 'unknown_release_channel' ];
+		}
+
+		return [ 'channel' => $channel, 'reason' => null ];
+	}
+
+	/**
+	 * @param array<string, mixed> $release Decoded GitHub release JSON.
+	 */
+	private static function release_version( array $release ): ?string {
+		$tag     = isset( $release['tag_name'] ) ? (string) $release['tag_name'] : '';
+		$version = ltrim( $tag, "vV" );
+		return 1 === preg_match( '/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/', $version ) ? $version : null;
 	}
 }

--- a/plugin/includes/Core/GitHubUpdater.php
+++ b/plugin/includes/Core/GitHubUpdater.php
@@ -18,6 +18,7 @@ final class GitHubUpdater {
 	public const API_URL   = 'https://api.github.com/repos/cosmincraciun97/stonewright-wp-mcp/releases?per_page=50';
 	public const SLUG      = 'stonewright';
 	private const RELEASE_CHANNELS = [ 'supported', 'preview', 'stable' ];
+	private const SEMVER_PATTERN = '/^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:(?:0|[1-9]\d*)|(?:\d*[A-Za-z-][0-9A-Za-z-]*))(?:\.(?:(?:0|[1-9]\d*)|(?:\d*[A-Za-z-][0-9A-Za-z-]*)))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/';
 
 	public static function register(): void {
 		add_filter( 'site_transient_update_plugins', [ self::class, 'inject_update' ] );
@@ -344,16 +345,16 @@ final class GitHubUpdater {
 			return [ 'channel' => '', 'reason' => 'missing_release_channel' ];
 		}
 
-		preg_match_all( '/^Release channel: `([^`]+)`$/m', $body, $matches );
-		$channels = $matches[1];
-		if ( 0 === count( $channels ) ) {
+		preg_match_all( '/^Release channel:.*$/m', $body, $declarations );
+		$declarations = $declarations[0];
+		if ( 0 === count( $declarations ) ) {
 			return [ 'channel' => '', 'reason' => str_contains( $body, 'Release channel:' ) ? 'malformed_release_channel' : 'missing_release_channel' ];
 		}
-		if ( 1 !== count( $channels ) ) {
+		if ( 1 !== count( $declarations ) || 1 !== preg_match( '/^Release channel: `([^`]+)`$/', $declarations[0], $matches ) ) {
 			return [ 'channel' => '', 'reason' => 'malformed_release_channel' ];
 		}
 
-		$channel = $channels[0];
+		$channel = $matches[1];
 		if ( ! in_array( $channel, self::RELEASE_CHANNELS, true ) ) {
 			return [ 'channel' => '', 'reason' => 'unknown_release_channel' ];
 		}
@@ -366,7 +367,7 @@ final class GitHubUpdater {
 	 */
 	private static function release_version( array $release ): ?string {
 		$tag     = isset( $release['tag_name'] ) ? (string) $release['tag_name'] : '';
-		$version = ltrim( $tag, "vV" );
-		return 1 === preg_match( '/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/', $version ) ? $version : null;
+		$version = ( str_starts_with( $tag, 'v' ) || str_starts_with( $tag, 'V' ) ) ? substr( $tag, 1 ) : $tag;
+		return 1 === preg_match( self::SEMVER_PATTERN, $version ) ? $version : null;
 	}
 }

--- a/plugin/stonewright.php
+++ b/plugin/stonewright.php
@@ -3,7 +3,7 @@
  * Plugin Name: Stonewright
  * Plugin URI: https://github.com/cosmincraciun97/stonewright-wp-mcp
  * Description: Guarded WordPress MCP tools for Elementor, Gutenberg/FSE, WooCommerce catalogs, content models, PHP runtime execution, and tokenized WP-CLI.
- * Version: 1.0.0-beta.11
+ * Version: 1.0.0-beta.11.1
  * Requires at least: 6.7
  * Requires PHP: 8.1
  * Author: Stonewright
@@ -33,7 +33,7 @@ if ( defined( 'STONEWRIGHT_FILE' ) ) {
 define( 'STONEWRIGHT_FILE', __FILE__ );
 define( 'STONEWRIGHT_DIR', plugin_dir_path( __FILE__ ) );
 define( 'STONEWRIGHT_URL', plugin_dir_url( __FILE__ ) );
-define( 'STONEWRIGHT_VERSION', '1.0.0-beta.11' );
+define( 'STONEWRIGHT_VERSION', '1.0.0-beta.11.1' );
 define( 'STONEWRIGHT_MIN_PHP', '8.1' );
 define( 'STONEWRIGHT_MIN_WP', '6.7' );
 

--- a/plugin/tests/Unit/Admin/CompanionUpdateStatusTest.php
+++ b/plugin/tests/Unit/Admin/CompanionUpdateStatusTest.php
@@ -16,8 +16,9 @@ final class CompanionUpdateStatusTest extends TestCase {
 		$GLOBALS['stonewright_test_options']    = [];
 		$GLOBALS['stonewright_test_transients'] = [
 			GitHubUpdater::cache_key( 'beta' ) => [
-				'channel' => 'beta',
-				'release' => [
+				'schema_version' => GitHubUpdater::CACHE_SCHEMA_VERSION,
+				'channel'        => 'beta',
+				'release'        => [
 					'version'           => '1.0.0-beta.99',
 					'package'           => 'https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.99/stonewright-1.0.0-beta.99.zip',
 					'companion_package' => 'https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.99/stonewright-companion-1.0.0-beta.99.tgz',

--- a/plugin/tests/Unit/Core/GitHubUpdaterTest.php
+++ b/plugin/tests/Unit/Core/GitHubUpdaterTest.php
@@ -53,6 +53,20 @@ final class GitHubUpdaterTest extends TestCase {
 		self::assertSame( '1.3.0-beta.10', $selected['version'] );
 	}
 
+	public function test_stable_release_with_hyphenated_build_metadata_is_not_treated_as_a_prerelease(): void {
+		$release = $this->release_with_version( $this->releases_fixture()[0], '1.2.3+build-1' );
+
+		self::assertNull( GitHubUpdater::release_rejection_reason( $release, 'stable' ) );
+		self::assertSame( '1.2.3+build-1', GitHubUpdater::select_release( [ $release ], 'stable' )['version'] ?? null );
+
+		$release['body'] = "Release channel: `supported`\n";
+		self::assertSame( 'release_channel_version_incompatible', GitHubUpdater::release_rejection_reason( $release, 'beta' ) );
+
+		$release['body']       = "Release channel: `preview`\n";
+		$release['prerelease'] = true;
+		self::assertSame( 'release_channel_version_incompatible', GitHubUpdater::release_rejection_reason( $release, 'beta' ) );
+	}
+
 	/**
 	 * @dataProvider allowed_release_channel_cases
 	 */
@@ -110,10 +124,48 @@ final class GitHubUpdaterTest extends TestCase {
 		self::assertIsArray( $parsed );
 		self::assertSame( '1.3.0-beta.30', $parsed['version'] );
 		self::assertSame(
-			[ 'channel' => 'beta', 'release' => $parsed ],
+			[ 'schema_version' => GitHubUpdater::CACHE_SCHEMA_VERSION, 'channel' => 'beta', 'release' => $parsed ],
 			get_transient( GitHubUpdater::cache_key( 'beta' ) )
 		);
 		self::assertStringContainsString( '/releases?per_page=', $GLOBALS['stonewright_test_wp_remote_get_calls'][0]['url'] );
+	}
+
+	public function test_legacy_unversioned_release_cache_is_refetched_and_replaced(): void {
+		$legacy = GitHubUpdater::select_release( $this->releases_fixture(), 'beta' );
+		self::assertIsArray( $legacy );
+		set_transient(
+			GitHubUpdater::cache_key( 'beta' ),
+			[ 'channel' => 'beta', 'release' => $legacy ],
+			GitHubUpdater::CACHE_TTL
+		);
+		$GLOBALS['stonewright_test_wp_remote_get'] = fn( string $url ): array => [
+			'response' => [ 'code' => 200 ],
+			'body'     => (string) wp_json_encode( $this->releases_fixture() ),
+		];
+
+		$parsed = GitHubUpdater::fetch_latest_release( false, '1.0.0-beta.1' );
+
+		self::assertIsArray( $parsed );
+		self::assertCount( 1, $GLOBALS['stonewright_test_wp_remote_get_calls'] );
+		self::assertSame(
+			[ 'schema_version' => GitHubUpdater::CACHE_SCHEMA_VERSION, 'channel' => 'beta', 'release' => $parsed ],
+			get_transient( GitHubUpdater::cache_key( 'beta' ) )
+		);
+	}
+
+	public function test_current_release_cache_schema_is_reused_without_a_network_request(): void {
+		$release = GitHubUpdater::select_release( $this->releases_fixture(), 'beta' );
+		self::assertIsArray( $release );
+		set_transient(
+			GitHubUpdater::cache_key( 'beta' ),
+			[ 'schema_version' => GitHubUpdater::CACHE_SCHEMA_VERSION, 'channel' => 'beta', 'release' => $release ],
+			GitHubUpdater::CACHE_TTL
+		);
+
+		$parsed = GitHubUpdater::fetch_latest_release( false, '1.0.0-beta.1' );
+
+		self::assertSame( $release, $parsed );
+		self::assertCount( 0, $GLOBALS['stonewright_test_wp_remote_get_calls'] );
 	}
 
 	public function test_cache_cannot_cross_channels(): void {
@@ -276,9 +328,32 @@ final class GitHubUpdaterTest extends TestCase {
 		self::assertIsArray( $release );
 		set_transient(
 			GitHubUpdater::cache_key( $channel ),
-			[ 'channel' => $channel, 'release' => $release ],
+			[ 'schema_version' => GitHubUpdater::CACHE_SCHEMA_VERSION, 'channel' => $channel, 'release' => $release ],
 			GitHubUpdater::CACHE_TTL
 		);
+	}
+
+	/**
+	 * @param array<string, mixed> $release
+ *
+	 * @return array<string, mixed>
+	 */
+	private function release_with_version( array $release, string $version ): array {
+		$tag                 = 'v' . $version;
+		$release['tag_name'] = $tag;
+		$release['html_url'] = 'https://github.com/' . GitHubUpdater::REPO . '/releases/tag/' . rawurlencode( $tag );
+		$release['assets']   = [
+			[
+				'name'                 => 'stonewright-' . $version . '.zip',
+				'browser_download_url' => 'https://github.com/' . GitHubUpdater::REPO . '/releases/download/' . rawurlencode( $tag ) . '/' . rawurlencode( 'stonewright-' . $version . '.zip' ),
+			],
+			[
+				'name'                 => 'stonewright-companion-' . $version . '.tgz',
+				'browser_download_url' => 'https://github.com/' . GitHubUpdater::REPO . '/releases/download/' . rawurlencode( $tag ) . '/' . rawurlencode( 'stonewright-companion-' . $version . '.tgz' ),
+			],
+		];
+
+		return $release;
 	}
 
 	/** @return array<int, array<string, mixed>> */

--- a/plugin/tests/Unit/Core/GitHubUpdaterTest.php
+++ b/plugin/tests/Unit/Core/GitHubUpdaterTest.php
@@ -247,6 +247,24 @@ final class GitHubUpdaterTest extends TestCase {
 		$missing_assets = $releases[2];
 		array_pop( $missing_assets['assets'] );
 		yield 'missing required package assets' => [ $missing_assets, 'beta', 'missing_required_assets' ];
+
+		foreach ( [ 'v1.3.0-beta..30', 'v01.0.0', 'v1.0.0-beta.01', 'vv1.3.0-beta.30' ] as $tag ) {
+			$malformed_semver             = $releases[2];
+			$malformed_semver['tag_name'] = $tag;
+			yield 'malformed semantic version ' . $tag => [ $malformed_semver, 'beta', 'invalid_semantic_version' ];
+		}
+
+		$duplicate_declaration = $releases[2];
+		$duplicate_declaration['body'] = "Release channel: `preview`\nRelease channel: `preview`\n";
+		yield 'duplicate release channel declaration' => [ $duplicate_declaration, 'beta', 'malformed_release_channel' ];
+
+		$mixed_declarations = $releases[2];
+		$mixed_declarations['body'] = "Release channel: `preview`\nRelease channel: `supported`\n";
+		yield 'mixed release channel declarations' => [ $mixed_declarations, 'beta', 'malformed_release_channel' ];
+
+		$valid_then_malformed = $releases[2];
+		$valid_then_malformed['body'] = "Release channel: `preview`\nRelease channel: preview\n";
+		yield 'valid declaration followed by malformed declaration' => [ $valid_then_malformed, 'beta', 'malformed_release_channel' ];
 	}
 
 	private function set_installed_version( string $version ): void {

--- a/plugin/tests/Unit/Core/GitHubUpdaterTest.php
+++ b/plugin/tests/Unit/Core/GitHubUpdaterTest.php
@@ -39,14 +39,44 @@ final class GitHubUpdaterTest extends TestCase {
 		self::assertIsArray( $stable );
 		self::assertSame( '1.2.0', $stable['version'] );
 		self::assertIsArray( $beta );
-		self::assertSame( '1.3.0-beta.10', $beta['version'] );
+		self::assertSame( '1.3.0-beta.30', $beta['version'] );
+	}
+
+	public function test_select_release_accepts_supported_beta_published_as_latest(): void {
+		$release               = $this->releases_fixture()[2];
+		$release['prerelease'] = false;
+		$release['body']       = "Release channel: `supported`\n";
+
+		$selected = GitHubUpdater::select_release( [ $release ], 'beta' );
+
+		self::assertIsArray( $selected );
+		self::assertSame( '1.3.0-beta.10', $selected['version'] );
+	}
+
+	/**
+	 * @dataProvider allowed_release_channel_cases
+	 */
+	public function test_select_release_accepts_only_allowed_release_channel_combinations( string $channel, int $fixture_index, string $expected_version ): void {
+		$selected = GitHubUpdater::select_release( [ $this->releases_fixture()[ $fixture_index ] ], $channel );
+
+		self::assertIsArray( $selected );
+		self::assertSame( $expected_version, $selected['version'] );
+	}
+
+	/**
+	 * @dataProvider rejected_release_channel_cases
+	 */
+	public function test_select_release_rejects_invalid_release_metadata_with_a_deterministic_reason( array $release, string $channel, string $reason ): void {
+		self::assertNull( GitHubUpdater::select_release( [ $release ], $channel ) );
+		self::assertSame( $reason, GitHubUpdater::release_rejection_reason( $release, $channel ) );
 	}
 
 	public function test_select_release_rejects_malformed_incomplete_and_cross_channel_candidates(): void {
 		$releases = $this->releases_fixture();
 		self::assertNull( GitHubUpdater::select_release( [ $releases[4] ], 'stable' ) );
 		self::assertNull( GitHubUpdater::select_release( [ $releases[5] ], 'beta' ) );
-		self::assertNull( GitHubUpdater::select_release( [ $releases[6] ], 'beta' ) );
+		$releases[2]['prerelease'] = false;
+		self::assertNull( GitHubUpdater::select_release( [ $releases[2] ], 'beta' ) );
 		self::assertNull( GitHubUpdater::select_release( [ $releases[0] ], 'beta' ) );
 		self::assertNull( GitHubUpdater::select_release( [ $releases[1] ], 'stable' ) );
 	}
@@ -78,7 +108,7 @@ final class GitHubUpdaterTest extends TestCase {
 
 		$parsed = GitHubUpdater::fetch_latest_release( false, '1.0.0-beta.1' );
 		self::assertIsArray( $parsed );
-		self::assertSame( '1.3.0-beta.10', $parsed['version'] );
+		self::assertSame( '1.3.0-beta.30', $parsed['version'] );
 		self::assertSame(
 			[ 'channel' => 'beta', 'release' => $parsed ],
 			get_transient( GitHubUpdater::cache_key( 'beta' ) )
@@ -125,7 +155,7 @@ final class GitHubUpdaterTest extends TestCase {
 		];
 
 		$parsed = GitHubUpdater::fetch_latest_release( true, '1.0.0-beta.1' );
-		self::assertSame( '1.3.0-beta.10', $parsed['version'] );
+		self::assertSame( '1.3.0-beta.30', $parsed['version'] );
 	}
 
 	public function test_inject_update_follows_beta_installed_channel(): void {
@@ -133,7 +163,22 @@ final class GitHubUpdaterTest extends TestCase {
 		$this->cache_release( 'beta' );
 		$result = GitHubUpdater::inject_update( (object) [ 'response' => [], 'no_update' => [] ] );
 		$plugin = GitHubUpdater::plugin_basename();
-		self::assertSame( '1.3.0-beta.10', $result->response[ $plugin ]->new_version );
+		self::assertSame( '1.3.0-beta.30', $result->response[ $plugin ]->new_version );
+	}
+
+	public function test_inject_update_adds_supported_beta_latest_release_to_the_wordpress_update_transient(): void {
+		$this->set_installed_version( '1.0.0-beta.1' );
+		$supported_beta = $this->releases_fixture()[6];
+		$GLOBALS['stonewright_test_wp_remote_get'] = static fn( string $url ): array => [
+			'response' => [ 'code' => 200 ],
+			'body'     => (string) wp_json_encode( [ $supported_beta ] ),
+		];
+
+		$result = GitHubUpdater::inject_update( (object) [ 'response' => [], 'no_update' => [] ] );
+		$plugin = GitHubUpdater::plugin_basename();
+
+		self::assertSame( '1.3.0-beta.30', $result->response[ $plugin ]->new_version );
+		self::assertStringEndsWith( '/stonewright-1.3.0-beta.30.zip', $result->response[ $plugin ]->package );
 	}
 
 	public function test_inject_update_follows_stable_installed_channel(): void {
@@ -153,6 +198,55 @@ final class GitHubUpdaterTest extends TestCase {
 	public function test_register_hooks_update_plugins_filter(): void {
 		GitHubUpdater::register();
 		self::assertArrayHasKey( 'site_transient_update_plugins', $GLOBALS['stonewright_test_filters'] );
+	}
+
+	/** @return iterable<string, array{string, int, string}> */
+	public static function allowed_release_channel_cases(): iterable {
+		yield 'supported beta published as latest' => [ 'beta', 6, '1.3.0-beta.30' ];
+		yield 'preview prerelease' => [ 'beta', 2, '1.3.0-beta.10' ];
+		yield 'stable release' => [ 'stable', 0, '1.2.0' ];
+	}
+
+	/** @return iterable<string, array{array<string, mixed>, string, string}> */
+	public function rejected_release_channel_cases(): iterable {
+		$releases = $this->releases_fixture();
+
+		$missing_declaration = $releases[2];
+		unset( $missing_declaration['body'] );
+		yield 'missing declaration' => [ $missing_declaration, 'beta', 'missing_release_channel' ];
+
+		$unknown_declaration = $releases[2];
+		$unknown_declaration['body'] = "Release channel: `other`\n";
+		yield 'unknown declaration' => [ $unknown_declaration, 'beta', 'unknown_release_channel' ];
+
+		$supported_prerelease = $releases[6];
+		$supported_prerelease['prerelease'] = true;
+		yield 'supported channel marked as GitHub prerelease' => [ $supported_prerelease, 'beta', 'github_prerelease_incompatible' ];
+
+		$preview_latest = $releases[2];
+		$preview_latest['prerelease'] = false;
+		yield 'preview channel marked as GitHub latest' => [ $preview_latest, 'beta', 'github_prerelease_incompatible' ];
+
+		$stable_prerelease_version = $releases[2];
+		$stable_prerelease_version['body'] = "Release channel: `stable`\n";
+		$stable_prerelease_version['prerelease'] = false;
+		yield 'stable channel with prerelease semantic version' => [ $stable_prerelease_version, 'stable', 'release_channel_version_incompatible' ];
+
+		$beta_stable_version = $releases[0];
+		$beta_stable_version['body'] = "Release channel: `supported`\n";
+		yield 'supported channel with stable semantic version' => [ $beta_stable_version, 'beta', 'release_channel_version_incompatible' ];
+
+		$preview_stable_version = $releases[0];
+		$preview_stable_version['body'] = "Release channel: `preview`\n";
+		yield 'preview channel with stable semantic version' => [ $preview_stable_version, 'beta', 'release_channel_version_incompatible' ];
+
+		$malformed_body = $releases[2];
+		$malformed_body['body'] = "Release channel: preview\n";
+		yield 'malformed release body' => [ $malformed_body, 'beta', 'malformed_release_channel' ];
+
+		$missing_assets = $releases[2];
+		array_pop( $missing_assets['assets'] );
+		yield 'missing required package assets' => [ $missing_assets, 'beta', 'missing_required_assets' ];
 	}
 
 	private function set_installed_version( string $version ): void {

--- a/plugin/tests/Unit/Support/ReleaseRetentionTest.php
+++ b/plugin/tests/Unit/Support/ReleaseRetentionTest.php
@@ -23,8 +23,10 @@ final class ReleaseRetentionTest extends TestCase {
 	}
 
 	public function test_root_changelog_keeps_latest_five_releases_and_links_older_history(): void {
-		$path = dirname( __DIR__, 4 ) . '/CHANGELOG.md';
-		$raw  = (string) file_get_contents( $path );
+		$root_path   = dirname( __DIR__, 4 ) . '/CHANGELOG.md';
+		$plugin_path = dirname( __DIR__, 3 ) . '/CHANGELOG.md';
+		$raw         = (string) file_get_contents( $root_path );
+		$plugin_raw  = (string) file_get_contents( $plugin_path );
 		preg_match_all( '/^## \\[([^\\]]+)\\]/m', $raw, $m );
 		$headers = $m[1] ?? [];
 		$versions = array_values(
@@ -36,6 +38,10 @@ final class ReleaseRetentionTest extends TestCase {
 		self::assertContains( 'Unreleased', $headers );
 		self::assertSame( [ '1.0.0-beta.11.1', '1.0.0-beta.11', '1.0.0-beta.10', '1.0.0-beta.9', '1.0.0-beta.8' ], $versions );
 		self::assertStringContainsString( '## Older releases', $raw );
-		self::assertStringContainsString( 'docs/releases/1.0.0-beta.1.md', $raw );
+		self::assertStringContainsString( '## Older releases', $plugin_raw );
+		foreach ( range( 1, 7 ) as $release_number ) {
+			self::assertStringContainsString( 'docs/releases/1.0.0-beta.' . $release_number . '.md', $raw );
+			self::assertStringContainsString( '../docs/releases/1.0.0-beta.' . $release_number . '.md', $plugin_raw );
+		}
 	}
 }

--- a/plugin/tests/Unit/Support/ReleaseRetentionTest.php
+++ b/plugin/tests/Unit/Support/ReleaseRetentionTest.php
@@ -19,7 +19,7 @@ final class ReleaseRetentionTest extends TestCase {
 				$versioned[] = $name;
 			}
 		}
-		self::assertSame( [ '1.0.0-beta.1.md', '1.0.0-beta.10.md', '1.0.0-beta.11.md', '1.0.0-beta.2.md', '1.0.0-beta.3.md', '1.0.0-beta.4.md', '1.0.0-beta.5.md', '1.0.0-beta.6.md', '1.0.0-beta.7.md', '1.0.0-beta.8.md', '1.0.0-beta.9.md' ], $versioned );
+		self::assertSame( [ '1.0.0-beta.1.md', '1.0.0-beta.10.md', '1.0.0-beta.11.1.md', '1.0.0-beta.11.md', '1.0.0-beta.2.md', '1.0.0-beta.3.md', '1.0.0-beta.4.md', '1.0.0-beta.5.md', '1.0.0-beta.6.md', '1.0.0-beta.7.md', '1.0.0-beta.8.md', '1.0.0-beta.9.md' ], $versioned );
 	}
 
 	public function test_root_changelog_keeps_latest_five_releases_and_links_older_history(): void {
@@ -34,7 +34,7 @@ final class ReleaseRetentionTest extends TestCase {
 			)
 		);
 		self::assertContains( 'Unreleased', $headers );
-		self::assertSame( [ '1.0.0-beta.11', '1.0.0-beta.10', '1.0.0-beta.9', '1.0.0-beta.8', '1.0.0-beta.7' ], $versions );
+		self::assertSame( [ '1.0.0-beta.11.1', '1.0.0-beta.11', '1.0.0-beta.10', '1.0.0-beta.9', '1.0.0-beta.8' ], $versions );
 		self::assertStringContainsString( '## Older releases', $raw );
 		self::assertStringContainsString( 'docs/releases/1.0.0-beta.1.md', $raw );
 	}

--- a/plugin/tests/fixtures/github/releases-list.json
+++ b/plugin/tests/fixtures/github/releases-list.json
@@ -3,6 +3,7 @@
     "tag_name": "v1.2.0",
     "draft": false,
     "prerelease": false,
+    "body": "Release channel: `stable`\n",
     "html_url": "https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/tag/v1.2.0",
     "assets": [
       { "name": "stonewright-1.2.0.zip", "browser_download_url": "https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.2.0/stonewright-1.2.0.zip" },
@@ -13,6 +14,7 @@
     "tag_name": "v1.3.0-beta.2",
     "draft": false,
     "prerelease": true,
+    "body": "Release channel: `preview`\n",
     "html_url": "https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/tag/v1.3.0-beta.2",
     "assets": [
       { "name": "stonewright-1.3.0-beta.2.zip", "browser_download_url": "https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.3.0-beta.2/stonewright-1.3.0-beta.2.zip" },
@@ -23,6 +25,7 @@
     "tag_name": "v1.3.0-beta.10",
     "draft": false,
     "prerelease": true,
+    "body": "Release channel: `preview`\n",
     "html_url": "https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/tag/v1.3.0-beta.10",
     "assets": [
       { "name": "stonewright-1.3.0-beta.10.zip", "browser_download_url": "https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.3.0-beta.10/stonewright-1.3.0-beta.10.zip" },
@@ -47,6 +50,7 @@
     "tag_name": "v1.3.0-beta.20",
     "draft": false,
     "prerelease": true,
+    "body": "Release channel: `preview`\n",
     "html_url": "https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/tag/v1.3.0-beta.20",
     "assets": [
       { "name": "stonewright-1.3.0-beta.20.zip", "browser_download_url": "https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.3.0-beta.20/stonewright-1.3.0-beta.20.zip" }
@@ -56,6 +60,7 @@
     "tag_name": "v1.3.0-beta.30",
     "draft": false,
     "prerelease": false,
+    "body": "Release channel: `supported`\n",
     "html_url": "https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/tag/v1.3.0-beta.30",
     "assets": [
       { "name": "stonewright-1.3.0-beta.30.zip", "browser_download_url": "https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.3.0-beta.30/stonewright-1.3.0-beta.30.zip" },

--- a/scripts/release-flags.mjs
+++ b/scripts/release-flags.mjs
@@ -4,11 +4,16 @@ import process from 'node:process';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
-const semver = /^\d+\.\d+\.\d+(?:-([0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*))?(?:\+[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?$/;
+const numericIdentifier = '(?:0|[1-9]\\d*)';
+const prereleaseIdentifier = `(?:${numericIdentifier}|(?:\\d*[A-Za-z-][0-9A-Za-z-]*))`;
+const semver = new RegExp(
+	`^${numericIdentifier}\\.${numericIdentifier}\\.${numericIdentifier}(?:-(${prereleaseIdentifier}(?:\\.${prereleaseIdentifier})*))?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$`,
+);
 const channels = new Set(['supported', 'preview', 'stable']);
 
 export function releaseChannelFromNotes(notes) {
-	const match = /^Release channel: `([^`]+)`$/m.exec(notes);
+	const declarations = notes.match(/^Release channel:.*$/gm) ?? [];
+	const match = declarations.length === 1 ? /^Release channel: `([^`]+)`$/.exec(declarations[0]) : null;
 	if (!match || !channels.has(match[1])) {
 		throw new Error('Release notes require one valid release channel: supported, preview, or stable.');
 	}

--- a/scripts/tests/release-flags.test.mjs
+++ b/scripts/tests/release-flags.test.mjs
@@ -20,6 +20,7 @@ test('supported public betas are latest releases', () => {
 
 test('preview beta and rc versions are prereleases', () => {
 	assert.deepEqual(releaseFlags('1.0.0-beta.11', 'preview'), ['--prerelease']);
+	assert.deepEqual(releaseFlags('1.0.0-beta.11.1', 'preview'), ['--prerelease']);
 	assert.deepEqual(releaseFlags('1.0.0-rc.1', 'preview'), ['--prerelease']);
 });
 

--- a/scripts/tests/release-flags.test.mjs
+++ b/scripts/tests/release-flags.test.mjs
@@ -32,6 +32,9 @@ test('release notes declare one recognized channel', () => {
 	assert.equal(releaseChannelFromNotes('Release channel: `supported`\n'), 'supported');
 	assert.throws(() => releaseChannelFromNotes('# Missing'), /release channel/i);
 	assert.throws(() => releaseChannelFromNotes('Release channel: `other`'), /release channel/i);
+	assert.throws(() => releaseChannelFromNotes('Release channel: `supported`\nRelease channel: `supported`\n'), /release channel/i);
+	assert.throws(() => releaseChannelFromNotes('Release channel: `supported`\nRelease channel: `preview`\n'), /release channel/i);
+	assert.throws(() => releaseChannelFromNotes('Release channel: `supported`\nRelease channel: supported\n'), /release channel/i);
 });
 
 test('missing and incompatible release channels fail closed', () => {
@@ -45,6 +48,10 @@ test('malformed versions fail closed', () => {
 	assert.throws(() => releaseFlags('v1.0.0', 'stable'), /semantic version/i);
 	assert.throws(() => releaseFlags('latest', 'stable'), /semantic version/i);
 	assert.throws(() => releaseFlags('1.0', 'stable'), /semantic version/i);
+	assert.throws(() => releaseFlags('1.3.0-beta..30', 'preview'), /semantic version/i);
+	assert.throws(() => releaseFlags('01.0.0', 'stable'), /semantic version/i);
+	assert.throws(() => releaseFlags('1.0.0-beta.01', 'preview'), /semantic version/i);
+	assert.throws(() => releaseFlags('vv1.3.0-beta.30', 'preview'), /semantic version/i);
 });
 
 test('plugin release archive carries the canonical license', () => {


### PR DESCRIPTION
## Summary

- accept supported public beta releases marked Latest through strict SemVer + release-channel policy
- publish aligned 1.0.0-beta.11.1 preview bridge for installations using legacy prerelease-only updater
- version updater caches so legacy metadata cannot bypass new fail-closed validator
- keep plugin, companion, release notes, changelogs, and release metadata aligned

## Abilities and safety gates

- Changed abilities: none
- Backup gate: unchanged
- Confirmation-token gate: unchanged
- Permission gate: unchanged
- Validation gate: unchanged
- Audit gate: unchanged

## Verification

- plugin: 7,745 tests / 42,423 assertions
- PHPStan: no errors
- PHPCS: 842 files passed
- security audit: passed
- dependency audit: no vulnerability advisories; existing abandoned wordpress/abilities-api package remains
- provenance: 42 imported files verified
- companion: 64 files / 536 tests; typecheck and build passed
- Visual: 8 files / 80 tests; typecheck and build passed
- release policy: 9/9
- docs freshness, license metadata, diff check: passed
- clean release artifacts built and inspected locally; runtime vendor and Visual bundle present; dev/private state absent

## Public docs changed

- root/plugin/companion changelogs
- plugin README
- versioned release notes for 1.0.0-beta.11.1

Release channel: preview prerelease. No tag or release publication occurs until every PR check is green.