### PR TITLE
Release 1.0.0-beta.12 supported public beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ development builds were never stable releases.
 
 ### Added
 
+- Nothing yet.
+
+## [1.0.0-beta.12] - 2026-08-24
+
+
+
+### Added
+
 - Add read-only Elementor provider discovery with ownership, trust, compatibility,
   certification, Status and Troubleshoot visibility, and certified
   native-preferred metadata for Elementor default styles; expose it in the
@@ -196,7 +204,6 @@ development builds were never stable releases.
   the first event and bounded count summaries.
 - Validate Direct lock owners with available host, boot, and per-PID process-start
   identity plus a bounded lease so a live decoy or reused PID cannot block forever.
-
 ## [1.0.0-beta.11.1] - 2026-08-24
 
 ### Fixed
@@ -435,18 +442,9 @@ development builds were never stable releases.
   controls over CSS/JavaScript, treat editor-canvas visibility as non-proof,
   and require settings readback plus frontend-class verification.
 
-## [1.0.0-beta.8] - 2026-08-12
-
-### Fixed
-
-- Accept `playwright` as the natural browser-provider value while preserving
-  the existing recommended-provider registry contract.
-- Make `connect verify` print content-safe runtime proof for companion version,
-  active alias, task-start/status availability, and refresh-required tools;
-  verification now fails while any refresh-required tool remains.
-
 ## Older releases
 
+- [1.0.0-beta.8](docs/releases/1.0.0-beta.8.md)
 - [1.0.0-beta.7](docs/releases/1.0.0-beta.7.md)
 - [1.0.0-beta.6](docs/releases/1.0.0-beta.6.md)
 - [1.0.0-beta.5](docs/releases/1.0.0-beta.5.md)

--- a/README.md
+++ b/README.md
@@ -19,17 +19,17 @@
 </p>
 
 <!-- supported-release:start -->
-<p align="center"><strong>Current release: 1.0.0-beta.11 — Public Beta</strong></p>
+<p align="center"><strong>Current release: 1.0.0-beta.12 — Public Beta</strong></p>
 <p align="center">
-  <a href="https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.11/stonewright-1.0.0-beta.11.zip">Download Plugin</a>
+  <a href="https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.12/stonewright-1.0.0-beta.12.zip">Download Plugin</a>
   ·
   <a href="docs/installation.md">Installation guide</a>
   ·
-  <a href="https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.11/stonewright-companion-1.0.0-beta.11.tgz">Companion</a>
+  <a href="https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.12/stonewright-companion-1.0.0-beta.12.tgz">Companion</a>
   ·
-  <a href="https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.11/SHA256SUMS.txt">Checksums</a>
+  <a href="https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.12/SHA256SUMS.txt">Checksums</a>
   ·
-  <a href="https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/tag/v1.0.0-beta.11">Release notes</a>
+  <a href="https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/tag/v1.0.0-beta.12">Release notes</a>
 </p>
 <p align="center"><sub>Preview builds appear on the complete Releases page and are not recommended by default.</sub></p>
 <!-- supported-release:end -->

--- a/companion/CHANGELOG.md
+++ b/companion/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Nothing yet.
+
+## [1.0.0-beta.12] - 2026-08-24
+
+
+
 ### Security
 
 - Redact nested private keys, PEM certificates, and credential blobs from
@@ -88,7 +96,6 @@
   expose configured-package truth only to an authenticated request backed by a
   validated source.
 - Resolve `chatgpt-desktop` through the Codex TOML adapter and catalog metadata.
-
 ## [1.0.0-beta.11.1] - 2026-08-24
 
 ### Changed

--- a/companion/package-lock.json
+++ b/companion/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@stonewright/companion",
-	"version": "1.0.0-beta.11.1",
+	"version": "1.0.0-beta.12",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@stonewright/companion",
-			"version": "1.0.0-beta.11.1",
+			"version": "1.0.0-beta.12",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/companion/package.json
+++ b/companion/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@stonewright/companion",
-	"version": "1.0.0-beta.11.1",
+	"version": "1.0.0-beta.12",
 	"description": "Node companion for the Stonewright WordPress MCP plugin: WP-CLI, health checks, and optional MCP HTTP proxy.",
 	"type": "module",
 	"license": "MIT",

--- a/companion/src/version.ts
+++ b/companion/src/version.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = '1.0.0-beta.11.1';
+export const APP_VERSION = '1.0.0-beta.12';
 
 export function companionPackageSpec(version: string = APP_VERSION): string {
 	return `https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v${version}/stonewright-companion-${version}.tgz`;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,6 +13,23 @@ and communicates through the process's standard input/output streams. Direct
 mode lives inside that companion. Remote Streamable HTTP bypasses the companion
 and connects straight to the WordPress plugin over HTTPS.
 
+At a glance, Stonewright stacks five layers:
+
+```text
+AI client
+   ↕
+Connection (stdio / HTTP)
+   ↕
+Stonewright safety + orchestration
+   ↕
+Native providers (Elementor, WordPress, WooCommerce, third-party)
+   ↕
+Verification · Audit · Restore
+```
+
+The diagram below expands each layer for plugin mode, Direct mode, and optional
+browser-assisted verification.
+
 ```mermaid
 flowchart TD
     Client["MCP client"]

--- a/docs/releases/1.0.0-beta.12.md
+++ b/docs/releases/1.0.0-beta.12.md
@@ -47,6 +47,9 @@ release notes that stay safe when GitHub bodies are untrusted Markdown.
 - Separate GitHub updater failure reasons, reject same-version false updates,
   verify release ZIPs against `SHA256SUMS.txt`, and preserve mode, surface,
   memory, skills, audit history, and Direct state across upgrades.
+- Stop macOS companion test flakes from contended Direct lock acquisition by
+  caching lock-owner process identity, backing off progressively, and cleaning
+  up leaked stress-test child processes.
 - Coalesce Plugin and Direct audit lifecycle noise without losing writes,
   failures, or security denials; stop finalizer timers after terminal errors.
 - Require process-bound client surface checks after companion updates; empty

--- a/docs/releases/1.0.0-beta.12.md
+++ b/docs/releases/1.0.0-beta.12.md
@@ -1,0 +1,93 @@
+# Stonewright 1.0.0-beta.12
+
+Released: 2026-08-24
+
+Release channel: `supported`
+
+## Summary
+
+This supported public beta closes the reliability gaps found after beta.11:
+update truth in Setup, audit lifecycle noise, Elementor CSS safety, native
+provider discovery, and readable release notes in WordPress View details.
+Plugin and companion stay aligned on `1.0.0-beta.12`.
+
+Operators get honest companion and bridge status, checksum-verified plugin
+updates, coalesced audit activity, bounded Elementor CSS closure with rollback,
+read-only upstream Elementor provider discovery, and formatted View details
+release notes that stay safe when GitHub bodies are untrusted Markdown.
+
+## Added
+
+- Read-only Elementor provider discovery with ownership, trust, compatibility,
+  certification, Status and Troubleshoot visibility, and certified
+  native-preferred metadata for Elementor default styles.
+- Formatted, sanitized GitHub release notes in the WordPress Plugins View
+  details modal.
+
+## Changed
+
+- Keep audit history until an operator configures scheduled retention, and
+  coalesce routine heartbeat and successful authentication activity.
+- Document the five-layer Stonewright architecture in `docs/architecture.md`.
+
+## Fixed
+
+- Retry Elementor post-lock and CSS directory lease renew on WordPress options
+  compare-and-swap misses while this writer still owns a live lease.
+- Prevent single-post Elementor writes from clearing the global generated CSS
+  directory; post-write closure uses Elementor's official Post CSS API inside a
+  bounded asset transaction with evidence, probes, collateral detection, and
+  byte-for-byte rollback.
+- Remove the former `regenerate_css` input; Direct mode preserves CSS metadata
+  and refuses global `flush-css`.
+- Mark upstream `elementor/manage-elements` non-routable while its
+  implementation clears Elementor's global files cache.
+- Recognize Jetpack classmap manifests used by WooCommerce 10.9 during MCP
+  compatibility preflight.
+- Separate GitHub updater failure reasons, reject same-version false updates,
+  verify release ZIPs against `SHA256SUMS.txt`, and preserve mode, surface,
+  memory, skills, audit history, and Direct state across upgrades.
+- Coalesce Plugin and Direct audit lifecycle noise without losing writes,
+  failures, or security denials; stop finalizer timers after terminal errors.
+- Require process-bound client surface checks after companion updates; empty
+  refresh lists no longer override a failed visibility check.
+
+## Security
+
+- Block MCP startup when required MCP Adapter or Abilities API symbols are
+  missing, conflicting, or ABI-incompatible.
+- Keep third-party Atomic schemas discoverable but read-only unless they match
+  Stonewright's verified authority.
+- Fetch bounded checksum manifests and fail closed on missing, malformed, or
+  mismatched plugin ZIP verification.
+- Bind active-client update attestation to one-time receipts, exact official
+  package provenance, restarted process, and process-bound catalog observation.
+- Recursively redact private keys, PEM certificates, and credential blobs from
+  audit payloads.
+
+## Upgrade
+
+Update the plugin from the native WordPress updater or install the published
+release ZIP. Update the companion package reference to the published beta.12
+asset, fully restart the MCP client, then run:
+
+```bash
+npx -y --package <published-companion-package> stonewright connect verify <alias> --client <client>
+```
+
+Success requires the requested alias, expected companion version,
+`stonewright-task-start`, status availability, and an empty
+`refresh_required_tool_names` list.
+
+## Compatibility and safety
+
+- WordPress plugin and companion: `1.0.0-beta.12`.
+- Plugin mode registers **388** abilities; Direct full exposes **101** tools.
+- WordPress: 6.7 or newer.
+- PHP: 8.1 or newer.
+- Node.js: 20 or newer for the companion.
+- Fresh installs start without user memory, user-created skills, incidents, or
+  audit history. Updates preserve existing private state.
+
+The release workflow generates and verifies the plugin ZIP, companion package,
+Visual package, and `SHA256SUMS.txt` before publishing installation assets.

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Added
 
+- Nothing yet.
+
+## [1.0.0-beta.12] - 2026-08-24
+
+
+
+### Added
+
 - Add read-only Elementor provider discovery with ownership, trust, compatibility,
   certification, Status and Troubleshoot visibility, and certified
   native-preferred metadata for Elementor default styles; expose it in the
@@ -153,7 +161,6 @@
 - Coalesce identical permission and safety denials by site, ability, and error,
   retaining the first event plus bounded count summaries and severity under a
   stale-recoverable option mutex with compare-and-delete ownership.
-
 ## [1.0.0-beta.11.1] - 2026-08-24
 
 ### Fixed
@@ -378,16 +385,9 @@
   `hide_*` switches; accept only the matching native device value or an empty
   off state before any document write.
 
-## [1.0.0-beta.8] - 2026-08-12
-
-### Changed
-
-- Align plugin metadata and generated companion package references with the
-  final connection-verification release. Plugin abilities and safety gates are
-  unchanged.
-
 ## Older releases
 
+- [1.0.0-beta.8](../docs/releases/1.0.0-beta.8.md)
 - [1.0.0-beta.7](../docs/releases/1.0.0-beta.7.md)
 - [1.0.0-beta.6](../docs/releases/1.0.0-beta.6.md)
 - [1.0.0-beta.5](../docs/releases/1.0.0-beta.5.md)

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,6 +1,6 @@
 # Stonewright Plugin
 
-Version: 1.0.0-beta.11.1
+Version: 1.0.0-beta.12
 Requires WordPress: 6.7+
 Requires PHP: 8.1+
 License: [AGPL-3.0-or-later](../LICENSE)

--- a/plugin/stonewright.php
+++ b/plugin/stonewright.php
@@ -3,7 +3,7 @@
  * Plugin Name: Stonewright
  * Plugin URI: https://github.com/cosmincraciun97/stonewright-wp-mcp
  * Description: Guarded WordPress MCP tools for Elementor, Gutenberg/FSE, WooCommerce catalogs, content models, PHP runtime execution, and tokenized WP-CLI.
- * Version: 1.0.0-beta.11.1
+ * Version: 1.0.0-beta.12
  * Requires at least: 6.7
  * Requires PHP: 8.1
  * Author: Stonewright
@@ -33,7 +33,7 @@ if ( defined( 'STONEWRIGHT_FILE' ) ) {
 define( 'STONEWRIGHT_FILE', __FILE__ );
 define( 'STONEWRIGHT_DIR', plugin_dir_path( __FILE__ ) );
 define( 'STONEWRIGHT_URL', plugin_dir_url( __FILE__ ) );
-define( 'STONEWRIGHT_VERSION', '1.0.0-beta.11.1' );
+define( 'STONEWRIGHT_VERSION', '1.0.0-beta.12' );
 define( 'STONEWRIGHT_MIN_PHP', '8.1' );
 define( 'STONEWRIGHT_MIN_WP', '6.7' );
 

--- a/plugin/tests/Unit/Core/GitHubUpdaterTest.php
+++ b/plugin/tests/Unit/Core/GitHubUpdaterTest.php
@@ -261,6 +261,18 @@ final class GitHubUpdaterTest extends TestCase {
 		self::assertSame( 'Do not update. Publish SHA256SUMS.txt, then try again.', $result['reason']['action'] );
 	}
 
+	public function test_inject_update_records_no_update_when_installed_version_matches_remote(): void {
+		$release = $this->parsed_beta_release();
+		$this->cache_parsed_release( $release, $release['version'] );
+
+		$transient = GitHubUpdater::inject_update( (object) [ 'response' => [], 'no_update' => [] ] );
+		$plugin    = GitHubUpdater::plugin_basename();
+
+		self::assertArrayNotHasKey( $plugin, $transient->response );
+		self::assertArrayHasKey( $plugin, $transient->no_update );
+		self::assertSame( $release['version'], $transient->no_update[ $plugin ]->new_version ?? null );
+	}
+
 	public function test_transient_injection_refuses_cached_release_without_sha256sums(): void {
 		$this->set_installed_version( '1.0.0-beta.1' );
 		$release = [

--- a/plugin/tests/Unit/Support/ReleaseRetentionTest.php
+++ b/plugin/tests/Unit/Support/ReleaseRetentionTest.php
@@ -19,7 +19,7 @@ final class ReleaseRetentionTest extends TestCase {
 				$versioned[] = $name;
 			}
 		}
-		self::assertSame( [ '1.0.0-beta.1.md', '1.0.0-beta.10.md', '1.0.0-beta.11.1.md', '1.0.0-beta.11.md', '1.0.0-beta.2.md', '1.0.0-beta.3.md', '1.0.0-beta.4.md', '1.0.0-beta.5.md', '1.0.0-beta.6.md', '1.0.0-beta.7.md', '1.0.0-beta.8.md', '1.0.0-beta.9.md' ], $versioned );
+		self::assertSame( [ '1.0.0-beta.1.md', '1.0.0-beta.10.md', '1.0.0-beta.11.1.md', '1.0.0-beta.11.md', '1.0.0-beta.12.md', '1.0.0-beta.2.md', '1.0.0-beta.3.md', '1.0.0-beta.4.md', '1.0.0-beta.5.md', '1.0.0-beta.6.md', '1.0.0-beta.7.md', '1.0.0-beta.8.md', '1.0.0-beta.9.md' ], $versioned );
 	}
 
 	public function test_root_changelog_keeps_latest_five_releases_and_links_older_history(): void {
@@ -36,7 +36,7 @@ final class ReleaseRetentionTest extends TestCase {
 			)
 		);
 		self::assertContains( 'Unreleased', $headers );
-		self::assertSame( [ '1.0.0-beta.11.1', '1.0.0-beta.11', '1.0.0-beta.10', '1.0.0-beta.9', '1.0.0-beta.8' ], $versions );
+		self::assertSame( [ '1.0.0-beta.12', '1.0.0-beta.11.1', '1.0.0-beta.11', '1.0.0-beta.10', '1.0.0-beta.9' ], $versions );
 		self::assertStringContainsString( '## Older releases', $raw );
 		self::assertStringContainsString( '## Older releases', $plugin_raw );
 		foreach ( range( 1, 7 ) as $release_number ) {

--- a/scripts/tests/release-flags.test.mjs
+++ b/scripts/tests/release-flags.test.mjs
@@ -15,7 +15,7 @@ const docsFreshness = readFileSync(
 
 test('supported public betas are latest releases', () => {
 	assert.deepEqual(releaseFlags('1.0.0-beta.10', 'supported'), ['--latest']);
-	assert.deepEqual(releaseFlags('1.0.0-beta.11', 'supported'), ['--latest']);
+	assert.deepEqual(releaseFlags('1.0.0-beta.12', 'supported'), ['--latest']);
 });
 
 test('preview beta and rc versions are prereleases', () => {
@@ -69,12 +69,12 @@ test('archive inspections remain reliable with pipefail enabled', () => {
 test('README exposes one validated supported public beta path', () => {
 	assert.match(readme, /<!-- supported-release:start -->/);
 	assert.match(readme, /<!-- supported-release:end -->/);
-	assert.match(readme, /Current release: 1\.0\.0-beta\.11 — Public Beta/);
-	assert.match(readme, /releases\/tag\/v1\.0\.0-beta\.11/);
-	assert.match(readme, /releases\/download\/v1\.0\.0-beta\.11\/stonewright-1\.0\.0-beta\.11\.zip/);
-	assert.match(readme, /releases\/download\/v1\.0\.0-beta\.11\/stonewright-companion-1\.0\.0-beta\.11\.tgz/);
-	assert.match(readme, /releases\/download\/v1\.0\.0-beta\.11\/SHA256SUMS\.txt/);
-	assert.doesNotMatch(readme, /1\.0\.0-beta\.11.*not released/i);
+	assert.match(readme, /Current release: 1\.0\.0-beta\.12 — Public Beta/);
+	assert.match(readme, /releases\/tag\/v1\.0\.0-beta\.12/);
+	assert.match(readme, /releases\/download\/v1\.0\.0-beta\.12\/stonewright-1\.0\.0-beta\.12\.zip/);
+	assert.match(readme, /releases\/download\/v1\.0\.0-beta\.12\/stonewright-companion-1\.0\.0-beta\.12\.tgz/);
+	assert.match(readme, /releases\/download\/v1\.0\.0-beta\.12\/SHA256SUMS\.txt/);
+	assert.doesNotMatch(readme, /1\.0\.0-beta\.12.*not released/i);
 	assert.match(readme, /docs\/installation\.md/);
 	assert.match(docsFreshness, /supported-release:start/);
 });


### PR DESCRIPTION
## Release decision record

- **User-visible change:** Supported public beta bundling update reliability (#65), audit lifecycle (#66), Elementor provider router (#67), Elementor CSS safety (#68), and formatted View details release notes (#69), plus Task 4 architecture diagram and same-version updater test.
- **Artifacts:** `stonewright-1.0.0-beta.12.zip`, `stonewright-companion-1.0.0-beta.12.tgz`, `stonewright-visual-*.tgz`, `SHA256SUMS.txt`, `docs/releases/1.0.0-beta.12.md`.
- **Recommended class:** supported public beta (`Release channel: supported`, GitHub Latest, not Pre-release).
- **SemVer:** `1.0.0-beta.12`.
- **Evidence:** Local gates green for plugin PHPUnit 8002/44020, PHPStan, PHPCS 849/849, security/dependency audits, docs freshness (388 abilities / 101 Direct tools), visual build/tests, package-verify. Known local flake: one concurrent Direct audit rotation timeout under load; CI matrix is authoritative.
- **Known gaps:** Full multi-client restart matrix (§9.4) remains post-release UAT on Transavia Local; no live-site mutations.
- **Risk / rollback:** Reinstall prior ZIP or rollback via WordPress; companion package ref revert + client restart. CSS safety uses bounded rollback; updater is checksum-gated.
- **Docs changed:** root/plugin/companion changelogs, README supported-release block, `docs/releases/1.0.0-beta.12.md`, `docs/architecture.md`, release-flags test.

## Abilities / gates

- No new write abilities in this PR (version/docs/release only).
- Backup, token, permission, validation, and audit gates unchanged.

## Test plan

- [ ] CI all 11 jobs green on merge commit
- [ ] Tag `v1.0.0-beta.12` via official release workflow
- [ ] Verify GitHub Latest=true, Pre-release=false, artifacts + checksums
- [ ] Transavia Local: native updater offers beta.12 from beta.11.1, install, View details formatted, client restart + MCP smoke


Made with [Cursor](https://cursor.com)