### PR TITLE
fix: one GitHub lookup per WordPress update cycle (beta.13.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ development builds were never stable releases.
 - Refetch GitHub Releases during WordPress plugin update checks so a newer
   supported beta appears on Dashboard → Updates instead of a stale cached
   "you are current" payload.
+- Force at most one uncached GitHub lookup per request during an update cycle
+  so a later transient write cannot rate-limit or wipe a successful discovery.
 
 ## [1.0.0-beta.13] - 2026-08-25
 

--- a/companion/CHANGELOG.md
+++ b/companion/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - Align companion package version with the plugin updater-discovery patch so
   WordPress and companion stay on the same SemVer after release.
+- Force at most one uncached GitHub lookup per request during an update cycle
+  so a later transient write cannot rate-limit or wipe a successful discovery.
 
 ## [1.0.0-beta.13] - 2026-08-25
 

--- a/docs/releases/1.0.0-beta.13.1.md
+++ b/docs/releases/1.0.0-beta.13.1.md
@@ -20,6 +20,8 @@ admin page loads still use the cache.
 - Refetch GitHub Releases when WordPress runs `wp_update_plugins` or the
   operator clicks Check again, so a newer supported beta is not hidden behind
   a stale 12-hour cache of the installed version.
+- Force at most one uncached GitHub lookup per request during an update cycle
+  so a later transient write cannot rate-limit or wipe a successful discovery.
 
 ## Upgrade
 

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Refetch GitHub Releases during WordPress plugin update checks so a newer
   supported beta appears on Dashboard → Updates instead of a stale cached
   "you are current" payload.
+- Force at most one uncached GitHub lookup per request during an update cycle
+  so a later transient write cannot rate-limit or wipe a successful discovery.
 
 ## [1.0.0-beta.13] - 2026-08-25
 

--- a/plugin/includes/Core/GitHubUpdater.php
+++ b/plugin/includes/Core/GitHubUpdater.php
@@ -24,6 +24,15 @@ final class GitHubUpdater {
 	private const RELEASE_CHANNELS = [ 'supported', 'preview', 'stable' ];
 	private const SEMVER_PATTERN = '/^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:(?:0|[1-9]\d*)|(?:\d*[A-Za-z-][0-9A-Za-z-]*))(?:\.(?:(?:0|[1-9]\d*)|(?:\d*[A-Za-z-][0-9A-Za-z-]*)))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/';
 
+	/**
+	 * One forced GitHub lookup per request. wp_update_plugins both reads and
+	 * writes the update_plugins transient, which would otherwise double-fetch
+	 * and let a later failure wipe a successful discovery.
+	 *
+	 * @var bool
+	 */
+	private static bool $forced_release_lookup_used = false;
+
 	public static function register(): void {
 		add_filter( 'site_transient_update_plugins', [ self::class, 'inject_update' ] );
 		add_filter( 'pre_set_site_transient_update_plugins', [ self::class, 'inject_update' ] );
@@ -422,12 +431,21 @@ final class GitHubUpdater {
 	 * WordPress Dashboard → Updates → Check again and the twice-daily
 	 * wp_update_plugins cron must not reuse a cached "you are current" release.
 	 * Ordinary Plugins-screen reads keep CACHE_TTL to avoid GitHub rate limits.
+	 *
+	 * Only the first forced lookup in a request hits GitHub. Later inject_update
+	 * calls (get then set of the same transient during wp_update_plugins) reuse
+	 * the warm cache so a second failure cannot erase a successful discovery.
 	 */
 	private static function wordpress_requested_fresh_release_lookup(): bool {
+		if ( self::$forced_release_lookup_used ) {
+			return false;
+		}
 		if ( function_exists( 'doing_action' ) && doing_action( 'wp_update_plugins' ) ) {
+			self::$forced_release_lookup_used = true;
 			return true;
 		}
 		if ( function_exists( 'did_action' ) && did_action( 'wp_update_plugins' ) > 0 ) {
+			self::$forced_release_lookup_used = true;
 			return true;
 		}
 		// WordPress core exposes force-check as an unauthenticated GET flag on update-core.php; capability is checked below.
@@ -436,7 +454,18 @@ final class GitHubUpdater {
 		if ( '' === $force_check || '0' === $force_check ) {
 			return false;
 		}
-		return ! function_exists( 'current_user_can' ) || current_user_can( 'update_plugins' );
+		if ( function_exists( 'current_user_can' ) && ! current_user_can( 'update_plugins' ) ) {
+			return false;
+		}
+		self::$forced_release_lookup_used = true;
+		return true;
+	}
+
+	/**
+	 * Reset per-request force-lookup state. Used by unit tests only.
+	 */
+	public static function reset_request_lookup_state(): void {
+		self::$forced_release_lookup_used = false;
 	}
 
 	/**

--- a/plugin/tests/Unit/Core/GitHubUpdaterTest.php
+++ b/plugin/tests/Unit/Core/GitHubUpdaterTest.php
@@ -22,6 +22,7 @@ final class GitHubUpdaterTest extends TestCase {
 		$GLOBALS['stonewright_test_did_actions']          = [];
 		$GLOBALS['stonewright_test_doing_action']         = [];
 		$_GET = [];
+		GitHubUpdater::reset_request_lookup_state();
 	}
 
 	protected function tearDown(): void {
@@ -35,6 +36,7 @@ final class GitHubUpdaterTest extends TestCase {
 		$GLOBALS['stonewright_test_did_actions']          = [];
 		$GLOBALS['stonewright_test_doing_action']         = [];
 		$_GET = [];
+		GitHubUpdater::reset_request_lookup_state();
 	}
 
 	public function test_installed_channel_distinguishes_stable_and_prerelease_versions(): void {
@@ -349,6 +351,51 @@ final class GitHubUpdaterTest extends TestCase {
 
 		self::assertSame( '1.3.0-beta.30', $result->response[ $plugin ]->new_version );
 		self::assertArrayNotHasKey( $plugin, $result->no_update );
+	}
+
+	public function test_inject_update_force_refreshes_github_only_once_per_request(): void {
+		$this->set_installed_version( '1.0.0-beta.12' );
+		$stale = $this->parsed_beta_release();
+		$stale['version']           = '1.0.0-beta.12';
+		$stale['package']           = 'https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.12/stonewright-1.0.0-beta.12.zip';
+		$stale['companion_package'] = 'https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.12/stonewright-companion-1.0.0-beta.12.tgz';
+		$stale['checksums']         = 'https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.12/SHA256SUMS.txt';
+		$stale['url']               = 'https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/tag/v1.0.0-beta.12';
+		$this->cache_parsed_release( $stale, '1.0.0-beta.12' );
+		$supported_beta = $this->releases_fixture()[6];
+		$calls          = 0;
+		$GLOBALS['stonewright_test_wp_remote_get'] = static function () use ( &$calls, $supported_beta ): array {
+			++$calls;
+			if ( 1 === $calls ) {
+				return [
+					'response' => [ 'code' => 200 ],
+					'body'     => (string) wp_json_encode( [ $supported_beta ] ),
+				];
+			}
+			return [
+				'response' => [ 'code' => 403 ],
+				'body'     => '{"message":"API rate limit exceeded"}',
+			];
+		};
+		$GLOBALS['stonewright_test_did_actions']['wp_update_plugins'] = 1;
+
+		$plugin = GitHubUpdater::plugin_basename();
+		$first  = GitHubUpdater::inject_update( (object) [ 'response' => [], 'no_update' => [] ] );
+		self::assertSame( '1.3.0-beta.30', $first->response[ $plugin ]->new_version );
+		self::assertSame( 1, $calls );
+
+		// Simulate the second hook in the same wp_update_plugins cycle (get then set).
+		// A second forced GitHub call that fails must not wipe the discovered update.
+		$second = GitHubUpdater::inject_update(
+			(object) [
+				'response'  => [ $plugin => $first->response[ $plugin ] ],
+				'no_update' => [],
+			]
+		);
+		self::assertSame( '1.3.0-beta.30', $second->response[ $plugin ]->new_version );
+		self::assertArrayNotHasKey( $plugin, $second->no_update );
+		self::assertSame( 1, $calls, 'only one uncached GitHub lookup per request' );
+		self::assertCount( 1, $GLOBALS['stonewright_test_wp_remote_get_calls'] );
 	}
 
 	public function test_transient_injection_refuses_cached_release_without_sha256sums(): void {


### PR DESCRIPTION
## Summary

- Codex P1 on the beta.13.1 updater work: `wp_update_plugins` both reads and writes `update_plugins`, so both `site_transient_*` and `pre_set_site_transient_*` forced a fresh GitHub call. A later failure could wipe a successful discovery.
- Cap forced lookups to one per request; later injects reuse the warm cache.
- Unpublished `v1.0.0-beta.13.1` tag/release workflow was cancelled before assets published.

## Changed abilities

None. Gates unchanged.

## Public docs

Release notes + changelogs for `1.0.0-beta.13.1` mention the once-per-cycle guard.

## Test plan

- [x] `vendor/bin/phpunit --filter GitHubUpdaterTest` including `test_inject_update_force_refreshes_github_only_once_per_request`
- [x] First inject during `wp_update_plugins` discovers update; second inject with a failing GitHub mock keeps the update and makes zero extra remote calls
- [ ] CI green, then re-tag `v1.0.0-beta.13.1` (maintainer already approved publish)

Made with [Cursor](https://cursor.com)