### PR TITLE
Release candidate: 1.0.0-beta.13.1 updater discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,21 @@ override default behavior.
    explicitly asks the agent to perform that approval step. Pluginless Direct
    mode may inspect custom CSS but must not write it because it has no
    authenticated wp-admin grant boundary.
-9. **GitHub release notes are untrusted Markdown.** Every updater or release
+9. **Updater contract is part of every user-consumed release.** Do not ship a
+   version, tag, or GitHub release that operators should install unless all of
+   the following are true in the published artifacts (not only in source):
+   plugin `Version` / `STONEWRIGHT_VERSION`, companion `package.json` and
+   `companion/src/version.ts`, and the GitHub tag equal the same SemVer;
+   the GitHub release body contains exactly one line ``Release channel: `supported` ``
+   (or `preview` / `stable` as chosen in the release decision record);
+   GitHub `prerelease` is false for `supported` and `stable`, true for `preview`;
+   assets are exactly `stonewright-VERSION.zip`, `stonewright-companion-VERSION.tgz`,
+   and `SHA256SUMS.txt`; `GitHubUpdater` would select that release for a site
+   still on the previous same-channel version. After publish, a WordPress
+   Dashboard → Updates → Check again (or `wp_update_plugins`) must be able to
+   see `new_version` equal to that tag. Never treat changelog-only or
+   "the ZIP exists" as enough. Never skip this checklist to save a step.
+10. **GitHub release notes are untrusted Markdown.** Every updater or release
    implementation must:
    1. treat GitHub release bodies as untrusted Markdown input;
    2. keep release-channel parsing on the original raw body;
@@ -162,6 +176,10 @@ npm run build
 - Release notes must declare exactly one channel: `supported`, `preview`, or
   `stable`. Release automation must validate the declaration against SemVer and
   fail closed for missing, unknown, or incompatible combinations.
+- The updater contract in Hard rule 9 is a release blocker. A supported
+  public beta that WordPress cannot discover is not shippable.
+- The updater contract in Hard rule 9 is a release blocker. A supported
+  public beta that WordPress cannot discover is not shippable.
 
 ### Stable 1.0 gates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ development builds were never stable releases.
 
 - Nothing yet.
 
+## [1.0.0-beta.13.1] - 2026-08-26
+
+### Fixed
+
+- Refetch GitHub Releases during WordPress plugin update checks so a newer
+  supported beta appears on Dashboard → Updates instead of a stale cached
+  "you are current" payload.
+
 ## [1.0.0-beta.13] - 2026-08-25
 
 ### Added
@@ -450,32 +458,9 @@ development builds were never stable releases.
 - Remove packaged industry landing-page playbooks from the skills catalog.
   Already-seeded playbook rows are retired on seed and on plugin upgrade.
 
-## [1.0.0-beta.10] - 2026-08-12
-
-### Added
-
-- Add a typed verified-repair recorder, canonical incident lifecycle metadata,
-  ranked task-start repair actions, stale-on-recurrence learning, and an
-  isolated private Direct incident store.
-- Add evidence-backed Elementor, custom-code, and repeated-failure use cases
-  plus a generic API-bridge comparison and verified-learning guide.
-
-### Changed
-
-- Lead onboarding with the inspect-to-restore proof chain and reduce the
-  default Plugin connection to four steps; advanced transports, profiles,
-  Direct mode, and browser choices remain progressively disclosed.
-- Expose the generated 361-ability Plugin and 101-tool Direct contracts.
-- Replace the root license summary with the canonical GNU AGPL v3 text, add a
-  component license map, and verify Plugin, Visual, and Companion metadata in
-  CI and release gates.
-- Select native Plugin and companion updates from the installed SemVer channel,
-  with isolated caches and exact trusted assets; future prerelease tags are
-  published as prereleases while stable tags alone become GitHub's latest
-  release.
-
 ## Older releases
 
+- [1.0.0-beta.10](docs/releases/1.0.0-beta.10.md)
 - [1.0.0-beta.9](docs/releases/1.0.0-beta.9.md)
 - [1.0.0-beta.8](docs/releases/1.0.0-beta.8.md)
 - [1.0.0-beta.7](docs/releases/1.0.0-beta.7.md)

--- a/README.md
+++ b/README.md
@@ -19,17 +19,17 @@
 </p>
 
 <!-- supported-release:start -->
-<p align="center"><strong>Current release: 1.0.0-beta.13 — Public Beta</strong></p>
+<p align="center"><strong>Current release: 1.0.0-beta.13.1 — Public Beta</strong></p>
 <p align="center">
-  <a href="https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.13/stonewright-1.0.0-beta.13.zip">Download Plugin</a>
+  <a href="https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.13.1/stonewright-1.0.0-beta.13.1.zip">Download Plugin</a>
   ·
   <a href="docs/installation.md">Installation guide</a>
   ·
-  <a href="https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.13/stonewright-companion-1.0.0-beta.13.tgz">Companion</a>
+  <a href="https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.13.1/stonewright-companion-1.0.0-beta.13.1.tgz">Companion</a>
   ·
-  <a href="https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.13/SHA256SUMS.txt">Checksums</a>
+  <a href="https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.13.1/SHA256SUMS.txt">Checksums</a>
   ·
-  <a href="https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/tag/v1.0.0-beta.13">Release notes</a>
+  <a href="https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/tag/v1.0.0-beta.13.1">Release notes</a>
 </p>
 <p align="center"><sub>Preview builds appear on the complete Releases page and are not recommended by default.</sub></p>
 <!-- supported-release:end -->

--- a/companion/CHANGELOG.md
+++ b/companion/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 - Nothing yet.
 
+## [1.0.0-beta.13.1] - 2026-08-26
+
+### Fixed
+
+- Align companion package version with the plugin updater-discovery patch so
+  WordPress and companion stay on the same SemVer after release.
+
 ## [1.0.0-beta.13] - 2026-08-25
 
 ### Added

--- a/companion/package-lock.json
+++ b/companion/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@stonewright/companion",
-	"version": "1.0.0-beta.13",
+	"version": "1.0.0-beta.13.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@stonewright/companion",
-			"version": "1.0.0-beta.13",
+			"version": "1.0.0-beta.13.1",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/companion/package.json
+++ b/companion/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@stonewright/companion",
-	"version": "1.0.0-beta.13",
+	"version": "1.0.0-beta.13.1",
 	"description": "Node companion for the Stonewright WordPress MCP plugin: WP-CLI, health checks, and optional MCP HTTP proxy.",
 	"type": "module",
 	"license": "MIT",

--- a/companion/src/version.ts
+++ b/companion/src/version.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = '1.0.0-beta.13';
+export const APP_VERSION = '1.0.0-beta.13.1';
 
 export function companionPackageSpec(version: string = APP_VERSION): string {
 	return `https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v${version}/stonewright-companion-${version}.tgz`;

--- a/docs/releases/1.0.0-beta.13.1.md
+++ b/docs/releases/1.0.0-beta.13.1.md
@@ -1,0 +1,47 @@
+# Stonewright 1.0.0-beta.13.1
+
+Released: 2026-08-26
+
+Release channel: `supported`
+
+## Summary
+
+This supported public beta patch makes WordPress discover a newer Stonewright
+GitHub release during the native update check. Plugin and companion stay
+aligned on `1.0.0-beta.13.1`.
+
+Sites that cached an older "you are current" GitHub payload for 12 hours did
+not show Dashboard → Updates rows after a later supported beta was published,
+even after Check again. Update checks now refetch GitHub Releases; ordinary
+admin page loads still use the cache.
+
+## Fixed
+
+- Refetch GitHub Releases when WordPress runs `wp_update_plugins` or the
+  operator clicks Check again, so a newer supported beta is not hidden behind
+  a stale 12-hour cache of the installed version.
+
+## Upgrade
+
+Open Dashboard → Updates and click Check again, then update Stonewright. If
+the row is still missing on beta.12, open Stonewright → Setup, click Check
+latest companion, reload Updates, or install the published ZIP with Replace
+current with uploaded. Update the companion package reference to the published
+beta.13.1 asset, fully restart the MCP client, then run:
+
+```bash
+npx -y --package <published-companion-package> stonewright connect verify <alias> --client <client>
+```
+
+Success requires the requested alias, expected companion version,
+`stonewright-task-start`, status availability, and an empty
+`refresh_required_tool_names` list.
+
+## Compatibility and safety
+
+- WordPress plugin and companion: `1.0.0-beta.13.1`.
+- Plugin mode ability count is unchanged from beta.13.
+- WordPress: 6.7 or newer.
+- PHP: 8.1 or newer.
+- Node.js: 20 or newer for the companion.
+- Updates preserve existing memory, user skills, audit history, and Direct state.

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 - Nothing yet.
 
+## [1.0.0-beta.13.1] - 2026-08-26
+
+### Fixed
+
+- Refetch GitHub Releases during WordPress plugin update checks so a newer
+  supported beta appears on Dashboard → Updates instead of a stale cached
+  "you are current" payload.
+
 ## [1.0.0-beta.13] - 2026-08-25
 
 ### Added
@@ -393,26 +401,9 @@
 - Stop the Block Editor Queue iframe from autosaving queued blocks into the live
   post before `blocks-finalize-batch`.
 
-## [1.0.0-beta.10] - 2026-08-12
-
-### Added
-
-- Add `stonewright/incident-repair-record` for persisted, correlated repair
-  receipts and one read-back verified reusable lesson.
-- Add canonical incident repair, learning, reopen, and stale metadata plus
-  ranked compact task-start actions.
-
-### Changed
-
-- Stop generic successful audit events from resolving incidents or promoting
-  audit-derived learning. Explicit user corrections remain immediately
-  recordable.
-- Keep Plugin and companion update discovery on the installed stable or
-  prerelease channel, using channel-specific caches and exact trusted release
-  assets without cross-channel fallback.
-
 ## Older releases
 
+- [1.0.0-beta.10](../docs/releases/1.0.0-beta.10.md)
 - [1.0.0-beta.9](../docs/releases/1.0.0-beta.9.md)
 - [1.0.0-beta.8](../docs/releases/1.0.0-beta.8.md)
 - [1.0.0-beta.7](../docs/releases/1.0.0-beta.7.md)

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,6 +1,6 @@
 # Stonewright Plugin
 
-Version: 1.0.0-beta.13
+Version: 1.0.0-beta.13.1
 Requires WordPress: 6.7+
 Requires PHP: 8.1+
 License: [AGPL-3.0-or-later](../LICENSE)

--- a/plugin/includes/Admin/ConfigurationPage.php
+++ b/plugin/includes/Admin/ConfigurationPage.php
@@ -970,7 +970,7 @@ final class ConfigurationPage {
 										<?php
 										printf(
 											/* translators: %s: WordPress Updates URL. */
-											wp_kses_post( __( 'Open <a href="%s">Dashboard → Updates</a> and update Stonewright. If no update appears, upload the new release ZIP and choose Replace current with uploaded.', 'stonewright' ) ),
+											wp_kses_post( __( 'Open <a href="%s">Dashboard → Updates</a>, click Check again, then update Stonewright. Check again refetches GitHub Releases. If the row is still missing, click Check latest companion on this page, reload Updates, or upload the release ZIP and choose Replace current with uploaded.', 'stonewright' ) ),
 											esc_url( admin_url( 'update-core.php' ) )
 										);
 										?>

--- a/plugin/includes/Core/GitHubUpdater.php
+++ b/plugin/includes/Core/GitHubUpdater.php
@@ -26,6 +26,7 @@ final class GitHubUpdater {
 
 	public static function register(): void {
 		add_filter( 'site_transient_update_plugins', [ self::class, 'inject_update' ] );
+		add_filter( 'pre_set_site_transient_update_plugins', [ self::class, 'inject_update' ] );
 		add_filter( 'plugins_api', [ self::class, 'plugins_api' ], 10, 3 );
 		add_filter( 'upgrader_pre_download', [ self::class, 'verify_package_download' ], 10, 4 );
 	}
@@ -151,11 +152,12 @@ final class GitHubUpdater {
 			$transient->no_update = [];
 		}
 
-		$remote = self::fetch_latest_release();
-		$plugin = self::plugin_basename();
+		$remote  = self::fetch_latest_release( self::wordpress_requested_fresh_release_lookup() );
+		$plugin  = self::plugin_basename();
 		$current = self::installed_version();
 
 		if ( null === $remote || '' === ( $remote['checksums'] ?? '' ) || ! version_compare( $current, $remote['version'], '<' ) ) {
+			unset( $transient->response[ $plugin ] );
 			$transient->no_update[ $plugin ] = (object) [
 				'slug'        => self::SLUG,
 				'plugin'      => $plugin,
@@ -166,6 +168,7 @@ final class GitHubUpdater {
 			return $transient;
 		}
 
+		unset( $transient->no_update[ $plugin ] );
 		$transient->response[ $plugin ] = (object) [
 			'slug'        => self::SLUG,
 			'plugin'      => $plugin,
@@ -413,6 +416,27 @@ final class GitHubUpdater {
 				),
 			],
 		];
+	}
+
+	/**
+	 * WordPress Dashboard → Updates → Check again and the twice-daily
+	 * wp_update_plugins cron must not reuse a cached "you are current" release.
+	 * Ordinary Plugins-screen reads keep CACHE_TTL to avoid GitHub rate limits.
+	 */
+	private static function wordpress_requested_fresh_release_lookup(): bool {
+		if ( function_exists( 'doing_action' ) && doing_action( 'wp_update_plugins' ) ) {
+			return true;
+		}
+		if ( function_exists( 'did_action' ) && did_action( 'wp_update_plugins' ) > 0 ) {
+			return true;
+		}
+		// WordPress core exposes force-check as an unauthenticated GET flag on update-core.php; capability is checked below.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- matches core update-core.php force-check.
+		$force_check = isset( $_GET['force-check'] ) ? sanitize_text_field( wp_unslash( (string) $_GET['force-check'] ) ) : '';
+		if ( '' === $force_check || '0' === $force_check ) {
+			return false;
+		}
+		return ! function_exists( 'current_user_can' ) || current_user_can( 'update_plugins' );
 	}
 
 	/**

--- a/plugin/stonewright.php
+++ b/plugin/stonewright.php
@@ -3,7 +3,7 @@
  * Plugin Name: Stonewright
  * Plugin URI: https://github.com/cosmincraciun97/stonewright-wp-mcp
  * Description: Guarded WordPress MCP tools for Elementor, Gutenberg/FSE, WooCommerce catalogs, content models, PHP runtime execution, and tokenized WP-CLI.
- * Version: 1.0.0-beta.13
+ * Version: 1.0.0-beta.13.1
  * Requires at least: 6.7
  * Requires PHP: 8.1
  * Author: Stonewright
@@ -33,7 +33,7 @@ if ( defined( 'STONEWRIGHT_FILE' ) ) {
 define( 'STONEWRIGHT_FILE', __FILE__ );
 define( 'STONEWRIGHT_DIR', plugin_dir_path( __FILE__ ) );
 define( 'STONEWRIGHT_URL', plugin_dir_url( __FILE__ ) );
-define( 'STONEWRIGHT_VERSION', '1.0.0-beta.13' );
+define( 'STONEWRIGHT_VERSION', '1.0.0-beta.13.1' );
 define( 'STONEWRIGHT_MIN_PHP', '8.1' );
 define( 'STONEWRIGHT_MIN_WP', '6.7' );
 

--- a/plugin/tests/Unit/Core/GitHubUpdaterTest.php
+++ b/plugin/tests/Unit/Core/GitHubUpdaterTest.php
@@ -19,6 +19,9 @@ final class GitHubUpdaterTest extends TestCase {
 		$GLOBALS['stonewright_test_download_url']         = null;
 		$GLOBALS['stonewright_test_wp_kses_calls']        = [];
 		$GLOBALS['stonewright_test_wp_kses_post_calls']   = [];
+		$GLOBALS['stonewright_test_did_actions']          = [];
+		$GLOBALS['stonewright_test_doing_action']         = [];
+		$_GET = [];
 	}
 
 	protected function tearDown(): void {
@@ -29,6 +32,9 @@ final class GitHubUpdaterTest extends TestCase {
 		$GLOBALS['stonewright_test_download_url']         = null;
 		$GLOBALS['stonewright_test_wp_kses_calls']        = [];
 		$GLOBALS['stonewright_test_wp_kses_post_calls']   = [];
+		$GLOBALS['stonewright_test_did_actions']          = [];
+		$GLOBALS['stonewright_test_doing_action']         = [];
+		$_GET = [];
 	}
 
 	public function test_installed_channel_distinguishes_stable_and_prerelease_versions(): void {
@@ -271,6 +277,78 @@ final class GitHubUpdaterTest extends TestCase {
 		self::assertArrayNotHasKey( $plugin, $transient->response );
 		self::assertArrayHasKey( $plugin, $transient->no_update );
 		self::assertSame( $release['version'], $transient->no_update[ $plugin ]->new_version ?? null );
+	}
+
+	public function test_inject_update_keeps_stale_cached_release_on_ordinary_admin_reads(): void {
+		$this->set_installed_version( '1.0.0-beta.12' );
+		$stale = $this->parsed_beta_release();
+		$stale['version']           = '1.0.0-beta.12';
+		$stale['package']           = 'https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.12/stonewright-1.0.0-beta.12.zip';
+		$stale['companion_package'] = 'https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.12/stonewright-companion-1.0.0-beta.12.tgz';
+		$stale['checksums']         = 'https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.12/SHA256SUMS.txt';
+		$stale['url']               = 'https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/tag/v1.0.0-beta.12';
+		$this->cache_parsed_release( $stale, '1.0.0-beta.12' );
+		$supported_beta = $this->releases_fixture()[6];
+		$GLOBALS['stonewright_test_wp_remote_get'] = static fn(): array => [
+			'response' => [ 'code' => 200 ],
+			'body'     => (string) wp_json_encode( [ $supported_beta ] ),
+		];
+
+		$result = GitHubUpdater::inject_update( (object) [ 'response' => [], 'no_update' => [] ] );
+		$plugin = GitHubUpdater::plugin_basename();
+
+		self::assertArrayNotHasKey( $plugin, $result->response );
+		self::assertArrayHasKey( $plugin, $result->no_update );
+		self::assertCount( 0, $GLOBALS['stonewright_test_wp_remote_get_calls'] );
+	}
+
+	public function test_inject_update_refetches_during_wordpress_plugin_update_check(): void {
+		$this->set_installed_version( '1.0.0-beta.12' );
+		$stale = $this->parsed_beta_release();
+		$stale['version']           = '1.0.0-beta.12';
+		$stale['package']           = 'https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.12/stonewright-1.0.0-beta.12.zip';
+		$stale['companion_package'] = 'https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.12/stonewright-companion-1.0.0-beta.12.tgz';
+		$stale['checksums']         = 'https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.12/SHA256SUMS.txt';
+		$stale['url']               = 'https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/tag/v1.0.0-beta.12';
+		$this->cache_parsed_release( $stale, '1.0.0-beta.12' );
+		$supported_beta = $this->releases_fixture()[6];
+		$GLOBALS['stonewright_test_wp_remote_get'] = static fn(): array => [
+			'response' => [ 'code' => 200 ],
+			'body'     => (string) wp_json_encode( [ $supported_beta ] ),
+		];
+		$GLOBALS['stonewright_test_did_actions']['wp_update_plugins'] = 1;
+
+		$result = GitHubUpdater::inject_update( (object) [ 'response' => [ 'other/other.php' => (object) [] ], 'no_update' => [] ] );
+		$plugin = GitHubUpdater::plugin_basename();
+
+		self::assertSame( '1.3.0-beta.30', $result->response[ $plugin ]->new_version );
+		self::assertArrayNotHasKey( $plugin, $result->no_update );
+		self::assertArrayHasKey( 'other/other.php', $result->response );
+		self::assertGreaterThanOrEqual( 1, count( $GLOBALS['stonewright_test_wp_remote_get_calls'] ) );
+	}
+
+	public function test_inject_update_refetches_when_an_administrator_force_checks_updates(): void {
+		$this->set_installed_version( '1.0.0-beta.12' );
+		$stale = $this->parsed_beta_release();
+		$stale['version']           = '1.0.0-beta.12';
+		$stale['package']           = 'https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.12/stonewright-1.0.0-beta.12.zip';
+		$stale['companion_package'] = 'https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.12/stonewright-companion-1.0.0-beta.12.tgz';
+		$stale['checksums']         = 'https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.12/SHA256SUMS.txt';
+		$stale['url']               = 'https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/tag/v1.0.0-beta.12';
+		$this->cache_parsed_release( $stale, '1.0.0-beta.12' );
+		$supported_beta = $this->releases_fixture()[6];
+		$GLOBALS['stonewright_test_wp_remote_get'] = static fn(): array => [
+			'response' => [ 'code' => 200 ],
+			'body'     => (string) wp_json_encode( [ $supported_beta ] ),
+		];
+		$GLOBALS['stonewright_test_user_caps']['update_plugins'] = true;
+		$_GET['force-check'] = '1';
+
+		$result = GitHubUpdater::inject_update( (object) [ 'response' => [], 'no_update' => [ GitHubUpdater::plugin_basename() => (object) [ 'new_version' => '1.0.0-beta.12' ] ] ] );
+		$plugin = GitHubUpdater::plugin_basename();
+
+		self::assertSame( '1.3.0-beta.30', $result->response[ $plugin ]->new_version );
+		self::assertArrayNotHasKey( $plugin, $result->no_update );
 	}
 
 	public function test_transient_injection_refuses_cached_release_without_sha256sums(): void {

--- a/plugin/tests/Unit/Core/GitHubUpdaterTest.php
+++ b/plugin/tests/Unit/Core/GitHubUpdaterTest.php
@@ -598,6 +598,7 @@ final class GitHubUpdaterTest extends TestCase {
 	public function test_register_hooks_update_plugins_filter(): void {
 		GitHubUpdater::register();
 		self::assertArrayHasKey( 'site_transient_update_plugins', $GLOBALS['stonewright_test_filters'] );
+		self::assertArrayHasKey( 'pre_set_site_transient_update_plugins', $GLOBALS['stonewright_test_filters'] );
 		self::assertArrayHasKey( 'upgrader_pre_download', $GLOBALS['stonewright_test_filters'] );
 	}
 

--- a/plugin/tests/Unit/Support/ReleaseRetentionTest.php
+++ b/plugin/tests/Unit/Support/ReleaseRetentionTest.php
@@ -19,7 +19,7 @@ final class ReleaseRetentionTest extends TestCase {
 				$versioned[] = $name;
 			}
 		}
-		self::assertSame( [ '1.0.0-beta.1.md', '1.0.0-beta.10.md', '1.0.0-beta.11.1.md', '1.0.0-beta.11.md', '1.0.0-beta.12.md', '1.0.0-beta.13.md', '1.0.0-beta.2.md', '1.0.0-beta.3.md', '1.0.0-beta.4.md', '1.0.0-beta.5.md', '1.0.0-beta.6.md', '1.0.0-beta.7.md', '1.0.0-beta.8.md', '1.0.0-beta.9.md' ], $versioned );
+		self::assertSame( [ '1.0.0-beta.1.md', '1.0.0-beta.10.md', '1.0.0-beta.11.1.md', '1.0.0-beta.11.md', '1.0.0-beta.12.md', '1.0.0-beta.13.1.md', '1.0.0-beta.13.md', '1.0.0-beta.2.md', '1.0.0-beta.3.md', '1.0.0-beta.4.md', '1.0.0-beta.5.md', '1.0.0-beta.6.md', '1.0.0-beta.7.md', '1.0.0-beta.8.md', '1.0.0-beta.9.md' ], $versioned );
 	}
 
 	public function test_root_changelog_keeps_latest_five_releases_and_links_older_history(): void {
@@ -36,7 +36,7 @@ final class ReleaseRetentionTest extends TestCase {
 			)
 		);
 		self::assertContains( 'Unreleased', $headers );
-		self::assertSame( [ '1.0.0-beta.13', '1.0.0-beta.12', '1.0.0-beta.11.1', '1.0.0-beta.11', '1.0.0-beta.10' ], $versions );
+		self::assertSame( [ '1.0.0-beta.13.1', '1.0.0-beta.13', '1.0.0-beta.12', '1.0.0-beta.11.1', '1.0.0-beta.11' ], $versions );
 		self::assertStringContainsString( '## Older releases', $raw );
 		self::assertStringContainsString( '## Older releases', $plugin_raw );
 		foreach ( range( 1, 7 ) as $release_number ) {

--- a/plugin/tests/bootstrap.php
+++ b/plugin/tests/bootstrap.php
@@ -1595,10 +1595,20 @@ if ( ! function_exists( 'clean_post_cache' ) ) {
 
 if ( ! function_exists( 'did_action' ) ) {
 	function did_action( string $hook_name ): int {
+		$override = $GLOBALS['stonewright_test_did_actions'][ $hook_name ] ?? null;
+		if ( is_int( $override ) || is_numeric( $override ) ) {
+			return (int) $override;
+		}
 		if ( 'elementor/loaded' === $hook_name ) {
 			return 1;
 		}
 		return 0;
+	}
+}
+
+if ( ! function_exists( 'doing_action' ) ) {
+	function doing_action( string $hook_name ): bool {
+		return did_action( $hook_name ) > 0 && ! empty( $GLOBALS['stonewright_test_doing_action'][ $hook_name ] );
 	}
 }
 

--- a/scripts/tests/release-flags.test.mjs
+++ b/scripts/tests/release-flags.test.mjs
@@ -16,6 +16,7 @@ const docsFreshness = readFileSync(
 test('supported public betas are latest releases', () => {
 	assert.deepEqual(releaseFlags('1.0.0-beta.10', 'supported'), ['--latest']);
 	assert.deepEqual(releaseFlags('1.0.0-beta.13', 'supported'), ['--latest']);
+	assert.deepEqual(releaseFlags('1.0.0-beta.13.1', 'supported'), ['--latest']);
 });
 
 test('preview beta and rc versions are prereleases', () => {

--- a/scripts/tests/release-flags.test.mjs
+++ b/scripts/tests/release-flags.test.mjs
@@ -70,12 +70,12 @@ test('archive inspections remain reliable with pipefail enabled', () => {
 test('README exposes one validated supported public beta path', () => {
 	assert.match(readme, /<!-- supported-release:start -->/);
 	assert.match(readme, /<!-- supported-release:end -->/);
-	assert.match(readme, /Current release: 1\.0\.0-beta\.13 — Public Beta/);
-	assert.match(readme, /releases\/tag\/v1\.0\.0-beta\.13/);
-	assert.match(readme, /releases\/download\/v1\.0\.0-beta\.13\/stonewright-1\.0\.0-beta\.13\.zip/);
-	assert.match(readme, /releases\/download\/v1\.0\.0-beta\.13\/stonewright-companion-1\.0\.0-beta\.13\.tgz/);
-	assert.match(readme, /releases\/download\/v1\.0\.0-beta\.13\/SHA256SUMS\.txt/);
-	assert.doesNotMatch(readme, /1\.0\.0-beta\.13.*not released/i);
+	assert.match(readme, /Current release: 1\.0\.0-beta\.13\.1 — Public Beta/);
+	assert.match(readme, /releases\/tag\/v1\.0\.0-beta\.13\.1/);
+	assert.match(readme, /releases\/download\/v1\.0\.0-beta\.13\.1\/stonewright-1\.0\.0-beta\.13\.1\.zip/);
+	assert.match(readme, /releases\/download\/v1\.0\.0-beta\.13\.1\/stonewright-companion-1\.0\.0-beta\.13\.1\.tgz/);
+	assert.match(readme, /releases\/download\/v1\.0\.0-beta\.13\.1\/SHA256SUMS\.txt/);
+	assert.doesNotMatch(readme, /1\.0\.0-beta\.13\.1.*not released/i);
 	assert.match(readme, /docs\/installation\.md/);
 	assert.match(docsFreshness, /supported-release:start/);
 });


### PR DESCRIPTION
## Summary

- WordPress Dashboard → Updates → Check again and `wp_update_plugins` now refetch GitHub Releases instead of reusing a 12-hour "you are current" cache.
- Document the updater/release contract in agent rules so a public beta cannot ship without selectable GitHub metadata.
- Version bump to `1.0.0-beta.13.1` (supported public beta). **No tag yet.**

## Changed abilities

None. Backup, confirmation-token, permission, validation, and audit gates unchanged.

## Public docs

Root/plugin/companion changelogs, `docs/releases/1.0.0-beta.13.1.md`, Setup update copy, `AGENTS.md` / `CLAUDE.md` updater contract. Ability matrix unchanged (no ability surface change).

## Release decision record

Release class: supported public beta
Proposed SemVer: 1.0.0-beta.13.1
Channel declaration: supported
User-visible change: native WordPress update check discovers a newer supported GitHub release
Artifacts: plugin ZIP + companion package (on publish)
Evidence: PHPUnit GitHubUpdater tests including stale-cache vs force-check cases; 8136 plugin tests, companion suite, hygiene and docs freshness green
Known gaps: sites still on beta.12 keep the old updater until they refetch (Check latest companion, cache TTL, or 13.1 ZIP upload)
Risk: extra GitHub API calls only during WordPress update checks, not on every admin page load
Rollback: reinstall 1.0.0-beta.13 ZIP without deleting runtime data
Publication authorization: pending maintainer approval

## Test plan

- [x] `vendor/bin/phpunit --filter GitHubUpdaterTest` passes, including stale-cache vs force-check cases
- [x] Ordinary Plugins-screen read does not call GitHub when cache is warm
- [x] `did_action( 'wp_update_plugins' )` or `?force-check=1` with `update_plugins` capability refetches and queues `new_version`
- [x] `composer test`, `composer phpstan`, `composer phpcs`
- [x] `npm run typecheck && npm run lint && npm test && npm run build`
- [x] `node scripts/check-public-hygiene.mjs` and `node scripts/check-docs-freshness.mjs`
- [ ] After merge+publish (maintainer only): a site still on 1.0.0-beta.12 shows 1.0.0-beta.13.1 after Check again or Check latest companion

Made with [Cursor](https://cursor.com)