### PR TITLE
Safe formatted WordPress View details release notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,15 @@ override default behavior.
    explicitly asks the agent to perform that approval step. Pluginless Direct
    mode may inspect custom CSS but must not write it because it has no
    authenticated wp-admin grant boundary.
+9. **GitHub release notes are untrusted Markdown.** Every updater or release
+   implementation must:
+   1. treat GitHub release bodies as untrusted Markdown input;
+   2. keep release-channel parsing on the original raw body;
+   3. render only the supported Markdown subset for WordPress View details;
+   4. sanitize that HTML with an explicit `wp_kses` allowlist and an
+      HTTPS-only link policy;
+   5. add security and formatting regression coverage whenever the
+      release-note format changes.
 
 ## Third-party source reuse
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ development builds were never stable releases.
 
 ### Changed
 
+- Show formatted, sanitized GitHub release notes in the WordPress Plugins
+  View details modal.
 - Keep audit history until an operator configures scheduled retention, and
   coalesce routine heartbeat and successful authentication activity.
 

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -43,6 +43,10 @@ variant cannot bypass that binding. Non-Stonewright plugin downloads, including
 wordpress.org packages, are left unchanged; the gate fail-closes only for
 official Stonewright ZIPs or the Stonewright plugin basename.
 
+Plugins → Stonewright → **View details** shows the GitHub release notes as
+readable WordPress HTML. Raw HTML in a release body is treated as text, and
+only HTTPS links are clickable.
+
 An update runs schema migrations in place. It does not delete or reset existing
 memory, user-created skills, audit history, content, Elementor data, store data,
 or Stonewright settings.

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Changed
 
+- Show formatted, sanitized GitHub release notes in the WordPress Plugins
+  View details modal.
 - Disable automatic audit retention by default and run deletion only through
   an explicitly configured daily policy.
 - Coalesce successful authentication polling and omit finalizer heartbeats from

--- a/plugin/includes/Core/GitHubUpdater.php
+++ b/plugin/includes/Core/GitHubUpdater.php
@@ -408,7 +408,9 @@ final class GitHubUpdater {
 			'tested'         => $remote['tested'] ?? '',
 			'download_link'  => $remote['package'],
 			'sections'       => [
-				'description' => $remote['body'] ?? __( 'AI builder tools for WordPress MCP.', 'stonewright' ),
+				'description' => ReleaseNotesRenderer::render(
+					isset( $remote['body'] ) && is_string( $remote['body'] ) ? $remote['body'] : ''
+				),
 			],
 		];
 	}

--- a/plugin/includes/Core/ReleaseNotesRenderer.php
+++ b/plugin/includes/Core/ReleaseNotesRenderer.php
@@ -1,0 +1,232 @@
+<?php
+declare( strict_types=1 );
+
+namespace Stonewright\WpMcp\Core;
+
+/**
+ * Deterministic Markdown subset renderer for WordPress View details.
+ *
+ * GitHub release bodies are untrusted. Escape raw HTML before interpretation,
+ * then sanitize the generated markup with an explicit wp_kses allowlist.
+ */
+final class ReleaseNotesRenderer {
+
+	private const MAX_BYTES = 65536;
+	private const CODE_PLACEHOLDER_PREFIX = "\x1eCODE";
+	private const CODE_PLACEHOLDER_SUFFIX = "\x1e";
+
+	/**
+	 * @var array<string, array<string, bool>>
+	 */
+	private const ALLOWED_HTML = [
+		'h1'     => [],
+		'h2'     => [],
+		'h3'     => [],
+		'h4'     => [],
+		'p'      => [],
+		'ul'     => [],
+		'ol'     => [],
+		'li'     => [],
+		'pre'    => [],
+		'code'   => [],
+		'strong' => [],
+		'em'     => [],
+		'a'      => [
+			'href' => true,
+			'rel'  => true,
+		],
+	];
+
+	public static function render( string $markdown ): string {
+		if ( '' === trim( $markdown ) ) {
+			return self::sanitize( self::fallback_html() );
+		}
+
+		if ( strlen( $markdown ) > self::MAX_BYTES ) {
+			$markdown = substr( $markdown, 0, self::MAX_BYTES );
+		}
+
+		$markdown = str_replace( [ "\r\n", "\r" ], "\n", $markdown );
+		$escaped  = htmlspecialchars( $markdown, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' );
+		$html     = self::parse_blocks( $escaped );
+
+		return self::sanitize( '' === trim( $html ) ? self::fallback_html() : $html );
+	}
+
+	private static function fallback_text(): string {
+		return __( 'Release notes are not available for this version.', 'stonewright' );
+	}
+
+	private static function fallback_html(): string {
+		return '<p>' . esc_html( self::fallback_text() ) . '</p>';
+	}
+
+	private static function sanitize( string $html ): string {
+		return wp_kses( $html, self::ALLOWED_HTML, [ 'https' ] );
+	}
+
+	private static function parse_blocks( string $text ): string {
+		$lines  = explode( "\n", $text );
+		$html   = '';
+		$n      = count( $lines );
+		$i      = 0;
+
+		while ( $i < $n ) {
+			$line = $lines[ $i ];
+			if ( '' === trim( $line ) ) {
+				++$i;
+				continue;
+			}
+
+			if ( str_starts_with( $line, '```' ) ) {
+				$code_lines = [];
+				++$i;
+				while ( $i < $n && ! str_starts_with( $lines[ $i ], '```' ) ) {
+					$code_lines[] = $lines[ $i ];
+					++$i;
+				}
+				if ( $i < $n ) {
+					++$i;
+				}
+				$html .= '<pre><code>' . implode( "\n", $code_lines ) . '</code></pre>';
+				continue;
+			}
+
+			if ( 1 === preg_match( '/^(#{1,4})[ \t]+(.+)$/', $line, $heading ) ) {
+				$level = (string) strlen( $heading[1] );
+				$html .= '<h' . $level . '>' . self::inline( rtrim( $heading[2], " \t#" ) ) . '</h' . $level . '>';
+				++$i;
+				continue;
+			}
+
+			if ( 1 === preg_match( '/^[-*+][ \t]+/', $line ) ) {
+				$items = [];
+				while ( $i < $n && 1 === preg_match( '/^[-*+][ \t]+(.*)$/', $lines[ $i ], $item ) ) {
+					$items[] = '<li>' . self::inline( $item[1] ) . '</li>';
+					++$i;
+				}
+				$html .= '<ul>' . implode( '', $items ) . '</ul>';
+				continue;
+			}
+
+			if ( 1 === preg_match( '/^\d{1,9}\.[ \t]+/', $line ) ) {
+				$items = [];
+				while ( $i < $n && 1 === preg_match( '/^\d{1,9}\.[ \t]+(.*)$/', $lines[ $i ], $item ) ) {
+					$items[] = '<li>' . self::inline( $item[1] ) . '</li>';
+					++$i;
+				}
+				$html .= '<ol>' . implode( '', $items ) . '</ol>';
+				continue;
+			}
+
+			$paragraph = [];
+			while ( $i < $n && '' !== trim( $lines[ $i ] ) && ! self::is_block_start( $lines[ $i ] ) ) {
+				$paragraph[] = $lines[ $i ];
+				++$i;
+			}
+			$html .= '<p>' . self::inline( implode( ' ', $paragraph ) ) . '</p>';
+		}
+
+		return $html;
+	}
+
+	private static function is_block_start( string $line ): bool {
+		return str_starts_with( $line, '```' )
+			|| 1 === preg_match( '/^(#{1,4}[ \t]|[-*+][ \t]|\d{1,9}\.[ \t])/', $line );
+	}
+
+	private static function inline( string $text, bool $allow_links = true ): string {
+		$codes = [];
+		$text  = preg_replace_callback(
+			'/`([^`]+)`/',
+			static function ( array $matches ) use ( &$codes ): string {
+				$token           = self::CODE_PLACEHOLDER_PREFIX . (string) count( $codes ) . self::CODE_PLACEHOLDER_SUFFIX;
+				$codes[ $token ] = '<code>' . $matches[1] . '</code>';
+				return $token;
+			},
+			$text
+		) ?? $text;
+
+		if ( $allow_links ) {
+			$text = preg_replace_callback(
+				'/\[([^\]]+)\]\(([^)]+)\)/',
+				static function ( array $matches ): string {
+					$label = self::inline( $matches[1], false );
+					$url   = self::safe_https_url( $matches[2] );
+					if ( null === $url ) {
+						return $label;
+					}
+					$href = esc_url( $url, [ 'https' ] );
+					if ( '' === $href ) {
+						return $label;
+					}
+					return '<a href="' . esc_attr( $href ) . '" rel="noopener noreferrer">' . $label . '</a>';
+				},
+				$text
+			) ?? $text;
+		}
+
+		$text = preg_replace_callback(
+			'/\*\*(.+?)\*\*/',
+			static fn( array $matches ): string => '<strong>' . $matches[1] . '</strong>',
+			$text
+		) ?? $text;
+		$text = preg_replace_callback(
+			'/__(.+?)__/',
+			static fn( array $matches ): string => '<strong>' . $matches[1] . '</strong>',
+			$text
+		) ?? $text;
+		$text = preg_replace_callback(
+			'/\*(.+?)\*/',
+			static fn( array $matches ): string => '<em>' . $matches[1] . '</em>',
+			$text
+		) ?? $text;
+		$text = preg_replace_callback(
+			'/(?<![A-Za-z0-9])_([^_]+)_(?![A-Za-z0-9])/',
+			static fn( array $matches ): string => '<em>' . $matches[1] . '</em>',
+			$text
+		) ?? $text;
+
+		return strtr( $text, $codes );
+	}
+
+	private static function safe_https_url( string $raw ): ?string {
+		$url = $raw;
+		for ( $i = 0; $i < 5; $i++ ) {
+			$decoded = html_entity_decode( $url, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+			if ( $decoded === $url ) {
+				break;
+			}
+			$url = $decoded;
+		}
+
+		$url = trim( $url );
+		if ( '' === $url || 1 === preg_match( '/[\s\x00-\x1f\x7f]/', $url ) ) {
+			return null;
+		}
+		if ( str_starts_with( $url, '//' ) || false !== strpbrk( $url, "<>\"'" ) ) {
+			return null;
+		}
+
+		$parts = parse_url( $url );
+		if ( ! is_array( $parts ) ) {
+			return null;
+		}
+
+		$scheme = strtolower( (string) ( $parts['scheme'] ?? '' ) );
+		if ( 'https' !== $scheme ) {
+			return null;
+		}
+		if ( isset( $parts['user'] ) || isset( $parts['pass'] ) ) {
+			return null;
+		}
+		if ( '' === (string) ( $parts['host'] ?? '' ) ) {
+			return null;
+		}
+		if ( false === filter_var( $url, FILTER_VALIDATE_URL ) ) {
+			return null;
+		}
+
+		return $url;
+	}
+}

--- a/plugin/includes/Core/ReleaseNotesRenderer.php
+++ b/plugin/includes/Core/ReleaseNotesRenderer.php
@@ -13,7 +13,8 @@ final class ReleaseNotesRenderer {
 
 	private const MAX_BYTES = 65536;
 	private const CODE_PLACEHOLDER_PREFIX = "\x1eCODE";
-	private const CODE_PLACEHOLDER_SUFFIX = "\x1e";
+	private const TAG_PLACEHOLDER_PREFIX  = "\x1eTAG";
+	private const PLACEHOLDER_SUFFIX      = "\x1e";
 
 	/**
 	 * @var array<string, array<string, bool>>
@@ -140,7 +141,7 @@ final class ReleaseNotesRenderer {
 		$text  = preg_replace_callback(
 			'/`([^`]+)`/',
 			static function ( array $matches ) use ( &$codes ): string {
-				$token           = self::CODE_PLACEHOLDER_PREFIX . (string) count( $codes ) . self::CODE_PLACEHOLDER_SUFFIX;
+				$token           = self::CODE_PLACEHOLDER_PREFIX . (string) count( $codes ) . self::PLACEHOLDER_SUFFIX;
 				$codes[ $token ] = '<code>' . $matches[1] . '</code>';
 				return $token;
 			},
@@ -166,6 +167,17 @@ final class ReleaseNotesRenderer {
 			) ?? $text;
 		}
 
+		$tags = [];
+		$text = preg_replace_callback(
+			'/<[^>]+>/',
+			static function ( array $matches ) use ( &$tags ): string {
+				$token          = self::TAG_PLACEHOLDER_PREFIX . (string) count( $tags ) . self::PLACEHOLDER_SUFFIX;
+				$tags[ $token ] = $matches[0];
+				return $token;
+			},
+			$text
+		) ?? $text;
+
 		$text = preg_replace_callback(
 			'/\*\*(.+?)\*\*/',
 			static fn( array $matches ): string => '<strong>' . $matches[1] . '</strong>',
@@ -187,7 +199,7 @@ final class ReleaseNotesRenderer {
 			$text
 		) ?? $text;
 
-		return strtr( $text, $codes );
+		return strtr( $text, $codes + $tags );
 	}
 
 	private static function safe_https_url( string $raw ): ?string {

--- a/plugin/tests/Unit/Core/GitHubUpdaterTest.php
+++ b/plugin/tests/Unit/Core/GitHubUpdaterTest.php
@@ -12,19 +12,23 @@ use Stonewright\WpMcp\Core\GitHubUpdater;
 final class GitHubUpdaterTest extends TestCase {
 
 	protected function setUp(): void {
-		$GLOBALS['stonewright_test_transients']          = [];
-		$GLOBALS['stonewright_test_filters']             = [];
-		$GLOBALS['stonewright_test_wp_remote_get']       = null;
-		$GLOBALS['stonewright_test_wp_remote_get_calls'] = [];
-		$GLOBALS['stonewright_test_download_url']        = null;
+		$GLOBALS['stonewright_test_transients']           = [];
+		$GLOBALS['stonewright_test_filters']              = [];
+		$GLOBALS['stonewright_test_wp_remote_get']        = null;
+		$GLOBALS['stonewright_test_wp_remote_get_calls']  = [];
+		$GLOBALS['stonewright_test_download_url']         = null;
+		$GLOBALS['stonewright_test_wp_kses_calls']        = [];
+		$GLOBALS['stonewright_test_wp_kses_post_calls']   = [];
 	}
 
 	protected function tearDown(): void {
-		$GLOBALS['stonewright_test_transients']          = [];
-		$GLOBALS['stonewright_test_filters']             = [];
-		$GLOBALS['stonewright_test_wp_remote_get']       = null;
-		$GLOBALS['stonewright_test_wp_remote_get_calls'] = [];
-		$GLOBALS['stonewright_test_download_url']        = null;
+		$GLOBALS['stonewright_test_transients']           = [];
+		$GLOBALS['stonewright_test_filters']              = [];
+		$GLOBALS['stonewright_test_wp_remote_get']        = null;
+		$GLOBALS['stonewright_test_wp_remote_get_calls']  = [];
+		$GLOBALS['stonewright_test_download_url']         = null;
+		$GLOBALS['stonewright_test_wp_kses_calls']        = [];
+		$GLOBALS['stonewright_test_wp_kses_post_calls']   = [];
 	}
 
 	public function test_installed_channel_distinguishes_stable_and_prerelease_versions(): void {
@@ -149,6 +153,90 @@ final class GitHubUpdaterTest extends TestCase {
 		self::assertStringEndsWith( '/stonewright-1.3.0-beta.10.zip', $parsed['package'] );
 		self::assertStringEndsWith( '/stonewright-companion-1.3.0-beta.10.tgz', $parsed['companion_package'] );
 		self::assertStringEndsWith( '/SHA256SUMS.txt', $parsed['checksums'] );
+	}
+
+	public function test_plugins_api_renders_sanitized_release_notes_for_stonewright_slug(): void {
+		$release          = $this->parsed_beta_release();
+		$release['body']  = "# Fixes\n\nRelease channel: `supported`\n\n- One\n- Two\n\nSee [docs](https://example.com/docs).\n\n<script>alert(1)</script>\n";
+		$release['requires']     = '6.7';
+		$release['requires_php'] = '8.1';
+		$release['tested']       = '6.8';
+		$this->cache_parsed_release( $release, '1.0.0-beta.1' );
+
+		$info = GitHubUpdater::plugins_api( false, 'plugin_information', (object) [ 'slug' => 'stonewright' ] );
+
+		self::assertIsObject( $info );
+		self::assertSame( 'Stonewright', $info->name );
+		self::assertSame( 'stonewright', $info->slug );
+		self::assertSame( $release['version'], $info->version );
+		self::assertSame( $release['url'], $info->homepage );
+		self::assertSame( $release['package'], $info->download_link );
+		self::assertSame( '6.7', $info->requires );
+		self::assertSame( '8.1', $info->requires_php );
+		self::assertSame( '6.8', $info->tested );
+		self::assertArrayHasKey( 'description', $info->sections );
+		$description = $info->sections['description'];
+		self::assertMatchesRegularExpression( '/<h1>\s*Fixes\s*<\/h1>/', $description );
+		self::assertMatchesRegularExpression( '/<ul>.*<li>\s*One\s*<\/li>.*<li>\s*Two\s*<\/li>.*<\/ul>/s', $description );
+		self::assertMatchesRegularExpression( '/<a href="https:\/\/example\.com\/docs"[^>]*>docs<\/a>/', $description );
+		self::assertStringNotContainsString( '# Fixes', $description );
+		self::assertDoesNotMatchRegularExpression( '/<script\b/i', $description );
+		self::assertStringContainsString( '&lt;script&gt;', $description );
+		self::assertNotEmpty( $GLOBALS['stonewright_test_wp_kses_calls'] );
+		self::assertSame( [ 'https' ], $GLOBALS['stonewright_test_wp_kses_calls'][0]['allowed_protocols'] );
+	}
+
+	public function test_plugins_api_uses_human_fallback_when_release_body_is_missing(): void {
+		$release = $this->parsed_beta_release();
+		unset( $release['body'] );
+		$this->cache_parsed_release( $release, '1.0.0-beta.1' );
+
+		$info = GitHubUpdater::plugins_api( false, 'plugin_information', (object) [ 'slug' => 'stonewright' ] );
+
+		self::assertIsObject( $info );
+		self::assertSame( $release['version'], $info->version );
+		self::assertStringContainsString( 'Release notes are not available for this version.', $info->sections['description'] );
+		self::assertStringNotContainsString( 'AI builder tools for WordPress MCP.', $info->sections['description'] );
+	}
+
+	public function test_plugins_api_passes_through_non_stonewright_slugs_and_unrelated_actions(): void {
+		$passthrough = (object) [ 'name' => 'Other Plugin', 'slug' => 'akismet' ];
+		$release     = $this->parsed_beta_release();
+		$release['body'] = "# Should not leak\n";
+		$this->cache_parsed_release( $release, '1.0.0-beta.1' );
+
+		self::assertSame(
+			$passthrough,
+			GitHubUpdater::plugins_api( $passthrough, 'plugin_information', (object) [ 'slug' => 'akismet' ] )
+		);
+		self::assertSame(
+			$passthrough,
+			GitHubUpdater::plugins_api( $passthrough, 'query_plugins', (object) [ 'slug' => 'stonewright' ] )
+		);
+		self::assertSame(
+			$passthrough,
+			GitHubUpdater::plugins_api( $passthrough, 'plugin_information', (object) [ 'slug' => 'stonewright-extra' ] )
+		);
+	}
+
+	public function test_release_channel_metadata_still_reads_raw_markdown_body(): void {
+		$github_release          = $this->releases_fixture()[6];
+		$github_release['body']  = "# Fixes\n\nRelease channel: `supported`\n\n<script>alert(1)</script>\n";
+
+		self::assertNull( GitHubUpdater::release_rejection_reason( $github_release, 'beta' ) );
+		$parsed = GitHubUpdater::parse_release( $github_release );
+		self::assertIsArray( $parsed );
+		self::assertSame( $github_release['body'], $parsed['body'] );
+		self::assertStringContainsString( 'Release channel: `supported`', $parsed['body'] );
+		self::assertStringContainsString( '<script>alert(1)</script>', $parsed['body'] );
+		self::assertStringContainsString( '# Fixes', $parsed['body'] );
+
+		$this->cache_parsed_release( $parsed, '1.0.0-beta.1' );
+		$info = GitHubUpdater::plugins_api( false, 'plugin_information', (object) [ 'slug' => 'stonewright' ] );
+		self::assertIsObject( $info );
+		self::assertNotSame( $parsed['body'], $info->sections['description'] );
+		self::assertDoesNotMatchRegularExpression( '/<script\b/i', $info->sections['description'] );
+		self::assertNull( GitHubUpdater::release_rejection_reason( $github_release, 'beta' ) );
 	}
 
 	public function test_release_without_sha256sums_is_rejected_with_a_typed_reason(): void {
@@ -766,6 +854,28 @@ final class GitHubUpdaterTest extends TestCase {
 			[ 'schema_version' => GitHubUpdater::CACHE_SCHEMA_VERSION, 'channel' => $channel, 'release' => $release ],
 			GitHubUpdater::CACHE_TTL
 		);
+	}
+
+	/**
+	 * @param array{version: string, package: string, companion_package: string, checksums: string, url: string, body?: string, tested?: string, requires?: string, requires_php?: string} $release
+	 */
+	private function cache_parsed_release( array $release, string $installed_version ): void {
+		$this->set_installed_version( $installed_version );
+		$channel = GitHubUpdater::installed_channel( $installed_version );
+		set_transient(
+			GitHubUpdater::cache_key( $channel ),
+			[ 'schema_version' => GitHubUpdater::CACHE_SCHEMA_VERSION, 'channel' => $channel, 'release' => $release ],
+			GitHubUpdater::CACHE_TTL
+		);
+	}
+
+	/**
+	 * @return array{version: string, package: string, companion_package: string, checksums: string, url: string, body?: string}
+	 */
+	private function parsed_beta_release(): array {
+		$release = GitHubUpdater::select_release( $this->releases_fixture(), 'beta' );
+		self::assertIsArray( $release );
+		return $release;
 	}
 
 	/**

--- a/plugin/tests/Unit/Core/ReleaseNotesRendererTest.php
+++ b/plugin/tests/Unit/Core/ReleaseNotesRendererTest.php
@@ -154,6 +154,51 @@ MD;
 		$this->assertNoExecutableMarkup( $html );
 	}
 
+	/**
+	 * @dataProvider href_metacharacter_cases
+	 */
+	public function test_href_with_markdown_metacharacters_stays_exact(
+		string $url,
+		string $markdown,
+		bool $expect_italic
+	): void {
+		$html = ReleaseNotesRenderer::render( $markdown );
+
+		self::assertStringContainsString( 'href="' . $url . '"', $html );
+		if ( $expect_italic ) {
+			self::assertMatchesRegularExpression( '/<em>\s*italic\s*<\/em>/', $html );
+		}
+		$this->assertNoExecutableMarkup( $html );
+	}
+
+	/**
+	 * @return array<string, array{0: string, 1: string, 2: bool}>
+	 */
+	public function href_metacharacter_cases(): array {
+		return [
+			'dunder init py'                   => [
+				'https://github.com/foo/bar/blob/main/plugin/__init__.py',
+				'[source](https://github.com/foo/bar/blob/main/plugin/__init__.py)',
+				false,
+			],
+			'underscored path'                 => [
+				'https://example.com/_foo_',
+				'[path](https://example.com/_foo_)',
+				false,
+			],
+			'asterisks in path'                => [
+				'https://example.com/foo*bar*baz',
+				'[path](https://example.com/foo*bar*baz)',
+				false,
+			],
+			'single asterisk with later italic' => [
+				'https://example.com/foo*bar',
+				'[path](https://example.com/foo*bar) and *italic*',
+				true,
+			],
+		];
+	}
+
 	public function test_empty_or_whitespace_body_returns_sanitized_human_fallback(): void {
 		foreach ( [ '', '   ', "\n\t" ] as $body ) {
 			$GLOBALS['stonewright_test_wp_kses_calls'] = [];

--- a/plugin/tests/Unit/Core/ReleaseNotesRendererTest.php
+++ b/plugin/tests/Unit/Core/ReleaseNotesRendererTest.php
@@ -1,0 +1,197 @@
+<?php
+declare( strict_types=1 );
+
+namespace Stonewright\WpMcp\Tests\Unit\Core;
+
+use PHPUnit\Framework\TestCase;
+use Stonewright\WpMcp\Core\ReleaseNotesRenderer;
+
+/**
+ * @covers \Stonewright\WpMcp\Core\ReleaseNotesRenderer
+ */
+final class ReleaseNotesRendererTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['stonewright_test_wp_kses_calls']      = [];
+		$GLOBALS['stonewright_test_wp_kses_post_calls'] = [];
+	}
+
+	protected function tearDown(): void {
+		$GLOBALS['stonewright_test_wp_kses_calls']      = [];
+		$GLOBALS['stonewright_test_wp_kses_post_calls'] = [];
+	}
+
+	public function test_headings_paragraphs_and_lists_render_structurally(): void {
+		$markdown = <<<'MD'
+# Title
+## Section
+### Detail
+#### Note
+
+A paragraph of release notes.
+
+- First
+- Second
+
+1. Alpha
+2. Beta
+MD;
+		$html     = ReleaseNotesRenderer::render( $markdown );
+
+		self::assertMatchesRegularExpression( '/<h1>\s*Title\s*<\/h1>/', $html );
+		self::assertMatchesRegularExpression( '/<h2>\s*Section\s*<\/h2>/', $html );
+		self::assertMatchesRegularExpression( '/<h3>\s*Detail\s*<\/h3>/', $html );
+		self::assertMatchesRegularExpression( '/<h4>\s*Note\s*<\/h4>/', $html );
+		self::assertMatchesRegularExpression( '/<p>\s*A paragraph of release notes\.\s*<\/p>/', $html );
+		self::assertMatchesRegularExpression( '/<ul>.*<li>\s*First\s*<\/li>.*<li>\s*Second\s*<\/li>.*<\/ul>/s', $html );
+		self::assertMatchesRegularExpression( '/<ol>.*<li>\s*Alpha\s*<\/li>.*<li>\s*Beta\s*<\/li>.*<\/ol>/s', $html );
+		self::assertStringNotContainsString( '# Title', $html );
+		self::assertStringNotContainsString( '<h5', $html );
+		$this->assertNoExecutableMarkup( $html );
+	}
+
+	public function test_inline_and_fenced_code_is_escaped_inside_code_and_pre(): void {
+		$markdown = "Use `wp_kses()` and `<script>`.\n\n```\n<script>alert(1)</script>\nconst x = 1;\n```";
+		$html     = ReleaseNotesRenderer::render( $markdown );
+
+		self::assertMatchesRegularExpression( '/<code>wp_kses\(\)<\/code>/', $html );
+		self::assertMatchesRegularExpression( '/<code>&lt;script&gt;<\/code>/', $html );
+		self::assertMatchesRegularExpression( '/<pre><code>[\s\S]*&lt;script&gt;alert\(1\)&lt;\/script&gt;[\s\S]*<\/code><\/pre>/', $html );
+		self::assertStringContainsString( 'const x = 1;', $html );
+		$this->assertNoExecutableMarkup( $html );
+	}
+
+	public function test_strong_and_emphasis_render_without_arbitrary_tags(): void {
+		$html = ReleaseNotesRenderer::render( 'This is **bold** and *italic*, plus __strong__ and _em_.' );
+
+		self::assertMatchesRegularExpression( '/<strong>\s*bold\s*<\/strong>/', $html );
+		self::assertMatchesRegularExpression( '/<em>\s*italic\s*<\/em>/', $html );
+		self::assertMatchesRegularExpression( '/<strong>\s*strong\s*<\/strong>/', $html );
+		self::assertMatchesRegularExpression( '/<em>\s*em\s*<\/em>/', $html );
+		self::assertStringNotContainsString( '<b>', $html );
+		self::assertStringNotContainsString( '<i>', $html );
+		self::assertStringNotContainsString( '<div>', $html );
+		$this->assertNoExecutableMarkup( $html );
+	}
+
+	public function test_valid_https_link_renders_with_safe_attributes(): void {
+		$html = ReleaseNotesRenderer::render( 'See [the guide](https://example.com/docs).' );
+
+		self::assertMatchesRegularExpression(
+			'/<a href="https:\/\/example\.com\/docs"(?: rel="noopener noreferrer")?>the guide<\/a>/',
+			$html
+		);
+		self::assertStringContainsString( 'rel="noopener noreferrer"', $html );
+		self::assertStringNotContainsString( 'target=', $html );
+		self::assertStringNotContainsString( 'onclick', $html );
+		$this->assertNoExecutableMarkup( $html );
+	}
+
+	public function test_raw_html_event_handlers_and_entity_tricks_remain_inert(): void {
+		$markdown = <<<'MD'
+<script>alert(1)</script>
+<img src=x onerror="alert(1)">
+<svg onload="alert(1)"></svg>
+<iframe src="https://example.com"></iframe>
+<style>body{display:none}</style>
+<!-- comment -->
+<div onclick="alert(1)">click</div>
+<p>nested <em><strong>ok</p>
+&lt;script&gt;alert(1)&lt;/script&gt;
+MD;
+		$html     = ReleaseNotesRenderer::render( $markdown );
+
+		self::assertStringContainsString( '&lt;script&gt;', $html );
+		self::assertStringContainsString( '&lt;iframe', $html );
+		self::assertStringContainsString( '&lt;svg', $html );
+		self::assertStringContainsString( '&lt;style', $html );
+		self::assertStringContainsString( '&amp;lt;script&amp;gt;', $html );
+		self::assertStringContainsString( 'click', $html );
+		$this->assertNoExecutableMarkup( $html );
+	}
+
+	/**
+	 * @dataProvider rejected_link_cases
+	 */
+	public function test_rejected_links_are_not_clickable( string $markdown, string $label ): void {
+		$html = ReleaseNotesRenderer::render( $markdown );
+
+		self::assertStringNotContainsString( '<a ', $html );
+		self::assertStringNotContainsString( 'href=', $html );
+		self::assertStringContainsString( $label, $html );
+		$this->assertNoExecutableMarkup( $html );
+	}
+
+	/**
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	public function rejected_link_cases(): array {
+		return [
+			'javascript scheme'   => [ '[Click](javascript:alert(1))', 'Click' ],
+			'javascript encoded'  => [ '[Click](javascript&#58;alert(1))', 'Click' ],
+			'data scheme'         => [ '[Click](data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==)', 'Click' ],
+			'http scheme'         => [ '[Click](http://example.com/docs)', 'Click' ],
+			'protocol relative'   => [ '[Click](//example.com/docs)', 'Click' ],
+			'userinfo'            => [ '[Click](https://user:pass@example.com/docs)', 'Click' ],
+			'userinfo user only'  => [ '[Click](https://user@example.com/docs)', 'Click' ],
+			'malformed empty'     => [ '[Click](https://)', 'Click' ],
+			'malformed no scheme' => [ '[Click](/relative/path)', 'Click' ],
+			'malformed spaces'    => [ '[Click](https://example.com/a b)', 'Click' ],
+		];
+	}
+
+	public function test_link_labels_and_code_keep_markdown_metacharacters(): void {
+		$html = ReleaseNotesRenderer::render(
+			'See [Use *this* + more](https://example.com/path) and `**not-bold**` plus `*still code*`.'
+		);
+
+		self::assertMatchesRegularExpression( '/<a href="https:\/\/example\.com\/path"[^>]*>/', $html );
+		self::assertStringContainsString( 'Use', $html );
+		self::assertStringContainsString( '+', $html );
+		self::assertMatchesRegularExpression( '/<code>\*\*not-bold\*\*<\/code>/', $html );
+		self::assertMatchesRegularExpression( '/<code>\*still code\*<\/code>/', $html );
+		self::assertStringNotContainsString( '<strong>not-bold</strong>', $html );
+		$this->assertNoExecutableMarkup( $html );
+	}
+
+	public function test_empty_or_whitespace_body_returns_sanitized_human_fallback(): void {
+		foreach ( [ '', '   ', "\n\t" ] as $body ) {
+			$GLOBALS['stonewright_test_wp_kses_calls'] = [];
+			$html                                      = ReleaseNotesRenderer::render( $body );
+			self::assertStringContainsString( 'Release notes are not available for this version.', $html );
+			self::assertMatchesRegularExpression( '/<p>Release notes are not available for this version\.<\/p>/', $html );
+			self::assertNotEmpty( $GLOBALS['stonewright_test_wp_kses_calls'] );
+			$this->assertNoExecutableMarkup( $html );
+		}
+	}
+
+	public function test_sanitizes_with_explicit_wp_kses_allowlist_not_only_wp_kses_post(): void {
+		ReleaseNotesRenderer::render( '# Hello' );
+
+		self::assertNotEmpty( $GLOBALS['stonewright_test_wp_kses_calls'] );
+		$call = $GLOBALS['stonewright_test_wp_kses_calls'][0];
+		self::assertIsArray( $call['allowed_html'] );
+		self::assertSame( [ 'https' ], $call['allowed_protocols'] );
+
+		$allowed = array_change_key_case( $call['allowed_html'], CASE_LOWER );
+		foreach ( [ 'h1', 'h2', 'h3', 'h4', 'p', 'ul', 'ol', 'li', 'pre', 'code', 'strong', 'em', 'a' ] as $tag ) {
+			self::assertArrayHasKey( $tag, $allowed );
+		}
+		foreach ( [ 'script', 'iframe', 'svg', 'style', 'img', 'div', 'span', 'blockquote' ] as $tag ) {
+			self::assertArrayNotHasKey( $tag, $allowed );
+		}
+		self::assertArrayHasKey( 'href', $allowed['a'] );
+		self::assertArrayNotHasKey( 'onclick', $allowed['a'] );
+		self::assertEmpty( $GLOBALS['stonewright_test_wp_kses_post_calls'] );
+	}
+
+	private function assertNoExecutableMarkup( string $html ): void {
+		self::assertDoesNotMatchRegularExpression( '/<script\b/i', $html );
+		self::assertDoesNotMatchRegularExpression( '/<iframe\b/i', $html );
+		self::assertDoesNotMatchRegularExpression( '/<svg\b/i', $html );
+		self::assertDoesNotMatchRegularExpression( '/<style\b/i', $html );
+		self::assertDoesNotMatchRegularExpression( '/<img\b/i', $html );
+		self::assertDoesNotMatchRegularExpression( '/<!--/', $html );
+		self::assertDoesNotMatchRegularExpression( '/<[a-zA-Z][^>]*\son[a-z]+\s*=/i', $html );
+	}
+}

--- a/plugin/tests/bootstrap.php
+++ b/plugin/tests/bootstrap.php
@@ -1426,7 +1426,67 @@ if ( ! function_exists( 'sanitize_key' ) ) {
 
 if ( ! function_exists( 'wp_kses_post' ) ) {
 	function wp_kses_post( string $content ): string {
+		$GLOBALS['stonewright_test_wp_kses_post_calls'][] = $content;
 		return $content;
+	}
+}
+
+if ( ! function_exists( 'wp_kses' ) ) {
+	/**
+	 * Minimal wp_kses stand-in that honors an explicit tag/protocol allowlist.
+	 *
+	 * @param array<string, mixed>|string $allowed_html
+	 * @param array<int, string>          $allowed_protocols
+	 */
+	function wp_kses( string $content, $allowed_html, array $allowed_protocols = [] ): string {
+		$GLOBALS['stonewright_test_wp_kses_calls'][] = [
+			'content'           => $content,
+			'allowed_html'      => $allowed_html,
+			'allowed_protocols' => $allowed_protocols,
+		];
+
+		if ( ! is_array( $allowed_html ) ) {
+			return '';
+		}
+
+		$allowed_html = array_change_key_case( $allowed_html, CASE_LOWER );
+		$content      = preg_replace( '/<!--.*?-->/s', '', $content ) ?? '';
+
+		return preg_replace_callback(
+			'/<(\/)?([a-zA-Z0-9]+)([^>]*)>/',
+			static function ( array $matches ) use ( $allowed_html, $allowed_protocols ): string {
+				$closing = '/' === $matches[1];
+				$tag     = strtolower( $matches[2] );
+				if ( ! isset( $allowed_html[ $tag ] ) ) {
+					return '';
+				}
+				if ( $closing ) {
+					return '</' . $tag . '>';
+				}
+
+				$allowed_attrs = is_array( $allowed_html[ $tag ] ) ? $allowed_html[ $tag ] : [];
+				$attrs_out     = '';
+				if ( preg_match_all( '/([a-zA-Z_:][a-zA-Z0-9:._-]*)\s*=\s*(["\'])(.*?)\2/s', $matches[3], $attr_matches, PREG_SET_ORDER ) ) {
+					foreach ( $attr_matches as $attr ) {
+						$name = strtolower( $attr[1] );
+						if ( ! array_key_exists( $name, $allowed_attrs ) ) {
+							continue;
+						}
+						$value = html_entity_decode( $attr[3], ENT_QUOTES, 'UTF-8' );
+						if ( in_array( $name, [ 'href', 'src' ], true ) && [] !== $allowed_protocols ) {
+							$scheme = strtolower( (string) ( parse_url( $value, PHP_URL_SCHEME ) ?: '' ) );
+							if ( ! in_array( $scheme, $allowed_protocols, true ) ) {
+								continue;
+							}
+						}
+						$attrs_out .= ' ' . $name . '="' . htmlspecialchars( $value, ENT_QUOTES, 'UTF-8' ) . '"';
+					}
+				}
+
+				return '<' . $tag . $attrs_out . '>';
+			},
+			$content
+		) ?? '';
 	}
 }
 


### PR DESCRIPTION
## Summary
- Render GitHub release bodies as sanitized HTML in the Plugins → View details modal (headings, lists, code, emphasis, HTTPS-only links).
- Keep release-channel parsing on the raw Markdown body; never trust release-body HTML.
- Add permanent AGENTS.md rule for untrusted release notes + explicit `wp_kses` allowlist + regression tests.

## Changed abilities / gates
No ability behavior change. Updater presentation boundary only (`plugins_api` for slug `stonewright`).
Backup / token / permission / validation / audit: unchanged.

## Reviews
- Spec: SPEC_COMPLIANT
- Quality: APPROVED after href-emphasis fix (`e0cd974`) for URLs containing `__`/`_`/`*`

## Test plan
- [ ] Focused PHPUnit ReleaseNotesRenderer + GitHubUpdater green
- [ ] CI full matrix green
- [ ] Spot-check View details modal formatting (no raw Markdown, no executable HTML)
- [ ] Merge commit (not squash)


Made with [Cursor](https://cursor.com)