### PR TITLE
1.0.0-beta.13.2: bundled skills, View details cache, Atomic prop descriptors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,7 @@ jobs:
             --exclude phpcs.xml \
             --exclude phpunit.xml \
             --exclude phpunit.xml.dist
+          rsync -a skills/ dist/stonewright/skills/
           cp LICENSE dist/stonewright/LICENSE
           STONEWRIGHT_PRIVATE_TERMS="${{ secrets.STONEWRIGHT_PRIVATE_TERMS }}" \
             node scripts/check-public-hygiene.mjs \
@@ -135,6 +136,14 @@ jobs:
           fi
           if ! unzip -Z1 "dist/stonewright-${version}.zip" | grep -E '^stonewright/assets/visual/workspace-browser\.js$' >/dev/null; then
             echo "Plugin archive is missing the Stonewright Visual bundle" >&2
+            exit 1
+          fi
+          if ! unzip -Z1 "dist/stonewright-${version}.zip" | grep -E '^stonewright/skills/agent-operating-rules/SKILL\.md$' >/dev/null; then
+            echo 'plugin zip is missing the bundled skill pack' >&2
+            exit 1
+          fi
+          if ! unzip -Z1 "dist/stonewright-${version}.zip" | grep -E '^stonewright/skills/playbooks/' >/dev/null; then
+            echo 'plugin zip is missing the bundled playbooks' >&2
             exit 1
           fi
           (cd dist && sha256sum "stonewright-${version}.zip" stonewright-companion-*.tgz stonewright-visual-*.tgz > SHA256SUMS.txt)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,13 @@ override default behavior.
    Dashboard → Updates → Check again (or `wp_update_plugins`) must be able to
    see `new_version` equal to that tag. Never treat changelog-only or
    "the ZIP exists" as enough. Never skip this checklist to save a step.
+- After the plugin updates itself, release metadata caches must be
+  invalidated; Plugins → View details must never render a release older
+  than the installed version.
+- The plugin release ZIP must bundle the built-in skill pack
+  (`skills/` inside the plugin directory) and release packaging must fail
+  closed when it is missing, so ZIP installs seed the same built-in
+  skills as repository checkouts.
 10. **GitHub release notes are untrusted Markdown.** Every updater or release
    implementation must:
    1. treat GitHub release bodies as untrusted Markdown input;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,20 @@ development builds were never stable releases.
 
 - Nothing yet.
 
+## [1.0.0-beta.13.2] - 2026-08-26
+
+### Fixed
+
+- Bundle built-in skills and playbooks in the plugin ZIP and seed them from
+  the plugin directory, so ZIP installs show the full Skills catalog and MCP
+  task-start serves the built-in pack.
+- Refetch GitHub Releases for Plugins → View details when the cached release
+  is older than the installed version, and purge release caches after the
+  plugin updates itself.
+- Normalize Elementor 4.2+ Atomic props whose serialization nests empty
+  object metadata, removing repeated "Prop descriptor unavailable"
+  Troubleshoot diagnostics and restoring the Atomic widget inventory.
+
 ## [1.0.0-beta.13.1] - 2026-08-26
 
 ### Fixed
@@ -270,198 +284,9 @@ development builds were never stable releases.
   declared supported, preview, and stable release channels before selecting an
   eligible update.
 
-## [1.0.0-beta.11] - 2026-08-22
-
-### Added
-
-- Add a renderer-aware motion train with capability discovery, strict
-  DesignSpec motion semantics, seven bundled static-first presets, read-only
-  suggestions and signed plans, plus guarded Gutenberg/FSE and Elementor V3
-  apply abilities.
-- Add optional motion and UI-excellence evidence to
-  `stonewright/design-quality-check`, so accessibility, editor parity, and
-  controlled performance findings participate in real and persisted verdicts.
-- Add verified design-direction deactivation through the existing
-  `stonewright/design-direction-activate` ability (`id: 0`), with a matching
-  admin Active toggle that autosubmits and reports failures honestly.
-- Add an explicit `stonewright/blocks-finalizer-cancel` ability that removes
-  queued, serialized, or failed finalizer records by id with dry-run support,
-  per-post permission checks, production-safe confirmation tokens, atomic
-  single-save deletion, and verified readback.
-
-- Add a Connect → Troubleshoot page that runs connection diagnostics in place
-  with a loading state, result cards, a copyable support report, bot/WAF
-  probes, OAuth registration checks, and a clipboard fallback.
-- Add a discover-execute MCP profile with three protocol tools for catalog
-  discovery and gated execution without exposing the full tool list.
-- Default Gutenberg block parse, registered-block list, and theme.json reads to
-  bounded summaries, with `responseMode=full` restoring the previous dumps.
-- Add read-only GenerateBlocks, Kadence Blocks, Spectra, and Blocksy library
-  introspection, plus Blocksy/Kadence/GeneratePress theme chrome get/update.
-- Add presence-gated Blocksy, Kadence, GenerateBlocks, and Spectra build-page
-  skills that compose through the Gutenberg finalizer, plus builder operating
-  manuals and ACF, SEO, and forms skills.
-- Add typed query-loop, FSE navigation, and synced-pattern update/delete/category
-  abilities, plus a child-theme theme.json handoff that stops at human approval.
-- Add a read-only Elementor performance audit ability reporting bounded document,
-  settings, backup, and revision size metrics without exposing content.
-- Add a browser-assisted Gutenberg block finalizer that serializes queued block
-  specs in the live editor iframe, persists path-aware hashed HTML through
-  existing backup, confirmation, and audit gates, and shows a Block Editor Queue
-  with heartbeat status. Partial block schemas stay marked as live-editor
-  validated.
-- Add Elementor list-widgets summary mode and optional full Design Direction
-  document loading from `stonewright/design-direction-brief`.
-- Add reviewable draft lessons when the same recurring error reaches ten repeats.
-- Add a Delete all logs control on the Audit Log page with inline DELETE confirmation, and a Block Editor Queue status strip with last-poll time and per-item status.
-
-### Security
-
-- Sign compiled motion plans with a site-bound HMAC and reject operation,
-  preset, asset, renderer, capability-digest, or design-direction drift before
-  dry-run and apply. Bind Elementor V3 motion evidence to the intended
-  capability and exact live schema/runtime/source identity.
-- Block Elementor `custom_css` / `_custom_css` writes and HTML widget `<style>` tags unless a consumed `custom_code_grant` accompanies the call, and allow `_css_classes` only from the `approved_css_classes` allowlist.
-- Block php-execute from calling `wp_update_custom_css_post` or writing kit/page custom CSS; those writes must use `stonewright/theme-custom-css`.
-- Enforce php-execute read-only at runtime, block concatenated protected meta
-  keys and direct database writes to core tables, and keep php-execute off the
-  default compact MCP surfaces.
-- Sign one-time admin login links, bind them to IP and User-Agent, rate-limit
-  issuance, skip remember-me cookies, and require confirmation in production-safe
-  mode.
-- Restrict REST ability execution to the active tool profile unless confirmed,
-  and require a confirmation token to toggle abilities over REST.
-- Require production-safe confirmation tokens on remaining content, Elementor,
-  Gutenberg, site, and admin-domain writers.
-- Require a human-issued `custom_code_grant` (and `allow_raw_html` for Gutenberg HTML) before raw `<style>` payloads, theme.json `css`, and all-raw-HTML block trees; do not strip the CSS.
-- Isolate the Gutenberg finalizer queue per owner, session, and target post:
-  state v2 records carry owner/session/post, tokens are HMAC-bound to all four
-  values, REST/AJAX/MCP results are scoped, replay after terminal states is
-  refused, legacy unbound records fail closed, and mutations run under a
-  bounded mutex. Hard limits now bound batch size, open records, payload
-  bytes, tree depth/nodes, serialized HTML, and total queue state, with
-  retention pruning for terminal records.
-
-### Fixed
-
-- Keep every Stonewright admin navigation link visible and contained at 320px
-  and 390px by allowing multi-link header groups to wrap inside the mobile
-  shell.
-- Register the conditional motion asset loader during plugin boot, distinguish
-  load from viewport entrances, make stagger configuration executable, restore
-  link-underline rendering, make played states outrank their initial hidden
-  states, and make the runtime fail open with page-cache and live
-  reduced-motion reinitialization.
-- Report Elementor V4 interaction triggers, breakpoint support, schema
-  fingerprint, and official write-primitives readiness from the loaded runtime;
-  refuse native V4 motion plans while the required typed mutation stack is
-  unavailable.
-- Fix the security-audit assert-call detector to use token-based PHP parsing:
-  method calls such as grant-gate assertions no longer produce false
-  positives, while functional `assert()` calls on strings or variables stay
-  blocked.
-- Return `schema_requests` when Elementor `require_evidence` writes are incomplete, copy those requests (and custom-CSS grant keys) into the MCP-visible error message so agents are not stuck with a one-line rejection, accept active-direction provenance for token-derived settings, honor batch or per-operation `responsive_scope` so tablet and mobile keys can be written without weakening the desktop-only default, and evaluate merge-patch control conditions against live settings plus the patch so apply-time write-delta validation does not drop unchanged typography activators.
-- Make design-direction unknown-field errors list accepted keys and a minimal `1.0` example, encode empty capture token maps as objects, compute ready from an empty issues list, and keep those validation rejections out of the incident queue.
-- Keep architecture-preflight reasons honest for inspected empty documents, and list accepted evidence keys when native-plan or quality-check payloads fail.
-
-- Treat 127.0.0.1 and ::1 as the same bind for one-time admin login links so a
-  local MCP client and a local browser can redeem the same token.
-- Bind one-time admin login links to an explicit browser `user_agent` when
-  issued for Playwright or other external automation, instead of the MCP
-  client UA that those browsers cannot match.
-- Keep Gutenberg static block queue items queued when the browser serializer
-  cannot produce HTML, instead of auto-failing them with an empty roundtrip.
-- Expose finalizer queue errors, failed counts, per-target editor/queue URLs,
-  and heartbeat-only online status so agents can drain the queue without
-  inspecting private storage.
-- Persist nested innerBlocks on dynamic Gutenberg inserts, or queue the whole
-  tree when any child needs the browser finalizer.
-- Emit query-loop specs with an `attributes` object (`{}` when empty, never a
-  JSON array) that inserts can consume directly, keep attribute-validation
-  errors structured, and preserve supplied heading, button, and group
-  attributes when serializing.
-
-- Stop Run diagnostics from refreshing the whole admin page when JavaScript is
-  available, and keep the no-JS form as a fallback.
-- Detect the skills table through wrapped `$wpdb` handles so packaged
-  landing-page playbooks actually retire on seed.
-- Keep local-site Connect tabs actionable: ChatGPT and Claude.ai now show the
-  Desktop/mcp-remote bridge instead of an empty notice.
-- Hide inactive OAuth client panels so tab switches actually change the visible
-  config.
-- Allow `cursor://` one-click install links through WordPress URL sanitization
-  and add a copy-link fallback.
-- Stop Setup diagnostics from claiming a companion contract mismatch when plugin
-  SemVer and the HTTP contract share major 1.
-- Reseed packaged skills when the plugin version changes so file copies without
-  reactivation still refresh the catalog.
-- Treat an Elementor elements manager that cannot list types as offline instead
-  of failing closed on a stub or half-booted runtime.
-- Store backup snapshots and restores through a slash-safe post-meta boundary so
-  Elementor documents containing escaped JSON round-trip byte-faithfully; the
-  snapshot integrity hash check now passes for legitimate writes and still fails
-  closed on genuine storage corruption.
-- Separate Codex Desktop from Codex CLI in Connect and dedupe generated MCP
-  server names.
-- Hide Elementor V4 tools when the atomic toggle is off, persist the MCP surface
-  from Apply now, and report when a session has widened beyond compact.
-- Surface audit-row error code, message, target, and repair, and make occurrence
-  links filter correctly.
-- Harden memory save failures, checkbox uncheck, matching window, and
-  `body_tool` routing.
-- Split paste-to-agent `--profile` from `--wp-surface` so compact versus full
-  surfaces stay explicit.
-- Normalize sparse container settings on the standalone Elementor add-container
-  path.
-- Restore editor iframe state after finalizer serialize, reject mixed finalizer
-  batches, and honor block path, position, and update semantics on persist.
-- Keep required `auth_guidance` on compact task-start so MCP schema validation
-  and the Troubleshoot loopback probe succeed when there is no extra auth copy.
-- List WordPress core pattern categories such as featured even before a user
-  pattern is assigned to them.
-- Treat `audit_write` as the write audit gate in the public API contract, and
-  look up draft-lesson memory rows with a SQL string plus scalar binds.
-- Stop the Block Editor Queue iframe from autosaving queued blocks into the live
-  post before `blocks-finalize-batch`.
-
-### Changed
-
-- Document Gutenberg output-quality rules: one H1 (section titles as H2 when
-  the theme already prints the page title), styled query loops (grid, cropped
-  featured images, card supports), and one finalizer change per post.
-- Polish the Audit Log: key-value details with a View JSON toggle, distinct incident badges, wider ability names, a More filters disclosure, and a clearer empty state.
-- Style Application Password client pickers with the same button tabs as OAuth.
-- Keep compact `stonewright-task-start` under the anti-slop byte budget with
-  truncated Context, `design_direction_ref`, and the visual quality floor, and
-  expose `stonewright/design-direction-brief` on the essential MCP surface.
-- Rebuild the Context admin page into side-by-side system and user sections,
-  with collapsible generated instructions and an on/off inject toggle.
-- Route ambiguous design, landing-page, and section tasks to Gutenberg when
-  Elementor is inactive or a block theme such as Blocksy is the stronger signal.
-- Discover skills as slug plus one-line description; load playbook bodies only
-  through `stonewright/skills-get`, presence-gate skill bodies as well as the
-  catalog, and hide skills whose required integrations are absent.
-- Harden pattern creates and FSE global-style/template writes with the same
-  backup, confirmation, sanitization, and audit envelope as the canonical
-  write abilities. Keep the older update-* names as compatibility wrappers.
-- Require an explicit, SemVer-compatible release channel and expose the
-  supported public beta through one validated README download path.
-- Clear the admin header of mode and version, mark Troubleshoot, Context,
-  Design, and Block Editor Queue as Experimental, and move Memory, Skills, and
-  Context under Workflows.
-- Expose the generated **387**-ability Plugin and **101**-tool Direct contracts.
-- Mark Troubleshoot, Context, Design, and Block Editor Queue with a compact
-  white EXP marker that stays on the first line while long labels wrap. Hover
-  shows that the feature is experimental.
-- Restyle the Block Editor Queue as a status card with idle and busy states.
-
-### Removed
-
-- Remove packaged industry landing-page playbooks from the skills catalog.
-  Already-seeded playbook rows are retired on seed and on plugin upgrade.
-
 ## Older releases
 
+- [1.0.0-beta.11](docs/releases/1.0.0-beta.11.md)
 - [1.0.0-beta.10](docs/releases/1.0.0-beta.10.md)
 - [1.0.0-beta.9](docs/releases/1.0.0-beta.9.md)
 - [1.0.0-beta.8](docs/releases/1.0.0-beta.8.md)

--- a/README.md
+++ b/README.md
@@ -19,17 +19,17 @@
 </p>
 
 <!-- supported-release:start -->
-<p align="center"><strong>Current release: 1.0.0-beta.13.1 — Public Beta</strong></p>
+<p align="center"><strong>Current release: 1.0.0-beta.13.2 — Public Beta</strong></p>
 <p align="center">
-  <a href="https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.13.1/stonewright-1.0.0-beta.13.1.zip">Download Plugin</a>
+  <a href="https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.13.2/stonewright-1.0.0-beta.13.2.zip">Download Plugin</a>
   ·
   <a href="docs/installation.md">Installation guide</a>
   ·
-  <a href="https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.13.1/stonewright-companion-1.0.0-beta.13.1.tgz">Companion</a>
+  <a href="https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.13.2/stonewright-companion-1.0.0-beta.13.2.tgz">Companion</a>
   ·
-  <a href="https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.13.1/SHA256SUMS.txt">Checksums</a>
+  <a href="https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.13.2/SHA256SUMS.txt">Checksums</a>
   ·
-  <a href="https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/tag/v1.0.0-beta.13.1">Release notes</a>
+  <a href="https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/tag/v1.0.0-beta.13.2">Release notes</a>
 </p>
 <p align="center"><sub>Preview builds appear on the complete Releases page and are not recommended by default.</sub></p>
 <!-- supported-release:end -->

--- a/companion/CHANGELOG.md
+++ b/companion/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 - Nothing yet.
 
+## [1.0.0-beta.13.2] - 2026-08-26
+
+### Fixed
+
+- Align companion package version with the plugin 1.0.0-beta.13.2 patch so
+  WordPress and companion stay on the same SemVer after release.
+
 ## [1.0.0-beta.13.1] - 2026-08-26
 
 ### Fixed

--- a/companion/package-lock.json
+++ b/companion/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@stonewright/companion",
-	"version": "1.0.0-beta.13.1",
+	"version": "1.0.0-beta.13.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@stonewright/companion",
-			"version": "1.0.0-beta.13.1",
+			"version": "1.0.0-beta.13.2",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/companion/package.json
+++ b/companion/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@stonewright/companion",
-	"version": "1.0.0-beta.13.1",
+	"version": "1.0.0-beta.13.2",
 	"description": "Node companion for the Stonewright WordPress MCP plugin: WP-CLI, health checks, and optional MCP HTTP proxy.",
 	"type": "module",
 	"license": "MIT",

--- a/companion/src/version.ts
+++ b/companion/src/version.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = '1.0.0-beta.13.1';
+export const APP_VERSION = '1.0.0-beta.13.2';
 
 export function companionPackageSpec(version: string = APP_VERSION): string {
 	return `https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v${version}/stonewright-companion-${version}.tgz`;

--- a/docs/releases/1.0.0-beta.13.2.md
+++ b/docs/releases/1.0.0-beta.13.2.md
@@ -1,0 +1,50 @@
+# Stonewright 1.0.0-beta.13.2
+
+Released: 2026-08-26
+
+Release channel: `supported`
+
+## Summary
+
+This supported public beta patch ships the built-in skill pack inside the
+plugin ZIP, keeps Plugins → View details on the installed-or-newer release,
+and fixes Atomic prop discovery on Elementor 4.2+. Plugin and companion stay
+aligned on `1.0.0-beta.13.2`.
+
+## Fixed
+
+- Bundle built-in skills and playbooks in the plugin ZIP and seed them from
+  the plugin directory, so ZIP installs show the full Skills catalog and MCP
+  task-start serves the built-in pack. Existing user skills, memory, and
+  audit history are preserved; upgrades reseed automatically.
+- Refetch GitHub Releases for Plugins → View details when the cached release
+  is older than the installed version, and purge release caches after the
+  plugin updates itself, so the modal never shows the pre-update release.
+- Normalize Elementor 4.2+ Atomic props whose serialization nests empty
+  object metadata, removing the repeated "Prop descriptor unavailable"
+  Troubleshoot diagnostics and restoring the Atomic widget inventory.
+
+## Upgrade
+
+Open Dashboard → Updates, click Check again, and update Stonewright. After
+the update, Stonewright → Skills lists the built-in pack and Troubleshoot
+reports no prop-descriptor diagnostics. Update the companion package
+reference to the published beta.13.2 asset, fully restart the MCP client,
+then run:
+
+```bash
+npx -y --package <published-companion-package> stonewright connect verify <alias> --client <client>
+```
+
+Success requires the requested alias, expected companion version,
+`stonewright-task-start`, status availability, and an empty
+`refresh_required_tool_names` list.
+
+## Compatibility and safety
+
+- WordPress plugin and companion: `1.0.0-beta.13.2`.
+- Plugin mode ability count is unchanged from beta.13.1.
+- WordPress: 6.7 or newer.
+- PHP: 8.1 or newer.
+- Node.js: 20 or newer for the companion.
+- Updates preserve existing memory, user skills, audit history, and Direct state.

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -6,6 +6,20 @@
 
 - Nothing yet.
 
+## [1.0.0-beta.13.2] - 2026-08-26
+
+### Fixed
+
+- Bundle built-in skills and playbooks in the plugin ZIP and seed them from
+  the plugin directory, so ZIP installs show the full Skills catalog and MCP
+  task-start serves the built-in pack.
+- Refetch GitHub Releases for Plugins → View details when the cached release
+  is older than the installed version, and purge release caches after the
+  plugin updates itself.
+- Normalize Elementor 4.2+ Atomic props whose serialization nests empty
+  object metadata, removing repeated "Prop descriptor unavailable"
+  Troubleshoot diagnostics and restoring the Atomic widget inventory.
+
 ## [1.0.0-beta.13.1] - 2026-08-26
 
 ### Fixed
@@ -217,194 +231,9 @@
 - Restore the native updater path for supported public betas published as
   GitHub Latest, while rejecting incompatible release metadata.
 
-## [1.0.0-beta.11] - 2026-08-22
-
-### Added
-
-- Add motion capability discovery, a strict DesignSpec motion contract, seven
-  bundled static-first presets, deterministic suggestions and signed plans,
-  guarded Gutenberg/FSE and Elementor V3 apply, and motion/UI evidence in the
-  persisted design-quality verdict.
-- Add verified design-direction deactivation through the existing
-  `stonewright/design-direction-activate` ability (`id: 0`), with a matching
-  admin Active toggle that autosubmits and reports failures honestly.
-- Add an explicit `stonewright/blocks-finalizer-cancel` ability that removes
-  queued, serialized, or failed finalizer records by id with dry-run support,
-  per-post permission checks, production-safe confirmation tokens, atomic
-  single-save deletion, and verified readback.
-
-- Add a Connect → Troubleshoot page that runs connection diagnostics in place
-  with a loading state, result cards, a copyable support report, bot/WAF
-  probes, OAuth registration checks, and a clipboard fallback.
-- Add a discover-execute MCP profile with three protocol tools for catalog
-  discovery and gated execution without exposing the full tool list.
-- Default Gutenberg block parse, registered-block list, and theme.json reads to
-  bounded summaries, with `responseMode=full` restoring the previous dumps.
-- Add Codex in ChatGPT Desktop, Codex CLI, ChatGPT, Claude.ai, and Antigravity
-  CLI to the shared OAuth and Application Password client choosers.
-- Add read-only GenerateBlocks, Kadence Blocks, Spectra, and Blocksy library
-  introspection, plus Blocksy/Kadence/GeneratePress theme chrome get/update.
-- Add presence-gated Blocksy, Kadence, GenerateBlocks, and Spectra build-page
-  skills that compose through the Gutenberg finalizer, plus builder operating
-  manuals and ACF, SEO, and forms skills.
-- Add typed query-loop, FSE navigation, and synced-pattern update/delete/category
-  abilities, plus a child-theme theme.json handoff that stops at human approval.
-- Add a read-only Elementor performance audit ability reporting bounded document,
-  settings, backup, and revision size metrics without exposing content.
-- Add a browser-assisted Gutenberg block finalizer that serializes queued
-  `{name, attributes, innerBlocks}` specs in the live editor iframe, persists
-  path-aware hashed HTML through a guarded finalize ability, and shows a Block
-  Editor Queue with heartbeat status. Partial block schemas stay marked as
-  live-editor validated.
-- Add Elementor list-widgets summary mode and optional full Design Direction
-  document loading from `stonewright/design-direction-brief`.
-- Add reviewable draft lessons when the same recurring error reaches ten repeats.
-- Add a Delete all logs control on the Audit Log page with inline DELETE confirmation, and a Block Editor Queue status strip with last-poll time and per-item status.
-
-### Security
-
-- Reject tampered or stale motion plans and require Elementor V3 motion
-  evidence to match the planned capability plus the exact live schema,
-  runtime fingerprint, and source identity.
-- Block Elementor `custom_css` / `_custom_css` writes and HTML widget `<style>` tags unless a consumed `custom_code_grant` accompanies the call, and allow `_css_classes` only from the `approved_css_classes` allowlist.
-- Block php-execute from calling `wp_update_custom_css_post` or writing kit/page custom CSS; those writes must use `stonewright/theme-custom-css`.
-- Enforce php-execute read-only at runtime, block concatenated protected meta
-  keys and direct database writes to core tables, and keep php-execute off the
-  default compact MCP surfaces.
-- Sign one-time admin login links, bind them to IP and User-Agent, rate-limit
-  issuance, skip remember-me cookies, and require confirmation in production-safe
-  mode.
-- Restrict REST ability execution to the active tool profile unless confirmed,
-  and require a confirmation token to toggle abilities over REST.
-- Require production-safe confirmation tokens on remaining content, Elementor,
-  Gutenberg, site, and admin-domain writers.
-- Require a human-issued `custom_code_grant` (and `allow_raw_html` for Gutenberg HTML) before raw `<style>` payloads, theme.json `css`, and all-raw-HTML block trees; do not strip the CSS.
-
-- Isolate the Gutenberg finalizer queue per owner, session, and target post:
-  state v2 records carry owner/session/post, tokens are HMAC-bound to all four
-  values, REST/AJAX/MCP results are scoped, replay after terminal states is
-  refused, legacy unbound records fail closed, and mutations run under a
-  bounded mutex. Hard limits now bound batch size, open records, payload
-  bytes, tree depth/nodes, serialized HTML, and total queue state, with
-  retention pruning for terminal records.
-
-### Changed
-
-- Document Gutenberg output-quality rules: one H1 (section titles as H2 when
-  the theme already prints the page title), styled query loops (grid, cropped
-  featured images, card supports), and one finalizer change per post.
-- Polish the Audit Log: key-value details with a View JSON toggle, distinct incident badges, wider ability names, a More filters disclosure, and a clearer empty state.
-- Style Application Password client pickers with the same button tabs as OAuth.
-- Keep compact `stonewright-task-start` under the anti-slop byte budget with
-  truncated Context, `design_direction_ref`, and the visual quality floor, and
-  expose `stonewright/design-direction-brief` on the essential MCP surface.
-- Rebuild the Context admin page into side-by-side system and user sections,
-  with collapsible generated instructions and an on/off inject toggle.
-- Route ambiguous design, landing-page, and section tasks to Gutenberg when
-  Elementor is inactive or a block theme such as Blocksy is the stronger signal.
-- Discover skills as slug plus one-line description; load playbook bodies only
-  through `stonewright/skills-get`, presence-gate skill bodies as well as the
-  catalog, and hide skills whose required integrations are absent.
-- Harden pattern creates and FSE global-style/template writes with the same
-  backup, confirmation, sanitization, and audit envelope as the canonical
-  write abilities. Keep the older update-* names as compatibility wrappers.
-- Clear the admin header of mode and version, mark Troubleshoot, Context,
-  Design, and Block Editor Queue as Experimental, and move Memory, Skills, and
-  Context under Workflows.
-- Expose the generated **387**-ability Plugin and **101**-tool Direct contracts.
-- Mark Troubleshoot, Context, Design, and Block Editor Queue with a compact
-  white EXP marker that stays on the first line while long labels wrap. Hover
-  shows that the feature is experimental.
-- Restyle the Block Editor Queue as a status card with idle and busy states.
-
-### Removed
-
-- Remove packaged industry landing-page playbooks from the skills catalog.
-  Already-seeded playbook rows are retired on seed and on plugin upgrade.
-
-### Fixed
-
-- Keep every Stonewright admin navigation link visible and contained at 320px
-  and 390px by allowing multi-link header groups to wrap inside the mobile
-  shell.
-- Boot the conditional motion loader, restore the link-underline effect, make
-  load/stagger/duration/delay lowering executable, make played states visible,
-  and fail open on runtime errors or page-cache restoration.
-- Derive V4 interactions truth from the loaded schema and official mutation
-  primitives, and return unsupported instead of compiling a write for a
-  runtime without the complete native adapter stack.
-- Fix the security-audit assert-call detector to use token-based PHP parsing:
-  method calls such as grant-gate assertions no longer produce false
-  positives, while functional `assert()` calls on strings or variables stay
-  blocked.
-- Return `schema_requests` when Elementor `require_evidence` writes are incomplete, copy those requests (and custom-CSS grant keys) into the MCP-visible error message so agents are not stuck with a one-line rejection, accept active-direction provenance for token-derived settings, honor batch or per-operation `responsive_scope` so tablet and mobile keys can be written without weakening the desktop-only default, and evaluate merge-patch control conditions against live settings plus the patch so apply-time write-delta validation does not drop unchanged typography activators.
-- Make design-direction unknown-field errors list accepted keys and a minimal `1.0` example, encode empty capture token maps as objects, compute ready from an empty issues list, and keep those validation rejections out of the incident queue.
-- Keep architecture-preflight reasons honest for inspected empty documents, and list accepted evidence keys when native-plan or quality-check payloads fail.
-
-- Treat 127.0.0.1 and ::1 as the same bind for one-time admin login links so a
-  local MCP client and a local browser can redeem the same token.
-- Bind one-time admin login links to an explicit browser `user_agent` when
-  issued for Playwright or other external automation, instead of the MCP
-  client UA that those browsers cannot match.
-- Keep Gutenberg static block queue items queued when the browser serializer
-  cannot produce HTML, instead of auto-failing them with an empty roundtrip.
-- Expose finalizer queue errors, failed counts, per-target editor/queue URLs,
-  and heartbeat-only online status so agents can drain the queue without
-  inspecting private storage.
-- Persist nested innerBlocks on dynamic Gutenberg inserts, or queue the whole
-  tree when any child needs the browser finalizer.
-- Emit query-loop specs with an `attributes` object (`{}` when empty, never a
-  JSON array) that inserts can consume directly, keep attribute-validation
-  errors structured, and preserve supplied heading, button, and group
-  attributes when serializing.
-
-- Stop Run diagnostics from refreshing the whole admin page when JavaScript is
-  available, and keep the no-JS form as a fallback.
-- Detect the skills table through wrapped `$wpdb` handles so packaged
-  landing-page playbooks actually retire on seed.
-- Keep local-site Connect tabs actionable: ChatGPT and Claude.ai now show the
-  Desktop/mcp-remote bridge instead of an empty notice.
-- Hide inactive OAuth client panels so tab switches actually change the visible
-  config.
-- Allow `cursor://` one-click install links through WordPress URL sanitization
-  and add a copy-link fallback.
-- Stop Setup diagnostics from claiming a companion contract mismatch when plugin
-  SemVer and the HTTP contract share major 1.
-- Reseed packaged skills when the plugin version changes so file copies without
-  reactivation still refresh the catalog.
-- Encode Cursor MCP install deeplinks as base64url and keep them as clickable
-  `cursor://` links on both OAuth and Application Password setup.
-- Treat an Elementor elements manager that cannot list types as offline instead
-  of failing closed on a stub or half-booted runtime.
-- Store backup snapshots and restores through a slash-safe post-meta boundary so
-  Elementor documents containing escaped JSON round-trip byte-faithfully; the
-  snapshot integrity hash check now passes for legitimate writes and still fails
-  closed on genuine storage corruption.
-- Separate Codex Desktop from Codex CLI in Connect and dedupe generated MCP
-  server names.
-- Hide Elementor V4 tools when the atomic toggle is off, persist the MCP surface
-  from Apply now, and report when a session has widened beyond compact.
-- Surface audit-row error code, message, target, and repair, and make occurrence
-  links filter correctly.
-- Harden memory save failures, checkbox uncheck, matching window, and
-  `body_tool` routing.
-- Split paste-to-agent `--profile` from `--wp-surface` so compact versus full
-  surfaces stay explicit.
-- Normalize sparse container settings on the standalone Elementor add-container
-  path.
-- Restore editor iframe state after finalizer serialize, reject mixed finalizer
-  batches, and honor block path, position, and update semantics on persist.
-- Keep required `auth_guidance` on compact task-start so MCP schema validation
-  and the Troubleshoot loopback probe succeed when there is no extra auth copy.
-- List WordPress core pattern categories such as featured even before a user
-  pattern is assigned to them.
-- Treat `audit_write` as the write audit gate in the public API contract, and
-  look up draft-lesson memory rows with a SQL string plus scalar binds.
-- Stop the Block Editor Queue iframe from autosaving queued blocks into the live
-  post before `blocks-finalize-batch`.
-
 ## Older releases
 
+- [1.0.0-beta.11](../docs/releases/1.0.0-beta.11.md)
 - [1.0.0-beta.10](../docs/releases/1.0.0-beta.10.md)
 - [1.0.0-beta.9](../docs/releases/1.0.0-beta.9.md)
 - [1.0.0-beta.8](../docs/releases/1.0.0-beta.8.md)

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,6 +1,6 @@
 # Stonewright Plugin
 
-Version: 1.0.0-beta.13.1
+Version: 1.0.0-beta.13.2
 Requires WordPress: 6.7+
 Requires PHP: 8.1+
 License: [AGPL-3.0-or-later](../LICENSE)

--- a/plugin/includes/Core/GitHubUpdater.php
+++ b/plugin/includes/Core/GitHubUpdater.php
@@ -431,7 +431,9 @@ final class GitHubUpdater {
 			// the operator is looking at the modal after an update.
 			$remote = self::fetch_latest_release( true );
 		}
-		if ( null === $remote ) {
+		if ( null === $remote || version_compare( (string) $remote['version'], self::installed_version(), '<' ) ) {
+			// Still older after a forced lookup (release deleted, reclassified,
+			// or feed gap): fall back instead of rendering stale metadata.
 			return $result;
 		}
 

--- a/plugin/includes/Core/GitHubUpdater.php
+++ b/plugin/includes/Core/GitHubUpdater.php
@@ -38,10 +38,31 @@ final class GitHubUpdater {
 		add_filter( 'pre_set_site_transient_update_plugins', [ self::class, 'inject_update' ] );
 		add_filter( 'plugins_api', [ self::class, 'plugins_api' ], 10, 3 );
 		add_filter( 'upgrader_pre_download', [ self::class, 'verify_package_download' ], 10, 4 );
+		add_action( 'upgrader_process_complete', [ self::class, 'purge_release_cache_after_self_update' ], 10, 2 );
 	}
 
 	public static function cache_key( string $channel ): string {
 		return self::CACHE_KEY . '_' . ( 'beta' === $channel ? 'beta' : 'stable' );
+	}
+
+	/**
+	 * After this plugin updates itself, the cached release (and View details
+	 * body) describes the pre-update world. Purge so the next read refetches.
+	 *
+	 * @param mixed $upgrader   Core upgrader instance (unused).
+	 * @param mixed $hook_extra Core upgrade context.
+	 */
+	public static function purge_release_cache_after_self_update( mixed $upgrader, mixed $hook_extra ): void {
+		unset( $upgrader );
+		if ( ! is_array( $hook_extra ) || 'plugin' !== (string) ( $hook_extra['type'] ?? '' ) ) {
+			return;
+		}
+		$plugins = isset( $hook_extra['plugins'] ) && is_array( $hook_extra['plugins'] ) ? $hook_extra['plugins'] : [];
+		if ( ! in_array( self::plugin_basename(), $plugins, true ) ) {
+			return;
+		}
+		delete_transient( self::cache_key( 'beta' ) );
+		delete_transient( self::cache_key( 'stable' ) );
 	}
 
 	public static function installed_channel( string $version ): string {
@@ -405,6 +426,11 @@ final class GitHubUpdater {
 		}
 
 		$remote = self::fetch_latest_release();
+		if ( null === $remote || version_compare( (string) $remote['version'], self::installed_version(), '<' ) ) {
+			// A cache older than the installed plugin is stale by definition:
+			// the operator is looking at the modal after an update.
+			$remote = self::fetch_latest_release( true );
+		}
 		if ( null === $remote ) {
 			return $result;
 		}

--- a/plugin/includes/Elementor/V4/AtomicPropDescriptorNormalizer.php
+++ b/plugin/includes/Elementor/V4/AtomicPropDescriptorNormalizer.php
@@ -102,7 +102,11 @@ final class AtomicPropDescriptorNormalizer {
 		if ( is_int( $value ) || is_bool( $value ) || is_float( $value ) || null === $value ) {
 			return [ 'ok' => true, 'value' => $value ];
 		}
-		if ( is_object( $value ) || ! is_array( $value ) ) {
+		if ( $value instanceof \stdClass ) {
+			// Elementor 4.2+ casts empty prop metadata to (object) [] so JSON
+			// keeps "{}". Plain data holders are safe to bound as arrays.
+			$value = get_object_vars( $value );
+		} elseif ( is_object( $value ) || ! is_array( $value ) ) {
 			return [ 'ok' => false, 'value' => null ];
 		}
 		if ( $depth > self::MAX_DEPTH ) {

--- a/plugin/includes/Skills/SkillsSeeder.php
+++ b/plugin/includes/Skills/SkillsSeeder.php
@@ -26,7 +26,7 @@ final class SkillsSeeder {
 	];
 
 	public static function seed(): void {
-		self::$skills_dir = rtrim( dirname( __DIR__, 3 ), '/\\' ) . '/skills';
+		self::$skills_dir = self::resolve_skills_dir( self::candidate_skills_dirs() );
 
 		foreach ( self::RETIRED_PACKAGED_SLUGS as $slug ) {
 			Skills::retire_packaged_slug( $slug );
@@ -50,6 +50,33 @@ final class SkillsSeeder {
 
 		self::seed_playbooks();
 		self::seed_meta_skill();
+	}
+
+	/**
+	 * Candidate skill-pack locations, most specific first.
+	 *
+	 * Release ZIP installs bundle the pack at <plugin dir>/skills. Git
+	 * checkouts keep it at <repo root>/skills, one level higher.
+	 *
+	 * @return list<string>
+	 */
+	public static function candidate_skills_dirs(): array {
+		return [
+			rtrim( dirname( __DIR__, 2 ), '/\\' ) . '/skills',
+			rtrim( dirname( __DIR__, 3 ), '/\\' ) . '/skills',
+		];
+	}
+
+	/**
+	 * @param list<string> $candidates Ordered candidate directories.
+	 */
+	public static function resolve_skills_dir( array $candidates ): string {
+		foreach ( $candidates as $candidate ) {
+			if ( is_dir( $candidate ) ) {
+				return $candidate;
+			}
+		}
+		return '';
 	}
 
 	/**

--- a/plugin/stonewright.php
+++ b/plugin/stonewright.php
@@ -3,7 +3,7 @@
  * Plugin Name: Stonewright
  * Plugin URI: https://github.com/cosmincraciun97/stonewright-wp-mcp
  * Description: Guarded WordPress MCP tools for Elementor, Gutenberg/FSE, WooCommerce catalogs, content models, PHP runtime execution, and tokenized WP-CLI.
- * Version: 1.0.0-beta.13.1
+ * Version: 1.0.0-beta.13.2
  * Requires at least: 6.7
  * Requires PHP: 8.1
  * Author: Stonewright
@@ -33,7 +33,7 @@ if ( defined( 'STONEWRIGHT_FILE' ) ) {
 define( 'STONEWRIGHT_FILE', __FILE__ );
 define( 'STONEWRIGHT_DIR', plugin_dir_path( __FILE__ ) );
 define( 'STONEWRIGHT_URL', plugin_dir_url( __FILE__ ) );
-define( 'STONEWRIGHT_VERSION', '1.0.0-beta.13.1' );
+define( 'STONEWRIGHT_VERSION', '1.0.0-beta.13.2' );
 define( 'STONEWRIGHT_MIN_PHP', '8.1' );
 define( 'STONEWRIGHT_MIN_WP', '6.7' );
 

--- a/plugin/tests/Unit/Core/GitHubUpdaterTest.php
+++ b/plugin/tests/Unit/Core/GitHubUpdaterTest.php
@@ -227,6 +227,74 @@ final class GitHubUpdaterTest extends TestCase {
 		);
 	}
 
+	public function test_plugins_api_refetches_when_cached_release_is_older_than_installed(): void {
+		$installed        = '1.0.0-beta.13.1';
+		$stale            = $this->parsed_beta_release();
+		$stale['version'] = '1.0.0-beta.12';
+		$stale['package'] = 'https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.12/stonewright-1.0.0-beta.12.zip';
+		$stale['companion_package'] = 'https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.12/stonewright-companion-1.0.0-beta.12.tgz';
+		$stale['checksums'] = 'https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.12/SHA256SUMS.txt';
+		$stale['url']       = 'https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/tag/v1.0.0-beta.12';
+		$this->set_installed_version( $installed );
+		set_transient(
+			GitHubUpdater::cache_key( 'beta' ),
+			[
+				'schema_version' => GitHubUpdater::CACHE_SCHEMA_VERSION,
+				'channel'        => 'beta',
+				'release'        => $stale,
+			],
+			GitHubUpdater::CACHE_TTL
+		);
+
+		$fresh = $this->release_with_version( $this->releases_fixture()[6], $installed );
+		$GLOBALS['stonewright_test_wp_remote_get'] = static fn(): array => [
+			'response' => [ 'code' => 200 ],
+			'body'     => (string) wp_json_encode( [ $fresh ] ),
+		];
+
+		$info = GitHubUpdater::plugins_api( false, 'plugin_information', (object) [ 'slug' => 'stonewright' ] );
+
+		self::assertIsObject( $info );
+		self::assertSame( $installed, $info->version );
+		self::assertNotSame( '1.0.0-beta.12', $info->version );
+		self::assertCount( 1, $GLOBALS['stonewright_test_wp_remote_get_calls'] );
+	}
+
+	public function test_purge_release_cache_after_self_update_clears_both_channels(): void {
+		$sentinel = [ 'schema_version' => GitHubUpdater::CACHE_SCHEMA_VERSION, 'channel' => 'beta', 'release' => [ 'version' => 'stale' ] ];
+		set_transient( GitHubUpdater::cache_key( 'beta' ), $sentinel, GitHubUpdater::CACHE_TTL );
+		set_transient( GitHubUpdater::cache_key( 'stable' ), $sentinel, GitHubUpdater::CACHE_TTL );
+
+		GitHubUpdater::purge_release_cache_after_self_update(
+			new \stdClass(),
+			[
+				'type'    => 'plugin',
+				'action'  => 'update',
+				'plugins' => [ GitHubUpdater::plugin_basename() ],
+			]
+		);
+
+		self::assertFalse( get_transient( GitHubUpdater::cache_key( 'beta' ) ) );
+		self::assertFalse( get_transient( GitHubUpdater::cache_key( 'stable' ) ) );
+	}
+
+	public function test_purge_release_cache_after_self_update_ignores_other_plugins(): void {
+		$sentinel = [ 'schema_version' => GitHubUpdater::CACHE_SCHEMA_VERSION, 'channel' => 'beta', 'release' => [ 'version' => 'keep' ] ];
+		set_transient( GitHubUpdater::cache_key( 'beta' ), $sentinel, GitHubUpdater::CACHE_TTL );
+		set_transient( GitHubUpdater::cache_key( 'stable' ), $sentinel, GitHubUpdater::CACHE_TTL );
+
+		GitHubUpdater::purge_release_cache_after_self_update(
+			new \stdClass(),
+			[
+				'type'    => 'plugin',
+				'plugins' => [ 'other/other.php' ],
+			]
+		);
+
+		self::assertSame( $sentinel, get_transient( GitHubUpdater::cache_key( 'beta' ) ) );
+		self::assertSame( $sentinel, get_transient( GitHubUpdater::cache_key( 'stable' ) ) );
+	}
+
 	public function test_release_channel_metadata_still_reads_raw_markdown_body(): void {
 		$github_release          = $this->releases_fixture()[6];
 		$github_release['body']  = "# Fixes\n\nRelease channel: `supported`\n\n<script>alert(1)</script>\n";
@@ -647,6 +715,7 @@ final class GitHubUpdaterTest extends TestCase {
 		self::assertArrayHasKey( 'site_transient_update_plugins', $GLOBALS['stonewright_test_filters'] );
 		self::assertArrayHasKey( 'pre_set_site_transient_update_plugins', $GLOBALS['stonewright_test_filters'] );
 		self::assertArrayHasKey( 'upgrader_pre_download', $GLOBALS['stonewright_test_filters'] );
+		self::assertTrue( (bool) has_action( 'upgrader_process_complete', [ GitHubUpdater::class, 'purge_release_cache_after_self_update' ] ) );
 	}
 
 	public function test_checksum_manifest_requires_one_exact_zip_filename_and_digest(): void {

--- a/plugin/tests/Unit/Core/GitHubUpdaterTest.php
+++ b/plugin/tests/Unit/Core/GitHubUpdaterTest.php
@@ -260,6 +260,37 @@ final class GitHubUpdaterTest extends TestCase {
 		self::assertCount( 1, $GLOBALS['stonewright_test_wp_remote_get_calls'] );
 	}
 
+	public function test_plugins_api_falls_back_when_forced_refetch_is_still_older_than_installed(): void {
+		$installed        = '1.0.0-beta.13.1';
+		$stale            = $this->parsed_beta_release();
+		$stale['version'] = '1.0.0-beta.12';
+		$stale['package'] = 'https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.12/stonewright-1.0.0-beta.12.zip';
+		$stale['companion_package'] = 'https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.12/stonewright-companion-1.0.0-beta.12.tgz';
+		$stale['checksums'] = 'https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/download/v1.0.0-beta.12/SHA256SUMS.txt';
+		$stale['url']       = 'https://github.com/cosmincraciun97/stonewright-wp-mcp/releases/tag/v1.0.0-beta.12';
+		$this->set_installed_version( $installed );
+		set_transient(
+			GitHubUpdater::cache_key( 'beta' ),
+			[
+				'schema_version' => GitHubUpdater::CACHE_SCHEMA_VERSION,
+				'channel'        => 'beta',
+				'release'        => $stale,
+			],
+			GitHubUpdater::CACHE_TTL
+		);
+
+		$still_old = $this->release_with_version( $this->releases_fixture()[6], '1.0.0-beta.12' );
+		$GLOBALS['stonewright_test_wp_remote_get'] = static fn(): array => [
+			'response' => [ 'code' => 200 ],
+			'body'     => (string) wp_json_encode( [ $still_old ] ),
+		];
+
+		$info = GitHubUpdater::plugins_api( false, 'plugin_information', (object) [ 'slug' => 'stonewright' ] );
+
+		self::assertFalse( $info );
+		self::assertCount( 1, $GLOBALS['stonewright_test_wp_remote_get_calls'] );
+	}
+
 	public function test_purge_release_cache_after_self_update_clears_both_channels(): void {
 		$sentinel = [ 'schema_version' => GitHubUpdater::CACHE_SCHEMA_VERSION, 'channel' => 'beta', 'release' => [ 'version' => 'stale' ] ];
 		set_transient( GitHubUpdater::cache_key( 'beta' ), $sentinel, GitHubUpdater::CACHE_TTL );

--- a/plugin/tests/Unit/Elementor/V4/AtomicPropDescriptorNormalizerTest.php
+++ b/plugin/tests/Unit/Elementor/V4/AtomicPropDescriptorNormalizerTest.php
@@ -133,6 +133,59 @@ final class AtomicPropDescriptorNormalizerTest extends TestCase {
 		self::assertSame( 1000, strlen( (string) $result['runtime_descriptor']['alpha'] ) );
 	}
 
+	public function test_normalizes_props_whose_serialization_nests_empty_std_class_objects(): void {
+		$prop = new class() implements \JsonSerializable {
+			public function jsonSerialize(): array {
+				return [
+					'kind'          => 'plain',
+					'key'           => 'classes',
+					'default'       => [ '$$type' => 'classes', 'value' => [] ],
+					'meta'          => new \stdClass(),
+					'settings'      => new \stdClass(),
+					'dependencies'  => null,
+					'initial_value' => null,
+				];
+			}
+		};
+
+		$result = AtomicPropDescriptorNormalizer::normalize( $prop );
+
+		self::assertTrue( $result['ok'] );
+		self::assertSame( 'elementor-json-serializable-v1', $result['descriptor_format'] );
+		self::assertSame( [], $result['runtime_descriptor']['meta'] );
+		self::assertSame( [], $result['runtime_descriptor']['settings'] );
+	}
+
+	public function test_normalizes_non_empty_std_class_values_recursively(): void {
+		$settings           = new \stdClass();
+		$settings->required = true;
+
+		$prop = new class( $settings ) implements \JsonSerializable {
+			public function __construct( private \stdClass $settings ) {}
+			public function jsonSerialize(): array {
+				return [ 'kind' => 'plain', 'settings' => $this->settings ];
+			}
+		};
+
+		$result = AtomicPropDescriptorNormalizer::normalize( $prop );
+
+		self::assertTrue( $result['ok'] );
+		self::assertSame( [ 'required' => true ], $result['runtime_descriptor']['settings'] );
+	}
+
+	public function test_still_rejects_non_std_class_objects_in_the_descriptor(): void {
+		$prop = new class() implements \JsonSerializable {
+			public function jsonSerialize(): array {
+				return [ 'kind' => 'plain', 'settings' => new \ArrayIterator( [] ) ];
+			}
+		};
+
+		$result = AtomicPropDescriptorNormalizer::normalize( $prop );
+
+		self::assertFalse( $result['ok'] );
+		self::assertSame( 'descriptor_unavailable', $result['issue']['code'] );
+	}
+
 	public function test_official_runtime_stays_inventory_only_until_adapter_matches(): void {
 		$normalized = AtomicPropDescriptorNormalizer::normalize( new SerializableProp() );
 		$evidence   = self::official_evidence( $normalized );

--- a/plugin/tests/Unit/Skills/SkillsSeederPathTest.php
+++ b/plugin/tests/Unit/Skills/SkillsSeederPathTest.php
@@ -1,0 +1,38 @@
+<?php
+declare( strict_types=1 );
+
+namespace Stonewright\WpMcp\Tests\Unit\Skills;
+
+use PHPUnit\Framework\TestCase;
+use Stonewright\WpMcp\Skills\SkillsSeeder;
+
+/**
+ * @covers \Stonewright\WpMcp\Skills\SkillsSeeder
+ */
+final class SkillsSeederPathTest extends TestCase {
+
+	public function test_candidates_prefer_the_bundled_plugin_copy(): void {
+		$candidates = SkillsSeeder::candidate_skills_dirs();
+
+		self::assertCount( 2, $candidates );
+		// Bundled location: <plugin dir>/skills (what the release ZIP ships).
+		self::assertStringEndsWith( '/plugin/skills', str_replace( '\\', '/', $candidates[0] ) );
+		// Dev fallback: <repo root>/skills (what a git checkout has).
+		self::assertStringEndsWith( '/skills', str_replace( '\\', '/', $candidates[1] ) );
+		self::assertNotSame( $candidates[0], $candidates[1] );
+	}
+
+	public function test_resolve_skills_dir_picks_the_first_existing_candidate(): void {
+		$missing = sys_get_temp_dir() . '/stonewright-not-a-dir-' . uniqid();
+		$real    = sys_get_temp_dir() . '/stonewright-skills-' . uniqid();
+		mkdir( $real );
+
+		try {
+			self::assertSame( $real, SkillsSeeder::resolve_skills_dir( [ $missing, $real ] ) );
+			self::assertSame( $real, SkillsSeeder::resolve_skills_dir( [ $real, $missing ] ) );
+			self::assertSame( '', SkillsSeeder::resolve_skills_dir( [ $missing ] ) );
+		} finally {
+			rmdir( $real );
+		}
+	}
+}

--- a/plugin/tests/Unit/Support/ReleaseRetentionTest.php
+++ b/plugin/tests/Unit/Support/ReleaseRetentionTest.php
@@ -44,4 +44,20 @@ final class ReleaseRetentionTest extends TestCase {
 			self::assertStringContainsString( '../docs/releases/1.0.0-beta.' . $release_number . '.md', $plugin_raw );
 		}
 	}
+
+	public function test_claude_md_is_a_symlink_to_agents_md(): void {
+		$root   = dirname( __DIR__, 4 );
+		$claude = $root . '/CLAUDE.md';
+		$agents = $root . '/AGENTS.md';
+
+		self::assertTrue( is_link( $claude ), 'CLAUDE.md must stay a symlink so Hard rules are not duplicated.' );
+		self::assertSame( 'AGENTS.md', readlink( $claude ) );
+		self::assertFileEquals( $agents, $claude );
+
+		$body = (string) file_get_contents( $claude );
+		self::assertStringContainsString( 'Updater contract is part of every user-consumed release', $body );
+		self::assertStringContainsString( 'GitHub release notes are untrusted Markdown', $body );
+		self::assertStringContainsString( 'View details must never render a release older', $body );
+		self::assertStringContainsString( 'plugin release ZIP must bundle the built-in skill pack', $body );
+	}
 }

--- a/plugin/tests/Unit/Support/ReleaseRetentionTest.php
+++ b/plugin/tests/Unit/Support/ReleaseRetentionTest.php
@@ -19,7 +19,7 @@ final class ReleaseRetentionTest extends TestCase {
 				$versioned[] = $name;
 			}
 		}
-		self::assertSame( [ '1.0.0-beta.1.md', '1.0.0-beta.10.md', '1.0.0-beta.11.1.md', '1.0.0-beta.11.md', '1.0.0-beta.12.md', '1.0.0-beta.13.1.md', '1.0.0-beta.13.md', '1.0.0-beta.2.md', '1.0.0-beta.3.md', '1.0.0-beta.4.md', '1.0.0-beta.5.md', '1.0.0-beta.6.md', '1.0.0-beta.7.md', '1.0.0-beta.8.md', '1.0.0-beta.9.md' ], $versioned );
+		self::assertSame( [ '1.0.0-beta.1.md', '1.0.0-beta.10.md', '1.0.0-beta.11.1.md', '1.0.0-beta.11.md', '1.0.0-beta.12.md', '1.0.0-beta.13.1.md', '1.0.0-beta.13.2.md', '1.0.0-beta.13.md', '1.0.0-beta.2.md', '1.0.0-beta.3.md', '1.0.0-beta.4.md', '1.0.0-beta.5.md', '1.0.0-beta.6.md', '1.0.0-beta.7.md', '1.0.0-beta.8.md', '1.0.0-beta.9.md' ], $versioned );
 	}
 
 	public function test_root_changelog_keeps_latest_five_releases_and_links_older_history(): void {
@@ -36,7 +36,7 @@ final class ReleaseRetentionTest extends TestCase {
 			)
 		);
 		self::assertContains( 'Unreleased', $headers );
-		self::assertSame( [ '1.0.0-beta.13.1', '1.0.0-beta.13', '1.0.0-beta.12', '1.0.0-beta.11.1', '1.0.0-beta.11' ], $versions );
+		self::assertSame( [ '1.0.0-beta.13.2', '1.0.0-beta.13.1', '1.0.0-beta.13', '1.0.0-beta.12', '1.0.0-beta.11.1' ], $versions );
 		self::assertStringContainsString( '## Older releases', $raw );
 		self::assertStringContainsString( '## Older releases', $plugin_raw );
 		foreach ( range( 1, 7 ) as $release_number ) {

--- a/plugin/tests/bootstrap.php
+++ b/plugin/tests/bootstrap.php
@@ -1078,6 +1078,9 @@ if ( ! function_exists( 'has_filter' ) ) {
 
 if ( ! function_exists( 'has_action' ) ) {
 	function has_action( string $hook_name, mixed $callback = false ): int|false {
+		if ( isset( $GLOBALS['stonewright_test_actions'][ $hook_name ] ) ) {
+			return 10;
+		}
 		return has_filter( $hook_name, $callback );
 	}
 }

--- a/scripts/tests/release-flags.test.mjs
+++ b/scripts/tests/release-flags.test.mjs
@@ -17,6 +17,7 @@ test('supported public betas are latest releases', () => {
 	assert.deepEqual(releaseFlags('1.0.0-beta.10', 'supported'), ['--latest']);
 	assert.deepEqual(releaseFlags('1.0.0-beta.13', 'supported'), ['--latest']);
 	assert.deepEqual(releaseFlags('1.0.0-beta.13.1', 'supported'), ['--latest']);
+	assert.deepEqual(releaseFlags('1.0.0-beta.13.2', 'supported'), ['--latest']);
 });
 
 test('preview beta and rc versions are prereleases', () => {
@@ -70,12 +71,12 @@ test('archive inspections remain reliable with pipefail enabled', () => {
 test('README exposes one validated supported public beta path', () => {
 	assert.match(readme, /<!-- supported-release:start -->/);
 	assert.match(readme, /<!-- supported-release:end -->/);
-	assert.match(readme, /Current release: 1\.0\.0-beta\.13\.1 — Public Beta/);
-	assert.match(readme, /releases\/tag\/v1\.0\.0-beta\.13\.1/);
-	assert.match(readme, /releases\/download\/v1\.0\.0-beta\.13\.1\/stonewright-1\.0\.0-beta\.13\.1\.zip/);
-	assert.match(readme, /releases\/download\/v1\.0\.0-beta\.13\.1\/stonewright-companion-1\.0\.0-beta\.13\.1\.tgz/);
-	assert.match(readme, /releases\/download\/v1\.0\.0-beta\.13\.1\/SHA256SUMS\.txt/);
-	assert.doesNotMatch(readme, /1\.0\.0-beta\.13\.1.*not released/i);
+	assert.match(readme, /Current release: 1\.0\.0-beta\.13\.2 — Public Beta/);
+	assert.match(readme, /releases\/tag\/v1\.0\.0-beta\.13\.2/);
+	assert.match(readme, /releases\/download\/v1\.0\.0-beta\.13\.2\/stonewright-1\.0\.0-beta\.13\.2\.zip/);
+	assert.match(readme, /releases\/download\/v1\.0\.0-beta\.13\.2\/stonewright-companion-1\.0\.0-beta\.13\.2\.tgz/);
+	assert.match(readme, /releases\/download\/v1\.0\.0-beta\.13\.2\/SHA256SUMS\.txt/);
+	assert.doesNotMatch(readme, /1\.0\.0-beta\.13\.2.*not released/i);
 	assert.match(readme, /docs\/installation\.md/);
 	assert.match(docsFreshness, /supported-release:start/);
 });


### PR DESCRIPTION
## Summary

- Bundle the built-in skill pack in the plugin ZIP; seeder prefers the bundled copy with repo-checkout fallback; packaging fails closed if the pack is missing.
- Plugins → View details refetches GitHub when the cached release is older than the installed version; a completed self-update purges both channel release caches.
- Normalize Elementor 4.2+ Atomic props that serialize empty `stdClass` metadata; restores the Atomic inventory and removes 36 repeated `descriptor_unavailable` diagnostics.
- Version bump to `1.0.0-beta.13.2` with changelogs and release notes.

## Changed abilities

None. No ability inputs/outputs changed. Backup, token, permission, validation, and audit gates unchanged. The Atomic descriptor change affects read-only inventory discovery only; the whole-type discard on any non-normalizable prop is preserved.

## Public docs

Root/plugin/companion changelogs, `docs/releases/1.0.0-beta.13.2.md`, README current-version mentions, AGENTS.md + CLAUDE.md updater/packaging contract.

## Release decision record

```
Release class: supported public beta
Proposed SemVer: 1.0.0-beta.13.2
Channel declaration: supported
User-visible changes:
  1. Built-in skills and playbooks ship inside the plugin ZIP and seed on
     install/upgrade, so the Skills page and MCP task-start serve the full
     built-in pack on ZIP installs.
  2. Plugins -> View details always shows the installed-or-newer release;
     release metadata caches are purged after the plugin updates itself.
  3. Elementor 4.2.x Atomic props that serialize nested empty objects now
     normalize into bounded descriptors; the Troubleshoot "Prop descriptor
     unavailable" noise disappears and the Atomic inventory populates.
Artifacts: plugin ZIP (now containing skills/), companion package
  (version alignment only)
Evidence: new PHPUnit tests for seeder path candidates, plugins_api
  stale-cache refetch, upgrader cache purge, and stdClass descriptor
  normalization; release workflow asserts the ZIP contains the skill pack
Known gaps: sites must update to 13.2 before the bundled skills appear;
  reseed is automatic via maybe_upgrade()
Risk: slightly larger ZIP; one extra GitHub API call only when View details
  holds a release older than the installed version
Rollback: reinstall 1.0.0-beta.13.1 ZIP without deleting runtime data
  (updates preserve memory, user skills, audit history)
Documentation: AGENTS.md + CLAUDE.md updater/packaging contract additions;
  changelogs; docs/releases/1.0.0-beta.13.2.md
Publication authorization: pending maintainer approval
```

## Test plan

- [x] `composer test` / `phpstan` / `phpcs` green (8145 tests, phpstan 0, phpcs 0, security audit 0)
- [x] companion typecheck/lint/build green
- [x] hygiene + docs freshness + release-flags green
- [ ] CI matrix fully green on the PR
- [ ] companion `tests/direct-incident-store.test.ts` concurrent lock case: local 20s timeout, unchanged vs `main`; confirm on CI (Linux)

Do not tag or publish until the maintainer replies `approve publish beta.13.2`.

## After publish (maintainer)

1. Dashboard → Updates → Check again → update to 13.2.
2. Plugins → View details shows `1.0.0-beta.13.2` release notes (not an older body).
3. Stonewright → Skills lists the built-in pack (~35 skills, BUILT-IN badges); pre-existing user skills/memory survived.
4. MCP client: `stonewright-task-start` matches built-in skills (not just the meta skill) for a relevant task.
5. Stonewright → Troubleshoot: `Prop descriptor unavailable` gone; Elementor provider discovery still shows the informational unsupported note (expected).

Made with [Cursor](https://cursor.com)